### PR TITLE
Fix NPE in MediaControllerImplLegacy#connectToSession()

### DIFF
--- a/libraries/session/src/main/java/androidx/media3/session/MediaController.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaController.java
@@ -417,6 +417,7 @@ public class MediaController implements Player {
       return;
     }
     released = true;
+    applicationHandler.removeCallbacksAndMessages(null);
     try {
       impl.release();
     } catch (Exception e) {

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerTest.java
@@ -192,7 +192,7 @@ public class MediaControllerTest {
   }
 
   @Test
-  public void isConnected_afterDisconnection_returnsFalse() throws Exception {
+  public void isConnected_afterDisconnectionBySessionRelease_returnsFalse() throws Exception {
     CountDownLatch disconnectedLatch = new CountDownLatch(1);
     MediaController controller =
         controllerTestRule.createController(
@@ -207,6 +207,42 @@ public class MediaControllerTest {
     remoteSession.release();
 
     assertThat(disconnectedLatch.await(TIMEOUT_MS, MILLISECONDS)).isTrue();
+    assertThat(controller.isConnected()).isFalse();
+  }
+
+  @Test
+  public void isConnected_afterDisconnectionByControllerRelease_returnsFalse() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    MediaController controller =
+        controllerTestRule.createController(
+            remoteSession.getToken(),
+            null,
+            new MediaController.Listener() {
+              @Override
+              public void onDisconnected(MediaController controller) {
+                latch.countDown();
+              }
+            });
+    threadTestRule.getHandler().postAndSync(controller::release);
+    assertThat(latch.await(TIMEOUT_MS, MILLISECONDS)).isTrue();
+    assertThat(controller.isConnected()).isFalse();
+  }
+
+  @Test
+  public void isConnected_afterDisconnectionByControllerReleaseRightAfterCreated_returnsFalse() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    MediaController controller =
+        controllerTestRule.createController(
+            remoteSession.getToken(),
+            null,
+            new MediaController.Listener() {
+              @Override
+              public void onDisconnected(MediaController controller) {
+                latch.countDown();
+              }
+            },
+            MediaController::release);
+    assertThat(latch.await(TIMEOUT_MS, MILLISECONDS)).isTrue();
     assertThat(controller.isConnected()).isFalse();
   }
 

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerTestRule.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerTestRule.java
@@ -22,13 +22,17 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.media.session.MediaSessionCompat;
+import androidx.annotation.MainThread;
 import androidx.annotation.Nullable;
 import androidx.collection.ArrayMap;
 import androidx.media3.common.util.Log;
 import androidx.media3.test.session.common.HandlerThreadTestRule;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import org.junit.rules.ExternalResource;
 
 /**
@@ -43,6 +47,15 @@ public final class MediaControllerTestRule extends ExternalResource {
   private volatile Context context;
   private volatile Class<? extends MediaController> controllerType;
   private volatile long timeoutMs;
+
+  public interface MediaControllerCreateListener {
+    /**
+     * This callback is invoked immediately after the {@link MediaController} instance is created.
+     * @param controller {@link MediaController} instance
+     */
+    @MainThread
+    void onCreated(MediaController controller);
+  }
 
   public MediaControllerTestRule(HandlerThreadTestRule handlerThreadTestRule) {
     this.handlerThreadTestRule = handlerThreadTestRule;
@@ -96,17 +109,24 @@ public final class MediaControllerTestRule extends ExternalResource {
   public MediaController createController(
       MediaSessionCompat.Token token, @Nullable MediaController.Listener listener)
       throws Exception {
+    return createController(token, listener, null);
+  }
+
+  /** Creates {@link MediaController} from {@link MediaSessionCompat.Token}. */
+  public MediaController createController(
+      MediaSessionCompat.Token token, @Nullable MediaController.Listener listener, @Nullable MediaControllerCreateListener controllerCreateListener)
+      throws Exception {
     TestMediaBrowserListener testListener = new TestMediaBrowserListener(listener);
-    MediaController controller = createControllerOnHandler(token, testListener);
+    MediaController controller = createControllerOnHandler(token, testListener, controllerCreateListener);
     controllers.put(controller, testListener);
     return controller;
   }
 
   private MediaController createControllerOnHandler(
-      MediaSessionCompat.Token token, TestMediaBrowserListener listener) throws Exception {
+      MediaSessionCompat.Token token, TestMediaBrowserListener listener, @Nullable MediaControllerCreateListener controllerCreateListener) throws Exception {
     SessionToken sessionToken =
         SessionToken.createSessionToken(context, token).get(TIMEOUT_MS, MILLISECONDS);
-    return createControllerOnHandler(sessionToken, /* connectionHints= */ null, listener);
+    return createControllerOnHandler(sessionToken, /* connectionHints= */ null, listener, controllerCreateListener);
   }
 
   /** Creates {@link MediaController} from {@link SessionToken} with default options. */
@@ -120,14 +140,24 @@ public final class MediaControllerTestRule extends ExternalResource {
       @Nullable Bundle connectionHints,
       @Nullable MediaController.Listener listener)
       throws Exception {
+    return createController(token, connectionHints, listener, null);
+  }
+
+  /** Creates {@link MediaController} from {@link SessionToken}. */
+  public MediaController createController(
+      SessionToken token,
+      @Nullable Bundle connectionHints,
+      @Nullable MediaController.Listener listener,
+      @Nullable MediaControllerCreateListener controllerCreateListener)
+      throws Exception {
     TestMediaBrowserListener testListener = new TestMediaBrowserListener(listener);
-    MediaController controller = createControllerOnHandler(token, connectionHints, testListener);
+    MediaController controller = createControllerOnHandler(token, connectionHints, testListener, controllerCreateListener);
     controllers.put(controller, testListener);
     return controller;
   }
 
   private MediaController createControllerOnHandler(
-      SessionToken token, @Nullable Bundle connectionHints, TestMediaBrowserListener listener)
+      SessionToken token, @Nullable Bundle connectionHints, TestMediaBrowserListener listener, @Nullable MediaControllerCreateListener controllerCreateListener)
       throws Exception {
     // Create controller on the test handler, for changing MediaBrowserCompat's Handler
     // Looper. Otherwise, MediaBrowserCompat will post all the commands to the handler
@@ -153,6 +183,17 @@ public final class MediaControllerTestRule extends ExternalResource {
                     return builder.buildAsync();
                   }
                 });
+
+    if (controllerCreateListener != null) {
+      future.addListener(() -> {
+        try {
+          MediaController controller = future.get();
+          controllerCreateListener.onCreated(controller);
+        } catch (ExecutionException ignored) {
+        } catch (InterruptedException ignored) {
+        }
+      }, MoreExecutors.directExecutor());
+    }
     return future.get(timeoutMs, MILLISECONDS);
   }
 

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerWithMediaSessionCompatTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerWithMediaSessionCompatTest.java
@@ -171,6 +171,23 @@ public class MediaControllerWithMediaSessionCompatTest {
   }
 
   @Test
