### PR TITLE
Fix proposal for video playback when looper is not main

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/EventHandlerRequestCallback.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/EventHandlerRequestCallback.java
@@ -1,0 +1,28 @@
+package androidx.media3.exoplayer;
+
+import android.os.Looper;
+import androidx.annotation.RequiresApi;
+import java.util.concurrent.Phaser;
+
+/**
+ * Used to react to the corresponding ExoPlayer instance requesting private work on its dedicated
+ * looper's thread.
+ */
+public interface EventHandlerRequestCallback {
+
+  /**
+   * Invoked at any time after a {@link Runnable} has been posted to the corresponding ExoPlayer's
+   * instance dedicated looper's thread. This callback will be invoked on a specifically designated
+   * thread where ExoPlayer will request nothing else to run on, immediately as the triggering
+   * {@link android.os.Handler#post(Runnable)} call has finished. You may use the given
+   * {@link Phaser} to track of whether all posted Runnables have finished execution or not.
+   *
+   * @param remainingPhaser A signal for how many posted Runnables have still not finished
+   *                        execution. It is safe to block execution of the thread associated to
+   *                        ExoPlayer's while and only while there are no yet-to-arrive parties on
+   *                        this object. Blocking the thread associated to ExoPlayer's looper
+   *                        otherwise may result on incorrect behavior, deadlocks, or exceptions.
+   * @see ExoPlayer.Builder#setLooper(Looper, EventHandlerRequestCallback)
+   */
+  void onRunnablePosted(Phaser remainingPhaser);
+}

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/EventHandlerRunnableDispatcher.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/EventHandlerRunnableDispatcher.java
@@ -1,0 +1,61 @@
+package androidx.media3.exoplayer;
+
+import static androidx.media3.common.util.Assertions.checkNotNull;
+
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import java.util.concurrent.Phaser;
+
+final class EventHandlerRunnableDispatcher {
+
+  private final Handler eventHandler;
+  @Nullable private final Handler callbackHandler;
+  @Nullable private final EventHandlerRequestCallback eventHandlerRequestCallback;
+  @Nullable private final Phaser remainingPhaser;
+
+  EventHandlerRunnableDispatcher(Handler eventHandler) {
+    this.eventHandler = eventHandler;
+    this.callbackHandler = null;
+    this.eventHandlerRequestCallback = null;
+    remainingPhaser = null;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  EventHandlerRunnableDispatcher(
+      Handler eventHandler,
+      @NonNull Handler callbackHandler,
+      @NonNull EventHandlerRequestCallback eventHandlerRequestCallback
+  ) {
+    this.eventHandler = eventHandler;
+    this.callbackHandler = callbackHandler;
+    this.eventHandlerRequestCallback = eventHandlerRequestCallback;
+    remainingPhaser = new Phaser();
+  }
+
+  Looper getEventLooper() {
+    return eventHandler.getLooper();
+  }
+
+  void submit(Runnable runnable) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      checkNotNull(callbackHandler);
+      checkNotNull(eventHandlerRequestCallback);
+      checkNotNull(remainingPhaser);
+      remainingPhaser.register();
+      eventHandler.post(() -> {
+        try {
+          runnable.run();
+        } finally {
+          remainingPhaser.arriveAndDeregister();
+        }
+      });
+      callbackHandler.post(() -> eventHandlerRequestCallback.onRunnablePosted(remainingPhaser));
+    } else {
+      eventHandler.post(runnable);
+    }
+  }
+}

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayer.java
@@ -23,6 +23,7 @@ import android.content.Context;
 import android.media.AudioDeviceInfo;
 import android.media.AudioTrack;
 import android.media.MediaCodec;
+import android.os.Build;
 import android.os.Looper;
 import android.os.Process;
 import android.view.Surface;
