### PR TITLE
Make download notification appear immediately

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DownloadNotificationHelper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DownloadNotificationHelper.java
@@ -237,6 +237,7 @@ public final class DownloadNotificationHelper {
     notificationBuilder.setProgress(maxProgress, currentProgress, indeterminateProgress);
     notificationBuilder.setOngoing(ongoing);
     notificationBuilder.setShowWhen(showWhen);
+    notificationBuilder.setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE);
     return notificationBuilder.build();
   }
 }


### PR DESCRIPTION
Since Android 12 (API 31) notifications produced by `startForeground` method wait 10 seconds until showing. This could be confusing to user who use `DownloadNotificationHelper` methods to build notifications to show in a custom `DownloadService` (`protected abstract Notification getForegroundNotification(List<Download> downloads, @RequirementFlags int notMetRequirements);`).

Docs excerpt:
> Devices that run Android 12 (API level 31) or higher provide a streamlined experience for short-running foreground services. On these devices, the system waits 10 seconds before showing the notification associated with a foreground service. There are a few exceptions; several types of services always [display a notification immediately](https://developer.android.com/guide/components/foreground-services#notification-immediate).

To make the notifications be shown immediately once actual download operation is started, `FOREGROUND_SERVICE_IMMEDIATE` can be set to `NotificationCompat.Builder.setForegroundServiceBehavior()`.
See: https://developer.android.com/guide/components/foreground-services#notification-immediate