### PR TITLE
AVI Seek and Audio Timing Fixes

### DIFF
--- a/demos/main/src/main/java/androidx/media3/demo/main/SampleChooserActivity.java
+++ b/demos/main/src/main/java/androidx/media3/demo/main/SampleChooserActivity.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -41,6 +42,8 @@ import android.widget.ExpandableListView.OnChildClickListener;
 import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.Nullable;
 import androidx.annotation.OptIn;
 import androidx.appcompat.app.AppCompatActivity;
@@ -76,6 +79,7 @@ public class SampleChooserActivity extends AppCompatActivity
   private static final String TAG = "SampleChooserActivity";
   private static final String GROUP_POSITION_PREFERENCE_KEY = "sample_chooser_group_position";
   private static final String CHILD_POSITION_PREFERENCE_KEY = "sample_chooser_child_position";
+  private static final Uri USER_CONTENT = new Uri.Builder().scheme(ContentResolver.SCHEME_CONTENT).authority("user").build();
 
   private String[] uris;
   private boolean useExtensionRenderers;
@@ -83,6 +87,13 @@ public class SampleChooserActivity extends AppCompatActivity
   private SampleAdapter sampleAdapter;
   private MenuItem preferExtensionDecodersMenuItem;
   private ExpandableListView sampleListView;
+  private final ActivityResultLauncher<String[]> openDocumentLauncher = registerForActivityResult(
+      new ActivityResultContracts.OpenDocument(), uri -> {
+        if (uri != null) {
+          final MediaItem mediaItem = new MediaItem.Builder().setUri(uri).build();
+          startPlayer(Collections.singletonList(mediaItem));
+        }
+      });
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -230,13 +241,25 @@ public class SampleChooserActivity extends AppCompatActivity
     prefEditor.apply();
 
     PlaylistHolder playlistHolder = (PlaylistHolder) view.getTag();
+    final List<MediaItem> mediaItems = playlistHolder.mediaItems;
+    if (!mediaItems.isEmpty()) {
+      final MediaItem mediaItem = mediaItems.get(0);
+      if (mediaItem.localConfiguration != null && USER_CONTENT.equals(mediaItem.localConfiguration.uri)) {
+        openDocumentLauncher.launch(new String[]{"video/*","audio/*"});
+        return true;
+      }
+    }
+    startPlayer(playlistHolder.mediaItems);
+    return true;
+  }
+
+  private void startPlayer(final List<MediaItem> mediaItems) {
     Intent intent = new Intent(this, PlayerActivity.class);
     intent.putExtra(
         IntentUtil.PREFER_EXTENSION_DECODERS_EXTRA,
         isNonNullAndChecked(preferExtensionDecodersMenuItem));
-    IntentUtil.addToIntent(playlistHolder.mediaItems, intent);
+    IntentUtil.addToIntent(mediaItems, intent);
     startActivity(intent);
-    return true;
   }
 
   private void onSampleDownloadButtonClicked(PlaylistHolder playlistHolder) {

--- a/demos/main/src/main/java/androidx/media3/demo/main/SampleChooserActivity.java
+++ b/demos/main/src/main/java/androidx/media3/demo/main/SampleChooserActivity.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -42,8 +41,6 @@ import android.widget.ExpandableListView.OnChildClickListener;
 import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
-import androidx.activity.result.ActivityResultLauncher;
-import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.Nullable;
 import androidx.annotation.OptIn;
 import androidx.appcompat.app.AppCompatActivity;
@@ -79,7 +76,6 @@ public class SampleChooserActivity extends AppCompatActivity
   private static final String TAG = "SampleChooserActivity";
   private static final String GROUP_POSITION_PREFERENCE_KEY = "sample_chooser_group_position";
   private static final String CHILD_POSITION_PREFERENCE_KEY = "sample_chooser_child_position";
-  private static final Uri USER_CONTENT = new Uri.Builder().scheme(ContentResolver.SCHEME_CONTENT).authority("user").build();
 
   private String[] uris;
   private boolean useExtensionRenderers;
@@ -87,13 +83,6 @@ public class SampleChooserActivity extends AppCompatActivity
   private SampleAdapter sampleAdapter;
   private MenuItem preferExtensionDecodersMenuItem;
   private ExpandableListView sampleListView;
-  private final ActivityResultLauncher<String[]> openDocumentLauncher = registerForActivityResult(
-      new ActivityResultContracts.OpenDocument(), uri -> {
-        if (uri != null) {
-          final MediaItem mediaItem = new MediaItem.Builder().setUri(uri).build();
-          startPlayer(Collections.singletonList(mediaItem));
-        }
-      });
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -241,25 +230,13 @@ public class SampleChooserActivity extends AppCompatActivity
     prefEditor.apply();
 
     PlaylistHolder playlistHolder = (PlaylistHolder) view.getTag();
-    final List<MediaItem> mediaItems = playlistHolder.mediaItems;
-    if (!mediaItems.isEmpty()) {
-      final MediaItem mediaItem = mediaItems.get(0);
-      if (mediaItem.localConfiguration != null && USER_CONTENT.equals(mediaItem.localConfiguration.uri)) {
-        openDocumentLauncher.launch(new String[]{"video/*","audio/*"});
-        return true;
-      }
-    }
-    startPlayer(playlistHolder.mediaItems);
-    return true;
-  }
-
-  private void startPlayer(final List<MediaItem> mediaItems) {
     Intent intent = new Intent(this, PlayerActivity.class);
     intent.putExtra(
         IntentUtil.PREFER_EXTENSION_DECODERS_EXTRA,
         isNonNullAndChecked(preferExtensionDecodersMenuItem));
-    IntentUtil.addToIntent(mediaItems, intent);
+    IntentUtil.addToIntent(playlistHolder.mediaItems, intent);
     startActivity(intent);
+    return true;
   }
 
   private void onSampleDownloadButtonClicked(PlaylistHolder playlistHolder) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/avi/AviExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/avi/AviExtractor.java
