### PR TITLE
Resolve discontinuities when seeking into fragmented AC-4 audio

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/SampleMetadata.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/SampleMetadata.java
@@ -1,0 +1,27 @@
+package androidx.media3.exoplayer.source;
+
+import androidx.annotation.Nullable;
+import androidx.media3.common.C;
+import androidx.media3.extractor.TrackOutput;
+
+/* package */ final class SampleMetadata {
+  final long timeUs;
+
+  @C.BufferFlags
+  final int flags;
+
+  final int size;
+
+  final long absoluteOffset;
+
+  @Nullable
+  final TrackOutput.CryptoData cryptoData;
+
+  SampleMetadata(long timeUs, @C.BufferFlags int flags, int size, long absoluteOffset, @Nullable TrackOutput.CryptoData cryptoData) {
+    this.timeUs = timeUs;
+    this.flags = flags;
+    this.size = size;
+    this.absoluteOffset = absoluteOffset;
+    this.cryptoData = cryptoData;
+  }
+}


### PR DESCRIPTION
Related to google/ExoPlayer#11000

Proof of concept for resolving discontinuities in FMP4 AC-4 playback.

The underlying cause on our end appears to come from the fact that we can't anticipate sync frames when committing them to our sample queue. Once we reach the end of our first fragment, we begin committing samples to our sample queue, even if suitable sync frames are available in later fragments.

For this PR, we would have some sort of intermediate structure to retain samples before committing them, in the event that our format does not guarantee that every frame is a key frame. When we encounter a key frame, we empty the contents of this structure, as we can begin playback from that key frame instead. When we pass our start time, we commit any samples in the intermediate structure to our sample queue, allowing us to play from the nearest key frame.