+  public void disconnected_byControllerReleaseRightAfterCreated() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    MediaController controller =
+        controllerTestRule.createController(
+            session.getSessionToken(),
+            new MediaController.Listener() {
+              @Override
+              public void onDisconnected(MediaController controller) {
+                latch.countDown();
+              }
+            },
+            MediaController::release);
+    assertThat(latch.await(TIMEOUT_MS, MILLISECONDS)).isTrue();
+    assertThat(controller.isConnected()).isFalse();
+  }
+
+  @Test
   public void close_twice_doesNotCrash() throws Exception {
     MediaController controller = controllerTestRule.createController(session.getSessionToken());
     threadTestRule.getHandler().postAndSync(controller::release);


### PR DESCRIPTION
This pull request fixes a `NullPointerException` occurs inside of the `MediaControllerImplLegacy#connectToSession()`.

```
2022-03-27 00:28:23.683 31182-31211/? E/AndroidRuntime: FATAL EXCEPTION: MCwMSCTest
    Process: androidx.media3.test.session, PID: 31182
    java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.support.v4.media.session.MediaControllerCompat.isSessionReady()' on a null object reference
        at androidx.media3.session.MediaControllerImplLegacy.lambda$connectToSession$2$androidx-media3-session-MediaControllerImplLegacy(MediaControllerImplLegacy.java:1274)
        at androidx.media3.session.MediaControllerImplLegacy$$ExternalSyntheticLambda14.run(Unknown Source:2)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.os.HandlerThread.run(HandlerThread.java:67)
```

### Where the `NPE` occurs

https://github.com/androidx/media/blob/72a4fb082d9e68ecd7db3ff87b19f4232a5991d2/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplLegacy.java#L1274

### Scenario

1. Create a `MediaController` instance
    - :point_right:  `MediaControllerImplLegacy` posts a callback which is executed on the main thread
2. Call `MediaController#release()` immediately on the main thread
    - :point_right: `MediaControllerImplLegacy` sets `controllerCompat = null`
3. The callback registered at Step 2 is invoked
   - :point_right: `controllerCompat.isSessionReady()` is called :boom: