### PR TITLE
Fix missing modulePrefix

### DIFF
--- a/libraries/test_session_current/build.gradle
+++ b/libraries/test_session_current/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation project(modulePrefix + 'test-session-common')
     implementation 'androidx.media:media:' + androidxMediaVersion
     implementation 'androidx.test:core:' + androidxTestCoreVersion
-    implementation project(path: ':test-data')
+    implementation project(modulePrefix + 'test-data')
     androidTestImplementation project(modulePrefix + 'lib-exoplayer')
     androidTestImplementation 'androidx.test.ext:junit:' + androidxTestJUnitVersion
     androidTestImplementation 'androidx.test.ext:truth:' + androidxTestTruthVersion


### PR DESCRIPTION
This pull request fixes a missing `modulePrefix` when referring to the `test-data` project.

I'm using the media3 library via a locally cloned repo code and facing a build error when `gradle.ext.androidxMediaModulePrefix` is used.

EDIT: This fixes issue #209. (I was not noticed when I created the PR)