@@ -487,6 +488,7 @@ public interface ExoPlayer extends Player {
     /* package */ boolean pauseAtEndOfMediaItems;
     /* package */ boolean usePlatformDiagnostics;
     @Nullable /* package */ Looper playbackLooper;
+    @Nullable /* package */ EventHandlerRequestCallback eventHandlerRequestCallback;
     /* package */ boolean buildCalled;
 
     /**
@@ -800,6 +802,27 @@ public interface ExoPlayer extends Player {
       checkState(!buildCalled);
       checkNotNull(looper);
       this.looper = looper;
+      return this;
+    }
+
+    /**
+     * Sets the {@link Looper} that must be used for all calls to the player and that is used to
+     * call listeners on, and optionally requests ExoPlayer to announce when it submits work to said
+     * looper's thread via the given callback.
+     *
+     * @param looper A {@link Looper}.
+     * @param eventHandlerRequestCallback The callback to notify of work being submitted.
+     * @return This builder.
+     * @throws IllegalStateException If {@link #build()} has already been called.
+     * @see <a href="https://github.com/google/ExoPlayer/issues/10880#issuecomment-1371083675">Possibility of deadlocks when playing video on a background thread-managed ExoPlayer</a>
+     */
+    @CanIgnoreReturnValue
+    @UnstableApi
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    public Builder setLooper(Looper looper, @Nullable EventHandlerRequestCallback eventHandlerRequestCallback) {
+      checkState(!buildCalled);
+      setLooper(looper);
+      this.eventHandlerRequestCallback = eventHandlerRequestCallback;
       return this;
     }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/SynchronousCallbackSurfaceHolder.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/SynchronousCallbackSurfaceHolder.java
@@ -1,0 +1,115 @@
+package androidx.media3.exoplayer;
+
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.os.Build;
+import android.os.Handler;
+import android.view.Surface;
+import android.view.SurfaceHolder;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import java.util.HashMap;
+import java.util.Map;
+
+final class SynchronousCallbackSurfaceHolder implements SurfaceHolder {
+  private final EventHandlerRunnableDispatcher eventHandlerRunnableDispatcher;
+  private final SurfaceHolder delegate;
+  private final Map<Callback, SynchronousSurfaceHolderCallback> mappedCallbacks = new HashMap<>();
+
+  SynchronousCallbackSurfaceHolder(
+      EventHandlerRunnableDispatcher eventHandlerRunnableDispatcher, SurfaceHolder delegate
+  ) {
+    this.eventHandlerRunnableDispatcher = eventHandlerRunnableDispatcher;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void addCallback(@Nullable Callback callback) {
+    if (callback == null) {
+      return;
+    }
+    synchronized (mappedCallbacks) {
+      SynchronousSurfaceHolderCallback mappedCallback = new SynchronousSurfaceHolderCallback(
+          eventHandlerRunnableDispatcher, callback
+      );
+      mappedCallbacks.put(callback, mappedCallback);
+      delegate.addCallback(mappedCallback);
+    }
+  }
+
+  @Override
+  public void removeCallback(@Nullable Callback callback) {
+    if (callback == null) {
+      return;
+    }
+    synchronized (mappedCallbacks) {
+      if (!mappedCallbacks.containsKey(callback)) {
+        return;
+      }
+      SynchronousSurfaceHolderCallback mappedCallback = mappedCallbacks.get(callback);
+      delegate.removeCallback(mappedCallback);
+      mappedCallbacks.remove(callback);
+    }
+  }
+
+  @Override
+  public boolean isCreating() {
+    return delegate.isCreating();
+  }
+
+  @Override
+  public void setType(int type) {
+    delegate.setType(type);
+  }
+
+  @Override
+  public void setFixedSize(int width, int height) {
+    delegate.setFixedSize(width, height);
+  }
+
+  @Override
+  public void setSizeFromLayout() {
+    delegate.setSizeFromLayout();
+  }
+
+  @Override
+  public void setFormat(int format) {
+    delegate.setFormat(format);
+  }
+
+  @Override
+  public void setKeepScreenOn(boolean screenOn) {
+    delegate.setKeepScreenOn(screenOn);
+  }
+
+  @Override
+  public Canvas lockCanvas() {
+    return delegate.lockCanvas();
+  }
+
+  @Override
+  public Canvas lockCanvas(Rect dirty) {
+    return delegate.lockCanvas(dirty);
+  }
+
+  @Override
+  public void unlockCanvasAndPost(Canvas canvas) {
+    delegate.unlockCanvasAndPost(canvas);
+  }
+
+  @Override
+  public Rect getSurfaceFrame() {
+    return delegate.getSurfaceFrame();
+  }
+
+  @Override
+  public Surface getSurface() {
+    return delegate.getSurface();
+  }
+
+  @Override
+  @RequiresApi(api = Build.VERSION_CODES.O)
+  public Canvas lockHardwareCanvas() {
+    return delegate.lockHardwareCanvas();
+  }
+}

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/SynchronousSurfaceHolderCallback.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/SynchronousSurfaceHolderCallback.java
@@ -1,0 +1,63 @@
+package androidx.media3.exoplayer;
+
+import android.os.Looper;
+import android.view.SurfaceHolder;
+import androidx.annotation.NonNull;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+final class SynchronousSurfaceHolderCallback implements SurfaceHolder.Callback {
+  private final EventHandlerRunnableDispatcher eventHandlerRunnableDispatcher;
+  private final SurfaceHolder.Callback delegate;
+  private final ReentrantLock reentrantLock = new ReentrantLock(true);
+
+  SynchronousSurfaceHolderCallback(
+      EventHandlerRunnableDispatcher eventHandlerRunnableDispatcher, SurfaceHolder.Callback delegate
+  ) {
+    this.eventHandlerRunnableDispatcher = eventHandlerRunnableDispatcher;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void surfaceCreated(@NonNull SurfaceHolder holder) {
+    dispatchAndWaitFor(() -> delegate.surfaceCreated(holder));
+  }
+
+  @Override
+  public void surfaceChanged(@NonNull SurfaceHolder holder, int format, int width, int height) {
+    dispatchAndWaitFor(() -> delegate.surfaceChanged(holder, format, width, height));
+  }
+
+  @Override
+  public void surfaceDestroyed(@NonNull SurfaceHolder holder) {
+    dispatchAndWaitFor(() -> delegate.surfaceDestroyed(holder));
+  }
+
+  private void dispatchAndWaitFor(Runnable runnable) {
+    if (eventHandlerRunnableDispatcher.getEventLooper() == Looper.myLooper()) {
+      runnable.run();
+      return;
+    }
+    AtomicBoolean finished = new AtomicBoolean(false);
+    Condition condition = reentrantLock.newCondition();
+    eventHandlerRunnableDispatcher.submit(() -> {
+      runnable.run();
+      reentrantLock.lock();
+      try {
+        condition.signal();
+      } finally {
+        reentrantLock.unlock();
+      }
+      finished.set(true);
+    });
+    reentrantLock.lock();
+    try {
+      while (!finished.get()) {
+        condition.awaitUninterruptibly();
+      }
+    } finally {
+      reentrantLock.unlock();
+    }
+  }
+}


### PR DESCRIPTION
This can be used to register interest on listening for ExoPlayer submitting work requests to its managing thread in order to allow hosts to avoid deadlocks. See https://github.com/google/ExoPlayer/issues/10880#issuecomment-1371083675 for more info on the issue.

This PR is intended as a request for comments on the fix proposal that I have come up with. In addition to the aforementioned mechanism, it causes calls on SurfaceHolder.Callback to be switched to the event Handler, but does effectively nothing if said Handler corresponds to the main Looper, meaning it should be backwards compatible in that regard. There will be a behaviour change for users that are calling setLooper with a non-main Looper while also using setVideoSurfaceHolder, but these users will have been facing an exception thus far (as described in the issue linked above) so the change described is a bugfix for them. The fix is tested to be working by using https://github.com/stoyicker/mwe-exoplayer-surfaceviewwrongthread/tree/c2b7d425b774c248865db1672680ef77ad65b7d4 via mavenLocal.

Worth highlighting that the callback will be ignored (not invoked) on API lower than 21 due to the use of Phaser. It should be possible to tackle this if desired by for example writing something that works with all supported APIs to replace Phaser.

Thoughts?
