### PR TITLE
Fix build error when androidxMediaModulePrefix is specified

### DIFF
--- a/libraries/common/build.gradle
+++ b/libraries/common/build.gradle
@@ -17,9 +17,9 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 // the Gradle properties of each library are populated and we can automatically
 // check if a 'releaseArtifactId' exists.
 rootProject.allprojects.forEach {
-    if ((it.name.contains('lib-') || it.name.contains('test-'))
+    if ((it.name.startsWith(modulePrefix.replace(':', '') + 'lib-') || it.name.startsWith(modulePrefix.replace(':', '') + 'test-'))
             && !it.name.endsWith('-common')) {
-        evaluationDependsOn(modulePrefix + it.name)
+        evaluationDependsOn(':' + it.name)
     }
 }
 // copybara:media3-only
@@ -36,8 +36,8 @@ dependencies {
         // List all released targets as constraints. This ensures they are all
         // resolved to the same version.
         rootProject.allprojects.forEach {
-            if (it.hasProperty('releaseArtifactId')) {
-                implementation project(modulePrefix + it.name)
+            if (it.hasProperty('releaseArtifactId') && it.releaseArtifactId.startsWith('media3-')) {
+                implementation project(':' + it.name)
             }
         }
     }


### PR DESCRIPTION
When the media3 modules are referred from an external project and `gradle.ext.androidxMediaModulePrefix` is specified, build error occurs like the following.


### Error message

```
A problem occurred evaluating project ':media-lib-common'.
> Project with path ':media-media-lib-cast' could not be found in project ':media-lib-common'.
```
(`gradle.ext.androidxMediaModulePrefix = "media-"` in this case)


As you can see, the build script of the common module is trying to use an incorrect named project which has duplicated prefixes.