### PR TITLE
MediaSession.Callback: Document an example when onAddMediaItems is called.

### DIFF
--- a/libraries/session/src/main/java/androidx/media3/session/MediaSession.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSession.java
@@ -993,7 +993,7 @@ public class MediaSession {
     /**
      * Called when a controller requested to add new {@linkplain MediaItem media items} to the
      * playlist via one of the {@code Player.addMediaItem(s)} or {@code Player.setMediaItem(s)}
-     * methods.
+     * methods. For instance when selecting an item on Android Auto, which should then be played.
      *
      * <p>Note that the requested {@linkplain MediaItem media items} don't have a {@link
      * MediaItem.LocalConfiguration} (for example, a URI) and need to be updated to make them


### PR DESCRIPTION
While the documentation is already super precise, personally for me coming from a non media related background, I'd appreciate some examples. Coming from: https://github.com/androidx/media/issues/156