### PR TITLE
DefaultMediaNotificationProvider: Use metadata.subtitle as content text of notification.

### DIFF
--- a/libraries/session/src/main/java/androidx/media3/session/DefaultMediaNotificationProvider.java
+++ b/libraries/session/src/main/java/androidx/media3/session/DefaultMediaNotificationProvider.java
@@ -276,7 +276,7 @@ public class DefaultMediaNotificationProvider implements MediaNotification.Provi
 
     // Set metadata info in the notification.
     MediaMetadata metadata = player.getMediaMetadata();
-    builder.setContentTitle(metadata.title).setContentText(metadata.artist);
+    builder.setContentTitle(metadata.title).setContentText(metadata.subtitle);
     @Nullable ListenableFuture<Bitmap> bitmapFuture = loadArtworkBitmap(metadata);
     if (bitmapFuture != null) {
       if (pendingOnBitmapLoadedFutureCallback != null) {


### PR DESCRIPTION
Why is the artist currently being used? It took me quite a while to figure out and my first instinct would have been to show the subtitle.