### PR TITLE
Proactively close the OkHttp Response on an interrupt.

### DIFF
--- a/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
+++ b/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
@@ -283,6 +283,10 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
       responseBody = Assertions.checkNotNull(response.body());
       responseByteStream = responseBody.byteStream();
     } catch (IOException e) {
+      if (e instanceof InterruptedIOException) {
+        closeConnectionQuietly();
+      }
+
       throw HttpDataSourceException.createForIOException(
           e, dataSpec, HttpDataSourceException.TYPE_OPEN);
     }
@@ -358,7 +362,7 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
       return readInternal(buffer, offset, length);
     } catch (IOException e) {
       if (e instanceof InterruptedIOException) {
-        response.close();
+        closeConnectionQuietly();
       }
 
       throw HttpDataSourceException.createForIOException(
@@ -460,6 +464,10 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
       }
       return;
     } catch (IOException e) {
+      if (e instanceof InterruptedIOException) {
+        closeConnectionQuietly();
+      }
+
       if (e instanceof HttpDataSourceException) {
         throw (HttpDataSourceException) e;
       } else {

--- a/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
+++ b/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
@@ -357,6 +357,10 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
     try {
       return readInternal(buffer, offset, length);
     } catch (IOException e) {
+      if (e instanceof InterruptedIOException) {
+        response.close();
+      }
+
       throw HttpDataSourceException.createForIOException(
           e, castNonNull(dataSpec), HttpDataSourceException.TYPE_READ);
     }


### PR DESCRIPTION
This works around what looks like an OkHttp bug that interrupts
don't cleanly cancel the Call.

Intended to be a fix for https://github.com/square/okhttp/issues/3146. 

I have a local reproduction of the issue 

a) the demo-session app with OkHttp enabled, useful for manual testing by clicking +30 seconds rapidly.
b) also one in OkHttp itself https://github.com/square/okhttp/pull/7014 which is automated.

But happy to discuss how best to verify this fix if needed?