### PR TITLE
Workaround OkHttp lack of clean interrupt support

### DIFF
--- a/libraries/datasource_okhttp/build.gradle
+++ b/libraries/datasource_okhttp/build.gradle
@@ -11,9 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
-android.defaultConfig.minSdkVersion 21
+apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
+apply plugin: 'kotlin-android'
+
+android {
+    defaultConfig {
+        minSdkVersion 21
+    }
+}
 
 dependencies {
     implementation project(modulePrefix + 'lib-common')
@@ -25,6 +31,14 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:' + okhttpVersion
     testImplementation 'org.robolectric:robolectric:' + robolectricVersion
     api 'com.squareup.okhttp3:okhttp:' + okhttpVersion
+
+    androidTestImplementation 'androidx.test:rules:' + androidxTestRulesVersion
+    androidTestImplementation 'androidx.test:runner:' + androidxTestRunnerVersion
+    androidTestImplementation 'androidx.multidex:multidex:' + androidxMultidexVersion
+    androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:' + dexmakerVersion
+    androidTestImplementation project(modulePrefix + 'test-utils')
+    androidTestImplementation project(modulePrefix + 'lib-exoplayer')
+    androidTestImplementation 'androidx.media:media:' + androidxMediaVersion
 }
 
 ext {

--- a/libraries/datasource_okhttp/src/androidTest/AndroidManifest.xml
+++ b/libraries/datasource_okhttp/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2021 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="androidx.media3.datasource.okhttp.test">
+
+  <uses-permission android:name="android.permission.INTERNET"/>
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
+  <application android:usesCleartextTraffic="true" />
+
+</manifest>

--- a/libraries/datasource_okhttp/src/androidTest/java/androidx/media3/datasource/okhttp/OkHttpDataSourceCancellationTest.kt
+++ b/libraries/datasource_okhttp/src/androidTest/java/androidx/media3/datasource/okhttp/OkHttpDataSourceCancellationTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.datasource.okhttp
+
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.HttpDataSource.HttpDataSourceException
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import org.junit.After
+import org.junit.Assert.fail
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.Closeable
+import java.net.InetAddress
+import java.net.UnknownHostException
+import java.util.concurrent.CountDownLatch
+import java.util.logging.Handler
+import java.util.logging.LogRecord
+
+/** [DataSource] contract tests for [OkHttpDataSource].  */
+@RunWith(AndroidJUnit4::class)
+class OkHttpDataSourceCancellationTest {
+    val logs: MutableList<String> = mutableListOf()
+
+    val okHttpClient: Call.Factory = OkHttpClient.Builder()
+            .build()
+
+    private var logging: Closeable? = null
+
+    @After
+    fun disableLogging() {
+        logging?.close()
+    }
+
+    fun createDataSource(): DataSource {
+        return OkHttpDataSource.Factory(okHttpClient).createDataSource()
+    }
+
+    @Test
+    fun handlesFastCancellations() {
+        assumeInternet()
+
+        val interruptPoint = CountDownLatch(1)
+        val interruptedPoint = CountDownLatch(1)
+
+        logging = OkHttpDebugLogging.enableHttp2(handler = TestLogHandler { message ->
+            if (message.matches(">>.*HEADERS".toRegex())) {
+                interruptPoint.countDown()
+                interruptedPoint.awaitUninterruptible()
+            }
+        })
+
+        val testThread = Thread.currentThread()
+
+        Thread {
+            interruptPoint.await()
+
+            testThread.interrupt()
+
+            interruptedPoint.countDown()
+        }.start()
+
+        val dataSource = createDataSource()
+        val content = DataSpec.Builder()
+                .setUri("https://storage.googleapis.com/exoplayer-test-media-1/gen-3/screens/dash-vod-single-segment/video-avc-baseline-480.mp4")
+                .build()
+
+        try {
+            dataSource.open(content)
+            fail()
+        } catch (hdse: HttpDataSourceException) {
+            // expected
+        }
+
+//        logs.forEach {
+//            println("'$it'")
+//        }
+
+        // Check we started a request
+        assertThat(logs).contains(">> 0x00000003   102 HEADERS       END_STREAM|END_HEADERS")
+
+        // If execute is used in OkHttpDataSource.open() then this RST_STREAM is not sent.
+        assertThat(logs).contains(">> 0x00000003     4 RST_STREAM    ")
+    }
+
+    private fun assumeInternet() {
+        try {
+            InetAddress.getByName("www.google.com")
+        } catch (uhe: UnknownHostException) {
+            assumeTrue("requires network", false)
+        }
+    }
+
+    inner class TestLogHandler(val onMessage: (message: String) -> Unit) : Handler() {
+        override fun publish(log: LogRecord) {
+            val message = log.message
+
+            logs.add(message)
+
+            onMessage(message)
+        }
+
+        override fun flush() {
+        }
+
+        override fun close() {
+        }
+    }
+}
+
+private fun CountDownLatch.awaitUninterruptible() {
+    var interrupted = false
+
+    try {
+        while (true) {
+            try {
+                await()
+                return
+            } catch (ie: InterruptedException) {
+                interrupted = true
+            }
+        }
+    } finally {
+        if (interrupted) {
+            Thread.currentThread().interrupt()
+        }
+    }
+}

--- a/libraries/datasource_okhttp/src/androidTest/java/androidx/media3/datasource/okhttp/OkHttpDataSourceContractTest.kt
+++ b/libraries/datasource_okhttp/src/androidTest/java/androidx/media3/datasource/okhttp/OkHttpDataSourceContractTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.datasource.okhttp
+
+import android.net.Uri
+import androidx.media3.datasource.DataSource
+import androidx.media3.test.utils.DataSourceContractTest
+import androidx.media3.test.utils.HttpDataSourceTestEnv
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.collect.ImmutableList
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+/** [DataSource] contract tests for [OkHttpDataSource].  */
+@RunWith(AndroidJUnit4::class)
+class OkHttpDataSourceContractTest : DataSourceContractTest() {
+    @get:Rule
+    var httpDataSourceTestEnv = HttpDataSourceTestEnv()
+
+    override fun createDataSource(): DataSource {
+        val okHttpClient: Call.Factory = OkHttpClient.Builder()
+                .build()
+
+        return OkHttpDataSource.Factory(okHttpClient).createDataSource()
+    }
+
+    override fun getTestResources(): ImmutableList<TestResource> {
+        return httpDataSourceTestEnv.servedResources
+    }
+
+    override fun getNotFoundUri(): Uri {
+        return Uri.parse(httpDataSourceTestEnv.nonexistentUrl)
+    }
+}

--- a/libraries/datasource_okhttp/src/androidTest/java/androidx/media3/datasource/okhttp/logging.kt
+++ b/libraries/datasource_okhttp/src/androidTest/java/androidx/media3/datasource/okhttp/logging.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.datasource.okhttp
+
+import okhttp3.internal.concurrent.TaskRunner
+import okhttp3.internal.http2.Http2
+import java.io.Closeable
+import java.util.concurrent.CopyOnWriteArraySet
+import java.util.logging.ConsoleHandler
+import java.util.logging.Handler
+import java.util.logging.Level
+import java.util.logging.LogRecord
+import java.util.logging.Logger
+import java.util.logging.SimpleFormatter
+import kotlin.reflect.KClass
+
+object OkHttpDebugLogging {
+    // Keep references to loggers to prevent their configuration from being GC'd.
+    private val configuredLoggers = CopyOnWriteArraySet<Logger>()
+
+    fun enableHttp2(handler: Handler = logHandler()) = enable(Http2::class, handler)
+
+    fun enableTaskRunner(handler: Handler = logHandler()) = enable(TaskRunner::class, handler)
+
+    fun logHandler() = ConsoleHandler().apply {
+        level = Level.FINE
+        formatter = object : SimpleFormatter() {
+            override fun format(record: LogRecord) =
+                    String.format("[%1\$tF %1\$tT] %2\$s %n", record.millis, record.message)
+        }
+    }
+
+    fun enable(loggerClass: String, handler: Handler = logHandler()): Closeable {
+        val logger = Logger.getLogger(loggerClass)
+        if (configuredLoggers.add(logger)) {
+            logger.addHandler(handler)
+            logger.level = Level.FINEST
+        }
+        return Closeable {
+            logger.removeHandler(handler)
+        }
+    }
+
+    fun enable(loggerClass: KClass<*>, handler: Handler = logHandler()) =
+            enable(loggerClass.java.name, handler)
+}


### PR DESCRIPTION
Workaround for https://github.com/square/okhttp/issues/3146

There is a draft PR https://github.com/square/okhttp/pull/7185/files which documents OkHttp's ideal handling of cancellation including interrupts.

But a few key points

1) This is a target state, and OkHttp does not currently handle interrupts correctly.  In the past this has been identified, and the advice is to avoid interrupts on Http threads, see discussion on https://github.com/square/okhttp/issues/1902. Also an attempt at a fix here https://github.com/square/okhttp/pull/7023 which wasn't in a form to land.

2) Even with this fixed, it is likely to never be optimal, because of OkHttp sharing a socket connection for multiple inflight requests.

From https://github.com/square/okhttp/pull/7185

```
Thread.interrupt() is Clumsy
----------------------------

`Thread.interrupt()` is Java's built-in mechanism to cancel an in-flight `Thread`, regardless of
what work it's currently performing.

We recommend against using `Thread.interrupt()` with OkHttp because it may disrupt shared resources
including HTTP/2 connections and cache files. In particular, calling `Thread.interrupt()` may cause
unrelated threads' call to fail with an `IOException`.
```

This PR leaves the Loader/DataSource thread parked on a countdown latch, while this may seem wasteful and an additional context switch. However in practice the response isn't returned until the Http2Connection and Http2Reader have a response from the server and these means effectively parking in a `wait()` statement here https://github.com/square/okhttp/blob/9e039e94123defbfd5f11dc64ae146c46b7230eb/okhttp/src/jvmMain/kotlin/okhttp3/internal/http2/Http2Stream.kt#L140

TODO

- [ ] test in CI
- [ ] Verify (again) that it fixes the demo-session example with frequent scrubbing.