@@ -91,20 +91,24 @@ public final class AviExtractor implements Extractor {
   @SuppressWarnings("ConstantCaseForConstants")
   public static final int FOURCC_vids = 0x73646976;
 
-  /** Parser states. */
+  /**
+   * Parser states.
+   */
   @Documented
   @Retention(RetentionPolicy.SOURCE)
   @Target(TYPE_USE)
   @IntDef({
-    STATE_SKIPPING_TO_HDRL,
-    STATE_READING_HDRL_HEADER,
-    STATE_READING_HDRL_BODY,
-    STATE_FINDING_MOVI_HEADER,
-    STATE_FINDING_IDX1_HEADER,
-    STATE_READING_IDX1_BODY,
-    STATE_READING_SAMPLES,
+      STATE_SKIPPING_TO_HDRL,
+      STATE_READING_HDRL_HEADER,
+      STATE_READING_HDRL_BODY,
+      STATE_FINDING_MOVI_HEADER,
+      STATE_FINDING_IDX1_HEADER,
+      STATE_READING_IDX1_BODY,
+      STATE_READING_SAMPLES,
   })
-  private @interface State {}
+  private @interface State {
+
+  }
 
   private static final int STATE_SKIPPING_TO_HDRL = 0;
   private static final int STATE_READING_HDRL_HEADER = 1;
@@ -356,19 +360,27 @@ public final class AviExtractor implements Extractor {
     extractorOutput.endTracks();
   }
 
-  /** Builds and outputs the {@link SeekMap} from the idx1 chunk. */
+  /**
+   * Builds and outputs the {@link SeekMap} from the idx1 chunk.
+   */
   private void parseIdx1Body(ParsableByteArray body) {
-    long seekOffset = peekSeekOffset(body);
+    final long seekOffset = peekSeekOffset(body);
+    final long streamOffset = seekOffset + 4; //Skip the "movi" chunk
     @Nullable ChunkReader seekChunkReader = null;
     for (ChunkReader chunkReader : chunkReaders) {
       if (chunkReader.getChunkType() == ChunkReader.CHUNK_TYPE_VIDEO) {
         seekChunkReader = chunkReader;
+        chunkReader.appendKeyFrame(streamOffset);
+      } else {
+        chunkReader.appendForeignKeyFrame(streamOffset);
       }
     }
     if (seekChunkReader == null) {
       //No video stream
       return;
     }
+
+    boolean skipKeyFrame = true;
     while (body.bytesLeft() >= 16) {
       int chunkId = body.readLittleEndianInt();
       int flags = body.readLittleEndianInt();
@@ -382,10 +394,14 @@ public final class AviExtractor implements Extractor {
       }
       if (chunkReader == seekChunkReader &&
           (flags & AVIIF_KEYFRAME) == AVIIF_KEYFRAME) {
-        chunkReader.appendKeyFrame(offset);
-        for (ChunkReader aChunkReader : chunkReaders) {
-          if (aChunkReader != chunkReader) {
-            aChunkReader.appendForeignKeyFrame(offset);
+        if (skipKeyFrame) {
+          skipKeyFrame = false;
+        } else {
+          chunkReader.appendKeyFrame(offset);
+          for (ChunkReader aChunkReader : chunkReaders) {
+            if (aChunkReader != chunkReader) {
+              aChunkReader.appendForeignKeyFrame(offset);
+            }
           }
         }
       }
@@ -454,7 +470,7 @@ public final class AviExtractor implements Extractor {
       }
       input.skipFully(8);
       input.resetPeekPosition();
-      ChunkReader chunkReader = getChunkReader(chunkType);
+      @Nullable ChunkReader chunkReader = getChunkReader(chunkType);
       if (chunkReader == null) {
         // No handler for this chunk. We skip it.
         pendingReposition = input.getPosition() + size;
@@ -469,8 +485,9 @@ public final class AviExtractor implements Extractor {
 
   @Nullable
   private ChunkReader processStreamList(ListChunk streamList, int streamId) {
-    AviStreamHeaderChunk aviStreamHeaderChunk = streamList.getChild(AviStreamHeaderChunk.class);
-    StreamFormatChunk streamFormatChunk = streamList.getChild(StreamFormatChunk.class);
+    @Nullable AviStreamHeaderChunk aviStreamHeaderChunk = streamList.getChild(
+        AviStreamHeaderChunk.class);
+    @Nullable StreamFormatChunk streamFormatChunk = streamList.getChild(StreamFormatChunk.class);
     if (aviStreamHeaderChunk == null) {
       Log.w(TAG, "Missing Stream Header");
       return null;
@@ -487,7 +504,7 @@ public final class AviExtractor implements Extractor {
     if (suggestedBufferSize != 0) {
       builder.setMaxInputSize(suggestedBufferSize);
     }
-    StreamNameChunk streamName = streamList.getChild(StreamNameChunk.class);
+    @Nullable StreamNameChunk streamName = streamList.getChild(StreamNameChunk.class);
     if (streamName != null) {
       builder.setLabel(streamName.name);
     }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/avi/ChunkReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/avi/ChunkReader.java
@@ -150,13 +150,17 @@ import java.util.Arrays;
   }
 
   public void seekToPosition(long position) {
-    int index = keyFrameMap.indexOf(position);
-    if (index >= 0) {
-      currentChunkIndex = keyFrameMap.getInt(index);
+    if (position == 0L) {
+      currentChunkIndex = 0;
     } else {
-      index = foreignKeyFrameMap.indexOf(position);
+      int index = keyFrameMap.indexOf(position);
       if (index >= 0) {
-        currentChunkIndex = foreignKeyFrameMap.getInt(index);
+        currentChunkIndex = keyFrameMap.getInt(index);
+      } else {
+        index = foreignKeyFrameMap.indexOf(position);
+        if (index >= 0) {
+          currentChunkIndex = foreignKeyFrameMap.getInt(index);
+        }
       }
     }
   }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/avi/ChunkReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/avi/ChunkReader.java
@@ -15,7 +15,6 @@
  */
 package androidx.media3.extractor.avi;
 
-import android.util.Log;
 import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.media3.common.util.Assertions;
@@ -25,8 +24,6 @@ import androidx.media3.extractor.SeekMap;
 import androidx.media3.extractor.SeekPoint;
 import androidx.media3.extractor.TrackOutput;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.Arrays;
 
 /** Reads chunks holding sample data. */
@@ -133,10 +130,6 @@ import java.util.Arrays;
     boolean done = bytesRemainingInCurrentChunk == 0;
     if (done) {
       if (currentChunkSize > 0) {
-        final ByteBuffer byteBuffer = ByteBuffer.allocate(4);
-        byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-        byteBuffer.putInt(chunkId);
-        Log.d("Test",new String(byteBuffer.array(),0,3) + " " + String.format("%.3f", getCurrentChunkTimestampUs() / 1_000_000.0) + " " + isCurrentFrameAKeyFrame());
         trackOutput.sampleMetadata(
             getCurrentChunkTimestampUs(),
             (isCurrentFrameAKeyFrame() ? C.BUFFER_FLAG_KEY_FRAME : 0),

--- a/libraries/test_data/src/test/assets/extractordumps/avi/sample.avi.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/avi/sample.avi.1.dump
@@ -289,463 +289,463 @@ track 1:
     channelCount = 2
     sampleRate = 48000
   sample 0:
-    time = 1296000
+    time = 1320000
     flags = 1
     data = length 384, hash 4338D4A1
   sample 1:
-    time = 1320000
+    time = 1344000
     flags = 1
     data = length 384, hash C65E6D68
   sample 2:
-    time = 1344000
+    time = 1368000
     flags = 1
     data = length 384, hash AE2762E8
   sample 3:
-    time = 1368000
+    time = 1392000
     flags = 1
     data = length 384, hash 8CFEAA7F
   sample 4:
-    time = 1392000
+    time = 1416000
     flags = 1
     data = length 384, hash A96A80B4
   sample 5:
-    time = 1416000
+    time = 1440000
     flags = 1
     data = length 384, hash 69A84538
   sample 6:
-    time = 1440000
+    time = 1464000
     flags = 1
     data = length 384, hash 9131F77E
   sample 7:
-    time = 1464000
+    time = 1488000
     flags = 1
     data = length 384, hash 818091B1
   sample 8:
-    time = 1488000
+    time = 1512000
     flags = 1
     data = length 384, hash 6DBECC10
   sample 9:
-    time = 1512000
+    time = 1536000
     flags = 1
     data = length 384, hash A9912967
   sample 10:
-    time = 1536000
+    time = 1560000
     flags = 1
     data = length 384, hash 4DA97472
   sample 11:
-    time = 1560000
+    time = 1584000
     flags = 1
     data = length 384, hash 31B363DC
   sample 12:
-    time = 1584000
+    time = 1608000
     flags = 1
     data = length 384, hash E15BB36C
   sample 13:
-    time = 1608000
+    time = 1632000
     flags = 1
     data = length 384, hash 159C963C
   sample 14:
-    time = 1632000
+    time = 1656000
     flags = 1
     data = length 384, hash 50B874D
   sample 15:
-    time = 1656000
+    time = 1680000
     flags = 1
     data = length 384, hash 8727F339
   sample 16:
-    time = 1680000
+    time = 1704000
     flags = 1
     data = length 384, hash C0853B6
   sample 17:
-    time = 1704000
+    time = 1728000
     flags = 1
     data = length 384, hash 9E026376
   sample 18:
-    time = 1728000
+    time = 1752000
     flags = 1
     data = length 384, hash C190380F
   sample 19:
-    time = 1752000
+    time = 1776000
     flags = 1
     data = length 384, hash 20925F33
   sample 20:
-    time = 1776000
+    time = 1800000
     flags = 1
     data = length 384, hash 9F740DAF
   sample 21:
-    time = 1800000
+    time = 1824000
     flags = 1
     data = length 384, hash F75757D6
   sample 22:
-    time = 1824000
+    time = 1848000
     flags = 1
     data = length 384, hash 46D76ED0
   sample 23:
-    time = 1848000
+    time = 1872000
     flags = 1
     data = length 384, hash 11DC480F
   sample 24:
-    time = 1872000
+    time = 1896000
     flags = 1
     data = length 384, hash 3428D6D8
   sample 25:
-    time = 1896000
+    time = 1920000
     flags = 1
     data = length 384, hash 16A11668
   sample 26:
-    time = 1920000
+    time = 1944000
     flags = 1
     data = length 384, hash 4CFBA63C
   sample 27:
-    time = 1944000
+    time = 1968000
     flags = 1
     data = length 384, hash 2B6702A9
   sample 28:
-    time = 1968000
+    time = 1992000
     flags = 1
     data = length 384, hash D047CEF9
   sample 29:
-    time = 1992000
+    time = 2016000
     flags = 1
     data = length 384, hash 25F05663
   sample 30:
-    time = 2016000
+    time = 2040000
     flags = 1
     data = length 384, hash 947441C7
   sample 31:
-    time = 2040000
+    time = 2064000
     flags = 1
     data = length 384, hash E82145F7
   sample 32:
-    time = 2064000
+    time = 2088000
     flags = 1
     data = length 384, hash 6C40F859
   sample 33:
-    time = 2088000
+    time = 2112000
     flags = 1
     data = length 384, hash 273FBEF8
   sample 34:
-    time = 2112000
+    time = 2136000
     flags = 1
     data = length 384, hash 2FF062B6
   sample 35:
-    time = 2136000
+    time = 2160000
     flags = 1
     data = length 384, hash 73FF8D58
   sample 36:
-    time = 2160000
+    time = 2184000
     flags = 1
     data = length 384, hash F2BAB943
   sample 37:
-    time = 2184000
+    time = 2208000
     flags = 1
     data = length 384, hash 507DEF9F
   sample 38:
-    time = 2208000
+    time = 2232000
     flags = 1
     data = length 384, hash 913E927A
   sample 39:
-    time = 2232000
+    time = 2256000
     flags = 1
     data = length 384, hash AFFD0AED
   sample 40:
-    time = 2256000
+    time = 2280000
     flags = 1
     data = length 384, hash EE0C6F4C
   sample 41:
-    time = 2280000
+    time = 2304000
     flags = 1
     data = length 384, hash 70726632
   sample 42:
-    time = 2304000
+    time = 2328000
     flags = 1
     data = length 384, hash B5D49F8
   sample 43:
-    time = 2328000
+    time = 2352000
     flags = 1
     data = length 384, hash B341AF3F
   sample 44:
-    time = 2352000
+    time = 2376000
     flags = 1
     data = length 384, hash 6AC1D8C4
   sample 45:
-    time = 2376000
+    time = 2400000
     flags = 1
     data = length 384, hash BC666685
   sample 46:
-    time = 2400000
+    time = 2424000
     flags = 1
     data = length 384, hash E58054E8
   sample 47:
-    time = 2424000
+    time = 2448000
     flags = 1
     data = length 384, hash 404AB403
   sample 48:
-    time = 2448000
+    time = 2472000
     flags = 1
     data = length 384, hash 265A86B8
   sample 49:
-    time = 2472000
+    time = 2496000
     flags = 1
     data = length 384, hash 306316F6
   sample 50:
-    time = 2496000
+    time = 2520000
     flags = 1
     data = length 384, hash 7BFDEA60
   sample 51:
-    time = 2520000
+    time = 2544000
     flags = 1
     data = length 384, hash 2EFF8E5B
   sample 52:
-    time = 2544000
+    time = 2568000
     flags = 1
     data = length 384, hash C06CE84C
   sample 53:
-    time = 2568000
+    time = 2592000
     flags = 1
     data = length 384, hash 9069A01E
   sample 54:
-    time = 2592000
+    time = 2616000
     flags = 1
     data = length 384, hash 4A78F181
   sample 55:
-    time = 2616000
+    time = 2640000
     flags = 1
     data = length 384, hash 57FD4BE7
   sample 56:
-    time = 2640000
+    time = 2664000
     flags = 1
     data = length 384, hash B09DB688
   sample 57:
-    time = 2664000
+    time = 2688000
     flags = 1
     data = length 384, hash 5602C52F
   sample 58:
-    time = 2688000
+    time = 2712000
     flags = 1
     data = length 384, hash 77762F5D
   sample 59:
-    time = 2712000
+    time = 2736000
     flags = 1
     data = length 384, hash 6A0BDB6
   sample 60:
-    time = 2736000
+    time = 2760000
     flags = 1
     data = length 384, hash 2428C91
   sample 61:
-    time = 2760000
+    time = 2784000
     flags = 1
     data = length 384, hash DEB54354
   sample 62:
-    time = 2784000
+    time = 2808000
     flags = 1
     data = length 384, hash FB0B7BEE
   sample 63:
-    time = 2808000
+    time = 2832000
     flags = 1
     data = length 384, hash BDD82F68
   sample 64:
-    time = 2832000
+    time = 2856000
     flags = 1
     data = length 384, hash BAB3B808
   sample 65:
-    time = 2856000
+    time = 2880000
     flags = 1
     data = length 384, hash E9183572
   sample 66:
-    time = 2880000
+    time = 2904000
     flags = 1
     data = length 384, hash 9E36BC40
   sample 67:
-    time = 2904000
+    time = 2928000
     flags = 1
     data = length 384, hash 937ED026
   sample 68:
-    time = 2928000
+    time = 2952000
     flags = 1
     data = length 384, hash BF337AD1
   sample 69:
-    time = 2952000
+    time = 2976000
     flags = 1
     data = length 384, hash E381C534
   sample 70:
-    time = 2976000
+    time = 3000000
     flags = 1
     data = length 384, hash 6C9E1D71
   sample 71:
-    time = 3000000
+    time = 3024000
     flags = 1
     data = length 384, hash 1C359B93
   sample 72:
-    time = 3024000
+    time = 3048000
     flags = 1
     data = length 384, hash 3D137C16
   sample 73:
-    time = 3048000
+    time = 3072000
     flags = 1
     data = length 384, hash 90D23677
   sample 74:
-    time = 3072000
+    time = 3096000
     flags = 1
     data = length 384, hash 438F4839
   sample 75:
-    time = 3096000
+    time = 3120000
     flags = 1
     data = length 384, hash EBAF44EF
   sample 76:
-    time = 3120000
+    time = 3144000
     flags = 1
     data = length 384, hash D8F64C54
   sample 77:
-    time = 3144000
+    time = 3168000
     flags = 1
     data = length 384, hash 994F2EA6
   sample 78:
-    time = 3168000
+    time = 3192000
     flags = 1
     data = length 384, hash 7E9DF6E4
   sample 79:
-    time = 3192000
+    time = 3216000
     flags = 1
     data = length 384, hash 577F18B8
   sample 80:
-    time = 3216000
+    time = 3240000
     flags = 1
     data = length 384, hash A47FCEE
   sample 81:
-    time = 3240000
+    time = 3264000
     flags = 1
     data = length 384, hash 5A1C435E
   sample 82:
-    time = 3264000
+    time = 3288000
     flags = 1
     data = length 384, hash 1D9EDC36
   sample 83:
-    time = 3288000
+    time = 3312000
     flags = 1
     data = length 384, hash 3355333
   sample 84:
-    time = 3312000
+    time = 3336000
     flags = 1
     data = length 384, hash 27CA9735
   sample 85:
-    time = 3336000
+    time = 3360000
     flags = 1
     data = length 384, hash EB74B3F7
   sample 86:
-    time = 3360000
+    time = 3384000
     flags = 1
     data = length 384, hash 22AC46CB
   sample 87:
-    time = 3384000
+    time = 3408000
     flags = 1
     data = length 384, hash 6002643D
   sample 88:
-    time = 3408000
+    time = 3432000
     flags = 1
     data = length 384, hash 487449E
   sample 89:
-    time = 3432000
+    time = 3456000
     flags = 1
     data = length 384, hash C5B10A14
   sample 90:
-    time = 3456000
+    time = 3480000
     flags = 1
     data = length 384, hash 6050635D
   sample 91:
-    time = 3480000
+    time = 3504000
     flags = 1
     data = length 384, hash 437EAD63
   sample 92:
-    time = 3504000
+    time = 3528000
     flags = 1
     data = length 384, hash 55A02C25
   sample 93:
-    time = 3528000
+    time = 3552000
     flags = 1
     data = length 384, hash 171CCC00
   sample 94:
-    time = 3552000
+    time = 3576000
     flags = 1
     data = length 384, hash 911127C8
   sample 95:
-    time = 3576000
+    time = 3600000
     flags = 1
     data = length 384, hash AA157B50
   sample 96:
-    time = 3600000
+    time = 3624000
     flags = 1
     data = length 384, hash 26F2D866
   sample 97:
-    time = 3624000
+    time = 3648000
     flags = 1
     data = length 384, hash 67ADB3A9
   sample 98:
-    time = 3648000
+    time = 3672000
     flags = 1
     data = length 384, hash F118D82D
   sample 99:
-    time = 3672000
+    time = 3696000
     flags = 1
     data = length 384, hash F51C252B
   sample 100:
-    time = 3696000
+    time = 3720000
     flags = 1
     data = length 384, hash BD13B97C
   sample 101:
-    time = 3720000
+    time = 3744000
     flags = 1
     data = length 384, hash 24BCF0AB
   sample 102:
-    time = 3744000
+    time = 3768000
     flags = 1
     data = length 384, hash 18DE9193
   sample 103:
-    time = 3768000
+    time = 3792000
     flags = 1
     data = length 384, hash 234D8C99
   sample 104:
-    time = 3792000
+    time = 3816000
     flags = 1
     data = length 384, hash EDFD2511
   sample 105:
-    time = 3816000
+    time = 3840000
     flags = 1
     data = length 384, hash 69E3E157
   sample 106:
-    time = 3840000
+    time = 3864000
     flags = 1
     data = length 384, hash AC90ADEC
   sample 107:
-    time = 3864000
+    time = 3888000
     flags = 1
     data = length 384, hash 6A333A56
   sample 108:
-    time = 3888000
+    time = 3912000
     flags = 1
     data = length 384, hash 493D75A3
   sample 109:
-    time = 3912000
+    time = 3936000
     flags = 1
     data = length 384, hash 53FE2A9E
   sample 110:
-    time = 3936000
+    time = 3960000
     flags = 1
     data = length 384, hash 65D6147C
   sample 111:
-    time = 3960000
+    time = 3984000
     flags = 1
     data = length 384, hash 5E744FB2
   sample 112:
-    time = 3984000
+    time = 4008000
     flags = 1
     data = length 384, hash 68AEB7CA
   sample 113:
-    time = 4008000
+    time = 4032000
     flags = 1
     data = length 384, hash AC2972C
   sample 114:
-    time = 4032000
+    time = 4056000
     flags = 1
     data = length 384, hash E2A06CB9
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/avi/sample.avi.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/avi/sample.avi.2.dump
@@ -193,295 +193,295 @@ track 1:
     channelCount = 2
     sampleRate = 48000
   sample 0:
-    time = 2304000
+    time = 2328000
     flags = 1
     data = length 384, hash B5D49F8
   sample 1:
-    time = 2328000
+    time = 2352000
     flags = 1
     data = length 384, hash B341AF3F
   sample 2:
-    time = 2352000
+    time = 2376000
     flags = 1
     data = length 384, hash 6AC1D8C4
   sample 3:
-    time = 2376000
+    time = 2400000
     flags = 1
     data = length 384, hash BC666685
   sample 4:
-    time = 2400000
+    time = 2424000
     flags = 1
     data = length 384, hash E58054E8
   sample 5:
-    time = 2424000
+    time = 2448000
     flags = 1
     data = length 384, hash 404AB403
   sample 6:
-    time = 2448000
+    time = 2472000
     flags = 1
     data = length 384, hash 265A86B8
   sample 7:
-    time = 2472000
+    time = 2496000
     flags = 1
     data = length 384, hash 306316F6
   sample 8:
-    time = 2496000
+    time = 2520000
     flags = 1
     data = length 384, hash 7BFDEA60
   sample 9:
-    time = 2520000
+    time = 2544000
     flags = 1
     data = length 384, hash 2EFF8E5B
   sample 10:
-    time = 2544000
+    time = 2568000
     flags = 1
     data = length 384, hash C06CE84C
   sample 11:
-    time = 2568000
+    time = 2592000
     flags = 1
     data = length 384, hash 9069A01E
   sample 12:
-    time = 2592000
+    time = 2616000
     flags = 1
     data = length 384, hash 4A78F181
   sample 13:
-    time = 2616000
+    time = 2640000
     flags = 1
     data = length 384, hash 57FD4BE7
   sample 14:
-    time = 2640000
+    time = 2664000
     flags = 1
     data = length 384, hash B09DB688
   sample 15:
-    time = 2664000
+    time = 2688000
     flags = 1
     data = length 384, hash 5602C52F
   sample 16:
-    time = 2688000
+    time = 2712000
     flags = 1
     data = length 384, hash 77762F5D
   sample 17:
-    time = 2712000
+    time = 2736000
     flags = 1
     data = length 384, hash 6A0BDB6
   sample 18:
-    time = 2736000
+    time = 2760000
     flags = 1
     data = length 384, hash 2428C91
   sample 19:
-    time = 2760000
+    time = 2784000
     flags = 1
     data = length 384, hash DEB54354
   sample 20:
-    time = 2784000
+    time = 2808000
     flags = 1
     data = length 384, hash FB0B7BEE
   sample 21:
-    time = 2808000
+    time = 2832000
     flags = 1
     data = length 384, hash BDD82F68
   sample 22:
-    time = 2832000
+    time = 2856000
     flags = 1
     data = length 384, hash BAB3B808
   sample 23:
-    time = 2856000
+    time = 2880000
     flags = 1
     data = length 384, hash E9183572
   sample 24:
-    time = 2880000
+    time = 2904000
     flags = 1
     data = length 384, hash 9E36BC40
   sample 25:
-    time = 2904000
+    time = 2928000
     flags = 1
     data = length 384, hash 937ED026
   sample 26:
-    time = 2928000
+    time = 2952000
     flags = 1
     data = length 384, hash BF337AD1
   sample 27:
-    time = 2952000
+    time = 2976000
     flags = 1
     data = length 384, hash E381C534
   sample 28:
-    time = 2976000
+    time = 3000000
     flags = 1
     data = length 384, hash 6C9E1D71
   sample 29:
-    time = 3000000
+    time = 3024000
     flags = 1
     data = length 384, hash 1C359B93
   sample 30:
-    time = 3024000
+    time = 3048000
     flags = 1
     data = length 384, hash 3D137C16
   sample 31:
-    time = 3048000
+    time = 3072000
     flags = 1
     data = length 384, hash 90D23677
   sample 32:
-    time = 3072000
+    time = 3096000
     flags = 1
     data = length 384, hash 438F4839
   sample 33:
-    time = 3096000
+    time = 3120000
     flags = 1
     data = length 384, hash EBAF44EF
   sample 34:
-    time = 3120000
+    time = 3144000
     flags = 1
     data = length 384, hash D8F64C54
   sample 35:
-    time = 3144000
+    time = 3168000
     flags = 1
     data = length 384, hash 994F2EA6
   sample 36:
-    time = 3168000
+    time = 3192000
     flags = 1
     data = length 384, hash 7E9DF6E4
   sample 37:
-    time = 3192000
+    time = 3216000
     flags = 1
     data = length 384, hash 577F18B8
   sample 38:
-    time = 3216000
+    time = 3240000
     flags = 1
     data = length 384, hash A47FCEE
   sample 39:
-    time = 3240000
+    time = 3264000
     flags = 1
     data = length 384, hash 5A1C435E
   sample 40:
-    time = 3264000
+    time = 3288000
     flags = 1
     data = length 384, hash 1D9EDC36
   sample 41:
-    time = 3288000
+    time = 3312000
     flags = 1
     data = length 384, hash 3355333
   sample 42:
-    time = 3312000
+    time = 3336000
     flags = 1
     data = length 384, hash 27CA9735
   sample 43:
-    time = 3336000
+    time = 3360000
     flags = 1
     data = length 384, hash EB74B3F7
   sample 44:
-    time = 3360000
+    time = 3384000
     flags = 1
     data = length 384, hash 22AC46CB
   sample 45:
-    time = 3384000
+    time = 3408000
     flags = 1
     data = length 384, hash 6002643D
   sample 46:
-    time = 3408000
+    time = 3432000
     flags = 1
     data = length 384, hash 487449E
   sample 47:
-    time = 3432000
+    time = 3456000
     flags = 1
     data = length 384, hash C5B10A14
   sample 48:
-    time = 3456000
+    time = 3480000
     flags = 1
     data = length 384, hash 6050635D
   sample 49:
-    time = 3480000
+    time = 3504000
     flags = 1
     data = length 384, hash 437EAD63
   sample 50:
-    time = 3504000
+    time = 3528000
     flags = 1
     data = length 384, hash 55A02C25
   sample 51:
-    time = 3528000
+    time = 3552000
     flags = 1
     data = length 384, hash 171CCC00
   sample 52:
-    time = 3552000
+    time = 3576000
     flags = 1
     data = length 384, hash 911127C8
   sample 53:
-    time = 3576000
+    time = 3600000
     flags = 1
     data = length 384, hash AA157B50
   sample 54:
-    time = 3600000
+    time = 3624000
     flags = 1
     data = length 384, hash 26F2D866
   sample 55:
-    time = 3624000
+    time = 3648000
     flags = 1
     data = length 384, hash 67ADB3A9
   sample 56:
-    time = 3648000
+    time = 3672000
     flags = 1
     data = length 384, hash F118D82D
   sample 57:
-    time = 3672000
+    time = 3696000
     flags = 1
     data = length 384, hash F51C252B
   sample 58:
-    time = 3696000
+    time = 3720000
     flags = 1
     data = length 384, hash BD13B97C
   sample 59:
-    time = 3720000
+    time = 3744000
     flags = 1
     data = length 384, hash 24BCF0AB
   sample 60:
-    time = 3744000
+    time = 3768000
     flags = 1
     data = length 384, hash 18DE9193
   sample 61:
-    time = 3768000
+    time = 3792000
     flags = 1
     data = length 384, hash 234D8C99
   sample 62:
-    time = 3792000
+    time = 3816000
     flags = 1
     data = length 384, hash EDFD2511
   sample 63:
-    time = 3816000
+    time = 3840000
     flags = 1
     data = length 384, hash 69E3E157
   sample 64:
-    time = 3840000
+    time = 3864000
     flags = 1
     data = length 384, hash AC90ADEC
   sample 65:
-    time = 3864000
+    time = 3888000
     flags = 1
     data = length 384, hash 6A333A56
   sample 66:
-    time = 3888000
+    time = 3912000
     flags = 1
     data = length 384, hash 493D75A3
   sample 67:
-    time = 3912000
+    time = 3936000
     flags = 1
     data = length 384, hash 53FE2A9E
   sample 68:
-    time = 3936000
+    time = 3960000
     flags = 1
     data = length 384, hash 65D6147C
   sample 69:
-    time = 3960000
+    time = 3984000
     flags = 1
     data = length 384, hash 5E744FB2
   sample 70:
-    time = 3984000
+    time = 4008000
     flags = 1
     data = length 384, hash 68AEB7CA
   sample 71:
-    time = 4008000
+    time = 4032000
     flags = 1
     data = length 384, hash AC2972C
   sample 72:
-    time = 4032000
+    time = 4056000
     flags = 1
     data = length 384, hash E2A06CB9
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/avi/sample.avi.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/avi/sample.avi.3.dump
@@ -49,43 +49,43 @@ track 1:
     channelCount = 2
     sampleRate = 48000
   sample 0:
-    time = 3816000
+    time = 3840000
     flags = 1
     data = length 384, hash 69E3E157
   sample 1:
-    time = 3840000
+    time = 3864000
     flags = 1
     data = length 384, hash AC90ADEC
   sample 2:
-    time = 3864000
+    time = 3888000
     flags = 1
     data = length 384, hash 6A333A56
   sample 3:
-    time = 3888000
+    time = 3912000
     flags = 1
     data = length 384, hash 493D75A3
   sample 4:
-    time = 3912000
+    time = 3936000
     flags = 1
     data = length 384, hash 53FE2A9E
   sample 5:
-    time = 3936000
+    time = 3960000
     flags = 1
     data = length 384, hash 65D6147C
   sample 6:
-    time = 3960000
+    time = 3984000
     flags = 1
     data = length 384, hash 5E744FB2
   sample 7:
-    time = 3984000
+    time = 4008000
     flags = 1
     data = length 384, hash 68AEB7CA
   sample 8:
-    time = 4008000
+    time = 4032000
     flags = 1
     data = length 384, hash AC2972C
   sample 9:
-    time = 4032000
+    time = 4056000
     flags = 1
     data = length 384, hash E2A06CB9
 tracksEnded = true


### PR DESCRIPTION
Fixes to audio stream timing and seeking.

Fixes:

- Tracks the non-key frame stream(s) chunk position relative to the key frame stream chunk position.  This is tracked as a "foreign" key frame reference in the non-key frame stream.   This allows us to maintain perfect AV sync on seek.
- Use chunk count to calculate chunk timing.  Frame count was being used.  This can be 1:1, but usually isn't.

Enhancements:

- Remove the audio frame key frame tracking.  All audio frames are keys frame.  This can lead to a massive memory footprint for large files.
- Minor improvement in chunk mapping.  Use a bitmask of type and stream id instead of the exact chunk id.  This removes the need for a secondary check for streams with different stream sub types (video compressed/uncompressed).

[Sample File](https://drive.google.com/file/d/1omz9_nHTy8UMWdk6keduOOP_dobkUGaY/view?usp=sharing)