### PR TITLE
Dts direct passthrough support

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -17,7 +17,7 @@
     *   Ogg: Fix bug when seeking in files with a long duration
         ([#391](https://github.com/androidx/media/issues/391)).
 *   Audio:
-    *   Add direct playback supports for DTS Express and DTS:X
+    *   Add direct playback support for DTS Express and DTS:X
         ([#335](https://github.com/androidx/media/pull/335)).
 *   Audio Offload:
     *   Add `AudioSink.getFormatOffloadSupport(Format)` that retrieves level of

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -17,6 +17,8 @@
     *   Ogg: Fix bug when seeking in files with a long duration
         ([#391](https://github.com/androidx/media/issues/391)).
 *   Audio:
+    *   Add direct playback supports for DTS Express and DTS:X
+        ([#335](https://github.com/androidx/media/pull/335)).
 *   Audio Offload:
     *   Add `AudioSink.getFormatOffloadSupport(Format)` that retrieves level of
         offload support the sink can provide for the format through a

--- a/libraries/common/src/main/java/androidx/media3/common/C.java
+++ b/libraries/common/src/main/java/androidx/media3/common/C.java
@@ -256,6 +256,10 @@ public final class C {
   @UnstableApi public static final int ENCODING_DTS = AudioFormat.ENCODING_DTS;
   /** See {@link AudioFormat#ENCODING_DTS_HD}. */
   @UnstableApi public static final int ENCODING_DTS_HD = AudioFormat.ENCODING_DTS_HD;
+  /**
+   * TODO: To replace with AudioFormat.ENCODING_DTS_UHD_P2 when Android 14.0 is released.
+   */
+  @UnstableApi public static final int ENCODING_DTS_UHD_P2 = 0x0000001e;
   /** See {@link AudioFormat#ENCODING_DOLBY_TRUEHD}. */
   @UnstableApi public static final int ENCODING_DOLBY_TRUEHD = AudioFormat.ENCODING_DOLBY_TRUEHD;
   /** See {@link AudioFormat#ENCODING_OPUS}. */

--- a/libraries/common/src/main/java/androidx/media3/common/C.java
+++ b/libraries/common/src/main/java/androidx/media3/common/C.java
@@ -257,7 +257,7 @@ public final class C {
   @UnstableApi public static final int ENCODING_DTS = AudioFormat.ENCODING_DTS;
   /** See {@link AudioFormat#ENCODING_DTS_HD}. */
   @UnstableApi public static final int ENCODING_DTS_HD = AudioFormat.ENCODING_DTS_HD;
-  /** TODO: To replace with AudioFormat.ENCODING_DTS_UHD_P2 when Android 14.0 is released. */
+  // TODO(internal b/283949283): Use AudioFormat.ENCODING_DTS_UHD_P2 when Android 14 is released.
   @UnstableApi public static final int ENCODING_DTS_UHD_P2 = 0x0000001e;
   /** See {@link AudioFormat#ENCODING_DOLBY_TRUEHD}. */
   @UnstableApi public static final int ENCODING_DOLBY_TRUEHD = AudioFormat.ENCODING_DOLBY_TRUEHD;

--- a/libraries/common/src/main/java/androidx/media3/common/C.java
+++ b/libraries/common/src/main/java/androidx/media3/common/C.java
@@ -256,9 +256,7 @@ public final class C {
   @UnstableApi public static final int ENCODING_DTS = AudioFormat.ENCODING_DTS;
   /** See {@link AudioFormat#ENCODING_DTS_HD}. */
   @UnstableApi public static final int ENCODING_DTS_HD = AudioFormat.ENCODING_DTS_HD;
-  /**
-   * TODO: To replace with AudioFormat.ENCODING_DTS_UHD_P2 when Android 14.0 is released.
-   */
+  /** TODO: To replace with AudioFormat.ENCODING_DTS_UHD_P2 when Android 14.0 is released. */
   @UnstableApi public static final int ENCODING_DTS_UHD_P2 = 0x0000001e;
   /** See {@link AudioFormat#ENCODING_DOLBY_TRUEHD}. */
   @UnstableApi public static final int ENCODING_DOLBY_TRUEHD = AudioFormat.ENCODING_DOLBY_TRUEHD;

--- a/libraries/common/src/main/java/androidx/media3/common/C.java
+++ b/libraries/common/src/main/java/androidx/media3/common/C.java
@@ -192,6 +192,7 @@ public final class C {
     ENCODING_DTS_HD,
     ENCODING_DOLBY_TRUEHD,
     ENCODING_OPUS,
+    ENCODING_DTS_UHD_P2,
   })
   public @interface Encoding {}
 

--- a/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
@@ -595,6 +595,10 @@ public final class MimeTypes {
         return C.ENCODING_DTS;
       case MimeTypes.AUDIO_DTS_HD:
         return C.ENCODING_DTS_HD;
+      case MimeTypes.AUDIO_DTS_EXPRESS:
+        return C.ENCODING_DTS; // This should be ENCODING_DTS_HD when IC platforms support it.
+      case MimeTypes.AUDIO_DTS_X:
+        return C.ENCODING_DTS; // This should be ENCODING_DTS_UHD_P2 when IC platforms support it.
       case MimeTypes.AUDIO_TRUEHD:
         return C.ENCODING_DOLBY_TRUEHD;
       case MimeTypes.AUDIO_OPUS:

--- a/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
@@ -596,9 +596,9 @@ public final class MimeTypes {
       case MimeTypes.AUDIO_DTS_HD:
         return C.ENCODING_DTS_HD;
       case MimeTypes.AUDIO_DTS_EXPRESS:
-        return C.ENCODING_DTS; // This should be ENCODING_DTS_HD when IC platforms support it.
+        return C.ENCODING_DTS_HD;
       case MimeTypes.AUDIO_DTS_X:
-        return C.ENCODING_DTS; // This should be ENCODING_DTS_UHD_P2 when IC platforms support it.
+        return C.ENCODING_DTS_UHD_P2;
       case MimeTypes.AUDIO_TRUEHD:
         return C.ENCODING_DOLBY_TRUEHD;
       case MimeTypes.AUDIO_OPUS:

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -1884,6 +1884,14 @@ public final class Util {
         return AudioFormat.CHANNEL_OUT_5POINT1 | AudioFormat.CHANNEL_OUT_BACK_CENTER;
       case 8:
         return AudioFormat.CHANNEL_OUT_7POINT1_SURROUND;
+      case 10:
+        if (Util.SDK_INT > 31) {
+          return AudioFormat.CHANNEL_OUT_5POINT1POINT4;
+        } else {
+          // This is used by DTS:X P2 with Direct Passthrough Playback.
+          // Specifying the audio format as 7.1 for 10 channels does not affect the playback.
+          return AudioFormat.CHANNEL_OUT_7POINT1_SURROUND;
+        }
       case 12:
         return AudioFormat.CHANNEL_OUT_7POINT1POINT4;
       default:

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -1885,11 +1885,12 @@ public final class Util {
       case 8:
         return AudioFormat.CHANNEL_OUT_7POINT1_SURROUND;
       case 10:
-        if (Util.SDK_INT > 31) {
+        if (Util.SDK_INT >= 32) {
           return AudioFormat.CHANNEL_OUT_5POINT1POINT4;
         } else {
-          // This is used by DTS:X P2 with Direct Passthrough Playback.
-          // Specifying the audio format as 7.1 for 10 channels does not affect the playback.
+          // Before API 32, height channel masks are not available. For those 10-channel streams
+          // supported on the audio output devices (e.g. DTS:X P2), we will use 7.1-surround
+          // instead.
           return AudioFormat.CHANNEL_OUT_7POINT1_SURROUND;
         }
       case 12:

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -537,6 +537,30 @@ public final class Util {
   }
 
   /**
+   * Remove duplicates from an Integer array.
+   *
+   * @param inputs The input integer array.
+   * @return The integer array without duplicates.
+   */
+  @UnstableApi
+  @SuppressWarnings("nullness:assignment")
+  public static int[] nullSafeIntegerArrayDistinct(int[] inputs) {
+    int end = inputs.length;
+    for (int i = 0; i < end; i++) {
+      for (int j = i + 1; j < end; j++) {
+        if (inputs[i] == inputs[j]) {
+          inputs[j] = inputs[end - 1];
+          end--;
+          j--;
+        }
+      }
+    }
+    int[] newlist = new int[end];
+    System.arraycopy(inputs, 0, newlist, 0, end);
+    return newlist;
+  }
+
+  /**
    * Copies the contents of {@code list} into {@code array}.
    *
    * <p>{@code list.size()} must be the same as {@code array.length} to ensure the contents can be
@@ -550,6 +574,23 @@ public final class Util {
   public static <T> void nullSafeListToArray(List<T> list, T[] array) {
     Assertions.checkState(list.size() == array.length);
     list.toArray(array);
+  }
+
+  /**
+   * Creates a new Integer array from a List of Integers.
+   *
+   * @param list The list of integers to convert.
+   * @return Created array of integers.
+   */
+  @UnstableApi
+  @SuppressWarnings("nullness:assignment")
+  public static int[] nullSafeIntegerListToArray(List<Integer> list) {
+    int[] intList = new int[list.size()];
+
+    for (int i = 0; i < list.size(); i++) {
+      intList[i] = list.get(i);
+    }
+    return intList;
   }
 
   /**

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -517,6 +517,26 @@ public final class Util {
   }
 
   /**
+   * Creates a new Integer array containing the concatenation of two non-null Integer arrays.
+   *
+   * @param first  The first array.
+   * @param second The second array.
+   * @return The concatenated result.
+   */
+  @UnstableApi
+  @SuppressWarnings("nullness:assignment")
+  public static int[] nullSafeIntegerArrayConcatenation(int[] first, int[] second) {
+    int[] concatenation = Arrays.copyOf(first, first.length + second.length);
+    System.arraycopy(
+        /* src= */ second,
+        +        /* srcPos= */ 0,
+        /* dest= */ concatenation,
+        /* destPos= */ first.length,
+        /* length= */ second.length);
+    return concatenation;
+  }
+
+  /**
    * Copies the contents of {@code list} into {@code array}.
    *
    * <p>{@code list.size()} must be the same as {@code array.length} to ensure the contents can be

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -517,30 +517,6 @@ public final class Util {
   }
 
   /**
-   * Remove duplicates from an Integer array.
-   *
-   * @param inputs The input integer array.
-   * @return The integer array without duplicates.
-   */
-  @UnstableApi
-  @SuppressWarnings("nullness:assignment")
-  public static int[] nullSafeIntegerArrayDistinct(int[] inputs) {
-    int end = inputs.length;
-    for (int i = 0; i < end; i++) {
-      for (int j = i + 1; j < end; j++) {
-        if (inputs[i] == inputs[j]) {
-          inputs[j] = inputs[end - 1];
-          end--;
-          j--;
-        }
-      }
-    }
-    int[] newlist = new int[end];
-    System.arraycopy(inputs, 0, newlist, 0, end);
-    return newlist;
-  }
-
-  /**
    * Copies the contents of {@code list} into {@code array}.
    *
    * <p>{@code list.size()} must be the same as {@code array.length} to ensure the contents can be

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -1889,8 +1889,7 @@ public final class Util {
           return AudioFormat.CHANNEL_OUT_5POINT1POINT4;
         } else {
           // Before API 32, height channel masks are not available. For those 10-channel streams
-          // supported on the audio output devices (e.g. DTS:X P2), we will use 7.1-surround
-          // instead.
+          // supported on the audio output devices (e.g. DTS:X P2), we use 7.1-surround instead.
           return AudioFormat.CHANNEL_OUT_7POINT1_SURROUND;
         }
       case 12:

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -517,26 +517,6 @@ public final class Util {
   }
 
   /**
-   * Creates a new Integer array containing the concatenation of two non-null Integer arrays.
-   *
-   * @param first  The first array.
-   * @param second The second array.
-   * @return The concatenated result.
-   */
-  @UnstableApi
-  @SuppressWarnings("nullness:assignment")
-  public static int[] nullSafeIntegerArrayConcatenation(int[] first, int[] second) {
-    int[] concatenation = Arrays.copyOf(first, first.length + second.length);
-    System.arraycopy(
-        /* src= */ second,
-        +        /* srcPos= */ 0,
-        /* dest= */ concatenation,
-        /* destPos= */ first.length,
-        /* length= */ second.length);
-    return concatenation;
-  }
-
-  /**
    * Remove duplicates from an Integer array.
    *
    * @param inputs The input integer array.
@@ -574,23 +554,6 @@ public final class Util {
   public static <T> void nullSafeListToArray(List<T> list, T[] array) {
     Assertions.checkState(list.size() == array.length);
     list.toArray(array);
-  }
-
-  /**
-   * Creates a new Integer array from a List of Integers.
-   *
-   * @param list The list of integers to convert.
-   * @return Created array of integers.
-   */
-  @UnstableApi
-  @SuppressWarnings("nullness:assignment")
-  public static int[] nullSafeIntegerListToArray(List<Integer> list) {
-    int[] intList = new int[list.size()];
-
-    for (int i = 0; i < list.size(); i++) {
-      intList[i] = list.get(i);
-    }
-    return intList;
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -101,8 +101,8 @@ public final class AudioCapabilities {
     if (Util.SDK_INT >= 23 && Api23.isBluetoothConnected(context)) {
       return DEFAULT_AUDIO_CAPABILITIES;
     }
-    ImmutableSet.Builder supportedEncodings = new ImmutableSet.Builder<>();
 
+    ImmutableSet.Builder supportedEncodings = new ImmutableSet.Builder<>();
     if (deviceMaySetExternalSurroundSoundGlobalSetting()
         && Global.getInt(context.getContentResolver(), EXTERNAL_SURROUND_SOUND_KEY, 0) == 1) {
       supportedEncodings.addAll(Ints.asList(EXTERNAL_SURROUND_SOUND_ENCODINGS));

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -119,7 +119,9 @@ public final class AudioCapabilities {
       supportedEncodings.addAll(Ints.asList(
           intent.getIntArrayExtra(AudioManager.EXTRA_ENCODINGS)));
       return new AudioCapabilities(
-          Ints.toArray(supportedEncodings.build()), /* defaultValue= */ DEFAULT_MAX_CHANNEL_COUNT);
+          Ints.toArray(supportedEncodings.build()),
+          intent.getIntExtra(AudioManager.EXTRA_MAX_CHANNEL_COUNT, /* defaultValue= */
+              DEFAULT_MAX_CHANNEL_COUNT));
     }
 
     if (supportedEncodings.build().isEmpty()) {
@@ -227,7 +229,13 @@ public final class AudioCapabilities {
       channelCount = getMaxSupportedChannelCountForPassthrough(encoding, sampleRate);
     } else {
       channelCount = format.channelCount;
-      if (channelCount > maxChannelCount) {
+      // To file a Bug: Some DTS:X TVs reports ACTION_HDMI_AUDIO_PLUG.EXTRA_MAX_CHANNEL_COUNT as 8
+      // instead of 10.
+      if (format.sampleMimeType == MimeTypes.AUDIO_DTS_X) {
+        if (channelCount > 10) {
+          return null;
+        }
+      } else if (channelCount > maxChannelCount) {
         return null;
       }
     }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -44,6 +44,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /** Represents the set of audio formats that a device is capable of playing. */
 @UnstableApi
@@ -402,7 +404,7 @@ public final class AudioCapabilities {
     /**
      * Returns an array list of surround encodings that maybe supported.
      */
-    private static ArrayList<Integer> getAllSurroundEncodingsMaybeSupported() {
+    private static List<Integer> getAllSurroundEncodingsMaybeSupported() {
       ArrayList<Integer> encodings = new ArrayList<>();
       for (int encoding : ALL_SURROUND_ENCODINGS_AND_MAX_CHANNELS.keySet()) {
         // AudioFormat.ENCODING_DTS_UHD_P2 is supported from API 34.
@@ -411,7 +413,7 @@ public final class AudioCapabilities {
         }
         encodings.add(encoding);
       }
-      return encodings;
+      return Collections.unmodifiableList(encodings);
     }
   }
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -59,8 +59,9 @@ public final class AudioCapabilities {
   @SuppressWarnings("InlinedApi")
   private static final AudioCapabilities EXTERNAL_SURROUND_SOUND_CAPABILITIES =
       new AudioCapabilities(
-          new int[] {
-            AudioFormat.ENCODING_PCM_16BIT, AudioFormat.ENCODING_AC3, AudioFormat.ENCODING_E_AC3
+          new int[]{
+              AudioFormat.ENCODING_PCM_16BIT, AudioFormat.ENCODING_AC3, AudioFormat.ENCODING_E_AC3,
+              AudioFormat.ENCODING_DTS, AudioFormat.ENCODING_DTS_HD
           },
           DEFAULT_MAX_CHANNEL_COUNT);
 
@@ -220,7 +221,13 @@ public final class AudioCapabilities {
       channelCount = getMaxSupportedChannelCountForPassthrough(encoding, sampleRate);
     } else {
       channelCount = format.channelCount;
-      if (channelCount > maxChannelCount) {
+      if (format.sampleMimeType == MimeTypes.AUDIO_DTS_X) {
+        if (channelCount > 10) {
+          // To fix wrong reporting from device. ChannelCount is reported as 8 for DTS:X P2
+          // on some devices.
+          return null;
+        }
+      } else if (channelCount > maxChannelCount) {
         return null;
       }
     }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -123,11 +123,12 @@ public final class AudioCapabilities {
               AudioManager.EXTRA_MAX_CHANNEL_COUNT, /* defaultValue= */ DEFAULT_MAX_CHANNEL_COUNT));
     }
 
-    if (supportedEncodings.build().isEmpty()) {
+    ImmutableSet supportedEncodingsSet = supportedEncodings.build();
+    if (supportedEncodingsSet.isEmpty()) {
       return DEFAULT_AUDIO_CAPABILITIES;
     } else {
       return new AudioCapabilities(
-          Ints.toArray(supportedEncodings.build()), /* defaultValue= */ DEFAULT_MAX_CHANNEL_COUNT);
+          Ints.toArray(supportedEncodingsSet), /* defaultValue= */ DEFAULT_MAX_CHANNEL_COUNT);
     }
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -58,9 +58,7 @@ public final class AudioCapabilities {
   /** Encodings supported when the device specifies external surround sound. */
   private static final ImmutableList<Integer> EXTERNAL_SURROUND_SOUND_ENCODINGS =
       ImmutableList.of(
-          AudioFormat.ENCODING_PCM_16BIT,
-          AudioFormat.ENCODING_AC3,
-          AudioFormat.ENCODING_E_AC3);
+          AudioFormat.ENCODING_PCM_16BIT, AudioFormat.ENCODING_AC3, AudioFormat.ENCODING_E_AC3);
 
   /**
    * All surround sound encodings that a device may be capable of playing mapped to a maximum

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -49,7 +49,7 @@ import java.util.Arrays;
 @UnstableApi
 public final class AudioCapabilities {
 
-  private static final int DEFAULT_MAX_CHANNEL_COUNT = 8;
+  private static final int DEFAULT_MAX_CHANNEL_COUNT = 10;
   @VisibleForTesting /* package */ static final int DEFAULT_SAMPLE_RATE_HZ = 48_000;
 
   /** The minimum audio capabilities supported by all devices. */
@@ -224,12 +224,7 @@ public final class AudioCapabilities {
       channelCount = getMaxSupportedChannelCountForPassthrough(encoding, sampleRate);
     } else {
       channelCount = format.channelCount;
-      if (format.sampleMimeType == MimeTypes.AUDIO_DTS_X) {
-        if (channelCount > 10) {
-          // To fix wrong reporting from device. ChannelCount is reported as 8 for DTS:X P2 on some devices
-          return null;
-        }
-      } else if (channelCount > maxChannelCount) {
+      if (channelCount > maxChannelCount) {
         return null;
       }
     }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -115,19 +115,19 @@ public final class AudioCapabilities {
       supportedEncodings.addAll(Ints.asList(Api29.getDirectPlaybackSupportedEncodings()));
     }
 
-    if (intent == null || intent.getIntExtra(AudioManager.EXTRA_AUDIO_PLUG_STATE, 0) == 0) {
-      if (supportedEncodings.build().isEmpty()) {
-        return DEFAULT_AUDIO_CAPABILITIES;
-      } else {
-        return new AudioCapabilities(Ints.toArray(supportedEncodings.build()), /* defaultValue= */
-            DEFAULT_MAX_CHANNEL_COUNT);
-      }
+    if (intent == null || intent.getIntExtra(AudioManager.EXTRA_AUDIO_PLUG_STATE, 0) == 1) {
+      supportedEncodings.addAll(Ints.asList(
+          intent.getIntArrayExtra(AudioManager.EXTRA_ENCODINGS)));
+      return new AudioCapabilities(
+          Ints.toArray(supportedEncodings.build()), /* defaultValue= */ DEFAULT_MAX_CHANNEL_COUNT);
     }
 
-    supportedEncodings.addAll(Ints.asList(
-        intent.getIntArrayExtra(AudioManager.EXTRA_ENCODINGS)));
-    return new AudioCapabilities(
-        Ints.toArray(supportedEncodings.build()), /* defaultValue= */ DEFAULT_MAX_CHANNEL_COUNT);
+    if (supportedEncodings.build().isEmpty()) {
+      return DEFAULT_AUDIO_CAPABILITIES;
+    } else {
+      return new AudioCapabilities(Ints.toArray(supportedEncodings.build()), /* defaultValue= */
+          DEFAULT_MAX_CHANNEL_COUNT);
+    }
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -115,7 +115,7 @@ public final class AudioCapabilities {
       supportedEncodings.addAll(Ints.asList(Api29.getDirectPlaybackSupportedEncodings()));
     }
 
-    if (intent == null || intent.getIntExtra(AudioManager.EXTRA_AUDIO_PLUG_STATE, 0) == 1) {
+    if (intent != null && intent.getIntExtra(AudioManager.EXTRA_AUDIO_PLUG_STATE, 0) == 1) {
       supportedEncodings.addAll(Ints.asList(
           intent.getIntArrayExtra(AudioManager.EXTRA_ENCODINGS)));
       return new AudioCapabilities(

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -57,8 +57,8 @@ public final class AudioCapabilities {
 
   /** Encodings supported when the device specifies external surround sound. */
   private static final int[] EXTERNAL_SURROUND_SOUND_ENCODINGS =
-      new int[]{
-          AudioFormat.ENCODING_PCM_16BIT, AudioFormat.ENCODING_AC3, AudioFormat.ENCODING_E_AC3
+      new int[] {
+        AudioFormat.ENCODING_PCM_16BIT, AudioFormat.ENCODING_AC3, AudioFormat.ENCODING_E_AC3
       };
 
   /**
@@ -116,19 +116,18 @@ public final class AudioCapabilities {
     }
 
     if (intent != null && intent.getIntExtra(AudioManager.EXTRA_AUDIO_PLUG_STATE, 0) == 1) {
-      supportedEncodings.addAll(Ints.asList(
-          intent.getIntArrayExtra(AudioManager.EXTRA_ENCODINGS)));
+      supportedEncodings.addAll(Ints.asList(intent.getIntArrayExtra(AudioManager.EXTRA_ENCODINGS)));
       return new AudioCapabilities(
           Ints.toArray(supportedEncodings.build()),
-          intent.getIntExtra(AudioManager.EXTRA_MAX_CHANNEL_COUNT, /* defaultValue= */
-              DEFAULT_MAX_CHANNEL_COUNT));
+          intent.getIntExtra(
+              AudioManager.EXTRA_MAX_CHANNEL_COUNT, /* defaultValue= */ DEFAULT_MAX_CHANNEL_COUNT));
     }
 
     if (supportedEncodings.build().isEmpty()) {
       return DEFAULT_AUDIO_CAPABILITIES;
     } else {
-      return new AudioCapabilities(Ints.toArray(supportedEncodings.build()), /* defaultValue= */
-          DEFAULT_MAX_CHANNEL_COUNT);
+      return new AudioCapabilities(
+          Ints.toArray(supportedEncodings.build()), /* defaultValue= */ DEFAULT_MAX_CHANNEL_COUNT);
     }
   }
 
@@ -211,8 +210,8 @@ public final class AudioCapabilities {
     if (encoding == C.ENCODING_E_AC3_JOC && !supportsEncoding(C.ENCODING_E_AC3_JOC)) {
       // E-AC3 receivers support E-AC3 JOC streams (but decode only the base layer).
       encoding = C.ENCODING_E_AC3;
-    } else if ((encoding == C.ENCODING_DTS_HD && !supportsEncoding(C.ENCODING_DTS_HD)) ||
-        (encoding == C.ENCODING_DTS_UHD_P2 && !supportsEncoding(C.ENCODING_DTS_UHD_P2))) {
+    } else if ((encoding == C.ENCODING_DTS_HD && !supportsEncoding(C.ENCODING_DTS_HD))
+        || (encoding == C.ENCODING_DTS_UHD_P2 && !supportsEncoding(C.ENCODING_DTS_UHD_P2))) {
       // DTS receivers support DTS-HD streams (but decode only the core layer).
       encoding = C.ENCODING_DTS;
     }
@@ -411,9 +410,7 @@ public final class AudioCapabilities {
       return 0;
     }
 
-    /**
-     * Returns an array list of surround encodings that maybe supported.
-     */
+    /** Returns an array list of surround encodings that maybe supported. */
     @DoNotInline
     private static int[] getAllSurroundEncodingsMaybeSupported() {
       ImmutableList.Builder<Integer> encodings = new ImmutableList.Builder<>();

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -214,8 +214,7 @@ public final class AudioCapabilities {
       return null;
     }
     int channelCount;
-    if (format.channelCount == Format.NO_VALUE || encoding == C.ENCODING_E_AC3_JOC
-        || encoding == C.ENCODING_DTS) {
+    if (format.channelCount == Format.NO_VALUE || encoding == C.ENCODING_E_AC3_JOC) {
       // In HLS chunkless preparation, the format channel count and sample rate may be unset. See
       // https://github.com/google/ExoPlayer/issues/10204 and b/222127949 for more details.
       // For E-AC3 JOC, the format is object based so the format channel count is arbitrary.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -102,7 +102,7 @@ public final class AudioCapabilities {
       return DEFAULT_AUDIO_CAPABILITIES;
     }
 
-    ImmutableSet.Builder supportedEncodings = new ImmutableSet.Builder<>();
+    ImmutableSet.Builder<Integer> supportedEncodings = new ImmutableSet.Builder<>();
     if (deviceMaySetExternalSurroundSoundGlobalSetting()
         && Global.getInt(context.getContentResolver(), EXTERNAL_SURROUND_SOUND_KEY, 0) == 1) {
       supportedEncodings.addAll(Ints.asList(EXTERNAL_SURROUND_SOUND_ENCODINGS));
@@ -123,10 +123,10 @@ public final class AudioCapabilities {
               AudioManager.EXTRA_MAX_CHANNEL_COUNT, /* defaultValue= */ DEFAULT_MAX_CHANNEL_COUNT));
     }
 
-    ImmutableSet supportedEncodingsSet = supportedEncodings.build();
+    ImmutableSet<Integer> supportedEncodingsSet = supportedEncodings.build();
     if (!supportedEncodingsSet.isEmpty()) {
       return new AudioCapabilities(
-          Ints.toArray(supportedEncodingsSet), /* defaultValue= */ DEFAULT_MAX_CHANNEL_COUNT);
+          Ints.toArray(supportedEncodingsSet), /* maxChannelCount= */ DEFAULT_MAX_CHANNEL_COUNT);
     }
     return DEFAULT_AUDIO_CAPABILITIES;
   }
@@ -230,7 +230,7 @@ public final class AudioCapabilities {
       channelCount = format.channelCount;
       // Some DTS:X TVs reports ACTION_HDMI_AUDIO_PLUG.EXTRA_MAX_CHANNEL_COUNT as 8
       // instead of 10. See https://github.com/androidx/media/issues/396
-      if (format.sampleMimeType == MimeTypes.AUDIO_DTS_X) {
+      if (format.sampleMimeType.equals(MimeTypes.AUDIO_DTS_X)) {
         if (channelCount > 10) {
           return null;
         }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -121,6 +121,7 @@ public final class AudioCapabilities {
       if (supportedEncodings.length == 0) {
         return DEFAULT_AUDIO_CAPABILITIES;
       } else {
+        supportedEncodings = Util.nullSafeIntegerArrayDistinct(supportedEncodings);
         return new AudioCapabilities(supportedEncodings, /* defaultValue= */
             DEFAULT_MAX_CHANNEL_COUNT);
       }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -114,10 +114,15 @@ public final class AudioCapabilities {
     // encodings.
     if (Util.SDK_INT >= 29 && (Util.isTv(context) || Util.isAutomotive(context))) {
       supportedEncodings.addAll(Api29.getDirectPlaybackSupportedEncodings());
+      return new AudioCapabilities(
+          Ints.toArray(supportedEncodings.build()), DEFAULT_MAX_CHANNEL_COUNT);
     }
 
     if (intent != null && intent.getIntExtra(AudioManager.EXTRA_AUDIO_PLUG_STATE, 0) == 1) {
-      supportedEncodings.addAll(Ints.asList(intent.getIntArrayExtra(AudioManager.EXTRA_ENCODINGS)));
+      @Nullable int[] encodingsFromExtra = intent.getIntArrayExtra(AudioManager.EXTRA_ENCODINGS);
+      if (encodingsFromExtra != null) {
+        supportedEncodings.addAll(Ints.asList(encodingsFromExtra));
+      }
       return new AudioCapabilities(
           Ints.toArray(supportedEncodings.build()),
           intent.getIntExtra(

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -124,12 +124,11 @@ public final class AudioCapabilities {
     }
 
     ImmutableSet supportedEncodingsSet = supportedEncodings.build();
-    if (supportedEncodingsSet.isEmpty()) {
-      return DEFAULT_AUDIO_CAPABILITIES;
-    } else {
+    if (!supportedEncodingsSet.isEmpty()) {
       return new AudioCapabilities(
           Ints.toArray(supportedEncodingsSet), /* defaultValue= */ DEFAULT_MAX_CHANNEL_COUNT);
     }
+    return DEFAULT_AUDIO_CAPABILITIES;
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -73,7 +73,7 @@ public final class AudioCapabilities {
       new ImmutableMap.Builder<Integer, Integer>()
           .put(C.ENCODING_AC3, 6)
           .put(C.ENCODING_AC4, 6)
-          .put(C.ENCODING_DTS, 6)
+          .put(C.ENCODING_DTS, 10)
           .put(C.ENCODING_E_AC3_JOC, 6)
           .put(C.ENCODING_E_AC3, 8)
           .put(C.ENCODING_DTS_HD, 8)
@@ -212,7 +212,8 @@ public final class AudioCapabilities {
       return null;
     }
     int channelCount;
-    if (format.channelCount == Format.NO_VALUE || encoding == C.ENCODING_E_AC3_JOC) {
+    if (format.channelCount == Format.NO_VALUE || encoding == C.ENCODING_E_AC3_JOC
+        || encoding == C.ENCODING_DTS) {
       // In HLS chunkless preparation, the format channel count and sample rate may be unset. See
       // https://github.com/google/ExoPlayer/issues/10204 and b/222127949 for more details.
       // For E-AC3 JOC, the format is object based so the format channel count is arbitrary.
@@ -221,13 +222,7 @@ public final class AudioCapabilities {
       channelCount = getMaxSupportedChannelCountForPassthrough(encoding, sampleRate);
     } else {
       channelCount = format.channelCount;
-      if (format.sampleMimeType == MimeTypes.AUDIO_DTS_X) {
-        if (channelCount > 10) {
-          // To fix wrong reporting from device. ChannelCount is reported as 8 for DTS:X P2
-          // on some devices.
-          return null;
-        }
-      } else if (channelCount > maxChannelCount) {
+      if (channelCount > maxChannelCount) {
         return null;
       }
     }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -56,10 +56,11 @@ public final class AudioCapabilities {
       new AudioCapabilities(new int[] {AudioFormat.ENCODING_PCM_16BIT}, DEFAULT_MAX_CHANNEL_COUNT);
 
   /** Encodings supported when the device specifies external surround sound. */
-  private static final int[] EXTERNAL_SURROUND_SOUND_ENCODINGS =
-      new int[] {
-        AudioFormat.ENCODING_PCM_16BIT, AudioFormat.ENCODING_AC3, AudioFormat.ENCODING_E_AC3
-      };
+  private static final ImmutableList<Integer> EXTERNAL_SURROUND_SOUND_ENCODINGS =
+      ImmutableList.of(
+          AudioFormat.ENCODING_PCM_16BIT,
+          AudioFormat.ENCODING_AC3,
+          AudioFormat.ENCODING_E_AC3);
 
   /**
    * All surround sound encodings that a device may be capable of playing mapped to a maximum
@@ -105,14 +106,14 @@ public final class AudioCapabilities {
     ImmutableSet.Builder<Integer> supportedEncodings = new ImmutableSet.Builder<>();
     if (deviceMaySetExternalSurroundSoundGlobalSetting()
         && Global.getInt(context.getContentResolver(), EXTERNAL_SURROUND_SOUND_KEY, 0) == 1) {
-      supportedEncodings.addAll(Ints.asList(EXTERNAL_SURROUND_SOUND_ENCODINGS));
+      supportedEncodings.addAll(EXTERNAL_SURROUND_SOUND_ENCODINGS);
     }
     // AudioTrack.isDirectPlaybackSupported returns true for encodings that are supported for audio
     // offload, as well as for encodings we want to list for passthrough mode. Therefore we only use
     // it on TV and automotive devices, which generally shouldn't support audio offload for surround
     // encodings.
     if (Util.SDK_INT >= 29 && (Util.isTv(context) || Util.isAutomotive(context))) {
-      supportedEncodings.addAll(Ints.asList(Api29.getDirectPlaybackSupportedEncodings()));
+      supportedEncodings.addAll(Api29.getDirectPlaybackSupportedEncodings());
     }
 
     if (intent != null && intent.getIntExtra(AudioManager.EXTRA_AUDIO_PLUG_STATE, 0) == 1) {
@@ -369,8 +370,8 @@ public final class AudioCapabilities {
     private Api29() {}
 
     @DoNotInline
-    public static int[] getDirectPlaybackSupportedEncodings() {
-      int[] encodings = Api29.getAllSurroundEncodingsMaybeSupported();
+    public static ImmutableList<Integer> getDirectPlaybackSupportedEncodings() {
+      ImmutableList<Integer> encodings = Api29.getAllSurroundEncodingsMaybeSupported();
       ImmutableList.Builder<Integer> supportedEncodingsListBuilder = ImmutableList.builder();
       for (int encoding : encodings) {
         if (AudioTrack.isDirectPlaybackSupported(
@@ -384,7 +385,7 @@ public final class AudioCapabilities {
         }
       }
       supportedEncodingsListBuilder.add(AudioFormat.ENCODING_PCM_16BIT);
-      return Ints.toArray(supportedEncodingsListBuilder.build());
+      return supportedEncodingsListBuilder.build();
     }
 
     /**
@@ -410,9 +411,9 @@ public final class AudioCapabilities {
       return 0;
     }
 
-    /** Returns an array list of surround encodings that maybe supported. */
+    /** Returns a list of surround encodings that maybe supported. */
     @DoNotInline
-    private static int[] getAllSurroundEncodingsMaybeSupported() {
+    private static ImmutableList<Integer> getAllSurroundEncodingsMaybeSupported() {
       ImmutableList.Builder<Integer> encodings = new ImmutableList.Builder<>();
       for (int encoding : ALL_SURROUND_ENCODINGS_AND_MAX_CHANNELS.keySet()) {
         // AudioFormat.ENCODING_DTS_UHD_P2 is supported from API 34.
@@ -421,7 +422,7 @@ public final class AudioCapabilities {
         }
         encodings.add(encoding);
       }
-      return Ints.toArray(encodings.build());
+      return encodings.build();
     }
   }
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -229,8 +229,8 @@ public final class AudioCapabilities {
       channelCount = getMaxSupportedChannelCountForPassthrough(encoding, sampleRate);
     } else {
       channelCount = format.channelCount;
-      // To file a Bug: Some DTS:X TVs reports ACTION_HDMI_AUDIO_PLUG.EXTRA_MAX_CHANNEL_COUNT as 8
-      // instead of 10.
+      // Some DTS:X TVs reports ACTION_HDMI_AUDIO_PLUG.EXTRA_MAX_CHANNEL_COUNT as 8
+      // instead of 10. See https://github.com/androidx/media/issues/396
       if (format.sampleMimeType == MimeTypes.AUDIO_DTS_X) {
         if (channelCount > 10) {
           return null;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -112,9 +112,8 @@ public final class AudioCapabilities {
     // it on TV and automotive devices, which generally shouldn't support audio offload for surround
     // encodings.
     if (Util.SDK_INT >= 29 && (Util.isTv(context) || Util.isAutomotive(context))) {
-      supportedEncodings = Util.nullSafeIntegerArrayConcatenation(supportedEncodings,
-          Api29.getDirectPlaybackSupportedEncodings(
-              Util.nullSafeIntegerListToArray(Api29.getAllSurroundEncodingsMaybeSupported())));
+      supportedEncodings = Ints.concat(supportedEncodings,
+          Api29.getDirectPlaybackSupportedEncodings(Api29.getAllSurroundEncodingsMaybeSupported()));
     }
 
     if (intent == null || intent.getIntExtra(AudioManager.EXTRA_AUDIO_PLUG_STATE, 0) == 0) {
@@ -127,7 +126,7 @@ public final class AudioCapabilities {
       }
     }
 
-    supportedEncodings = Util.nullSafeIntegerArrayConcatenation(supportedEncodings,
+    supportedEncodings = Ints.concat(supportedEncodings,
         intent.getIntArrayExtra(AudioManager.EXTRA_ENCODINGS));
     supportedEncodings = Util.nullSafeIntegerArrayDistinct(supportedEncodings);
     return new AudioCapabilities(
@@ -409,7 +408,7 @@ public final class AudioCapabilities {
     /**
      * Returns an array list of surround encodings that maybe supported.
      */
-    private static ImmutableList<Integer> getAllSurroundEncodingsMaybeSupported() {
+    private static int[] getAllSurroundEncodingsMaybeSupported() {
       ImmutableList.Builder<Integer> encodings = new ImmutableList.Builder<>();
       for (int encoding : ALL_SURROUND_ENCODINGS_AND_MAX_CHANNELS.keySet()) {
         // AudioFormat.ENCODING_DTS_UHD_P2 is supported from API 34.
@@ -418,7 +417,7 @@ public final class AudioCapabilities {
         }
         encodings.add(encoding);
       }
-      return encodings.build();
+      return Ints.toArray(encodings.build());
     }
   }
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -42,10 +42,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 /** Represents the set of audio formats that a device is capable of playing. */
 @UnstableApi
@@ -59,7 +56,7 @@ public final class AudioCapabilities {
       new AudioCapabilities(new int[] {AudioFormat.ENCODING_PCM_16BIT}, DEFAULT_MAX_CHANNEL_COUNT);
 
   /** Encodings supported when the device specifies external surround sound. */
-  private static final int[] EXTERNAL_SURROUND_SOUND_CAPABILITIES =
+  private static final int[] EXTERNAL_SURROUND_SOUND_ENCODINGS =
       new int[]{
           AudioFormat.ENCODING_PCM_16BIT, AudioFormat.ENCODING_AC3, AudioFormat.ENCODING_E_AC3
       };
@@ -98,13 +95,13 @@ public final class AudioCapabilities {
   }
 
   private static AudioCapabilities getExternalSurroundCapabilities(@Nullable Intent intent) {
-    int[] supportedEncodings = EXTERNAL_SURROUND_SOUND_CAPABILITIES;
+    int[] supportedEncodings = EXTERNAL_SURROUND_SOUND_ENCODINGS;
 
     if (Util.SDK_INT >= 29) {
       // Check if DTS Encodings are supported via Direct Playback.
-      int[] dtsTypes = {AudioFormat.ENCODING_DTS, AudioFormat.ENCODING_DTS_HD};
+      int[] dtsEncodings = {AudioFormat.ENCODING_DTS, AudioFormat.ENCODING_DTS_HD};
       supportedEncodings = Util.nullSafeIntegerArrayConcatenation(supportedEncodings,
-          Api29.getDirectPlaybackSupportedEncodings(dtsTypes));
+          Api29.getDirectPlaybackSupportedEncodings(dtsEncodings));
     }
     supportedEncodings = Arrays.stream(supportedEncodings).distinct().toArray();
     return new AudioCapabilities(supportedEncodings,/* defaultValue= */ DEFAULT_MAX_CHANNEL_COUNT);
@@ -415,8 +412,8 @@ public final class AudioCapabilities {
     /**
      * Returns an array list of surround encodings that maybe supported.
      */
-    private static List<Integer> getAllSurroundEncodingsMaybeSupported() {
-      ArrayList<Integer> encodings = new ArrayList<>();
+    private static ImmutableList<Integer> getAllSurroundEncodingsMaybeSupported() {
+      ImmutableList.Builder<Integer> encodings = new ImmutableList.Builder<>();
       for (int encoding : ALL_SURROUND_ENCODINGS_AND_MAX_CHANNELS.keySet()) {
         // AudioFormat.ENCODING_DTS_UHD_P2 is supported from API 34.
         if (Util.SDK_INT < 34 && encoding == C.ENCODING_DTS_UHD_P2) {
@@ -424,7 +421,7 @@ public final class AudioCapabilities {
         }
         encodings.add(encoding);
       }
-      return Collections.unmodifiableList(encodings);
+      return encodings.build();
     }
   }
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -42,6 +42,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
+import java.util.ArrayList;
 import java.util.Arrays;
 
 /** Represents the set of audio formats that a device is capable of playing. */
@@ -365,11 +366,7 @@ public final class AudioCapabilities {
     @DoNotInline
     public static int[] getDirectPlaybackSupportedEncodings() {
       ImmutableList.Builder<Integer> supportedEncodingsListBuilder = ImmutableList.builder();
-      for (int encoding : ALL_SURROUND_ENCODINGS_AND_MAX_CHANNELS.keySet()) {
-        // Skip ENCODING_DTS_UHD_P2 if API < 34. Otherwise setEncoding will crash.
-        if ((Util.SDK_INT < 34) && (encoding == C.ENCODING_DTS_UHD_P2)) {
-          continue;
-        }
+      for (int encoding : getAllSurroundEncodingsMaybeSupported()) {
         if (AudioTrack.isDirectPlaybackSupported(
             new AudioFormat.Builder()
                 .setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
@@ -405,6 +402,21 @@ public final class AudioCapabilities {
         }
       }
       return 0;
+    }
+
+    /**
+     * Returns an array list of surround encodings that maybe supported.
+     */
+    private static ArrayList<Integer> getAllSurroundEncodingsMaybeSupported() {
+      ArrayList<Integer> encodings = new ArrayList<>();
+      for (int encoding : ALL_SURROUND_ENCODINGS_AND_MAX_CHANNELS.keySet()) {
+        // AudioFormat.ENCODING_DTS_UHD_P2 is supported from API 34.
+        if (Util.SDK_INT < 34 && encoding == C.ENCODING_DTS_UHD_P2) {
+          continue;
+        }
+        encodings.add(encoding);
+      }
+      return encodings;
     }
   }
 }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
@@ -41,6 +41,9 @@ public final class DtsUtil {
   private static final int SYNC_VALUE_14B_BE = 0x1FFFE800;
   private static final int SYNC_VALUE_LE = 0xFE7F0180;
   private static final int SYNC_VALUE_14B_LE = 0xFF1F00E8;
+  private static final int SYNC_EXT_SUB_LE = 0x25205864;
+  private static final int SYNC_FTOC_LE = 0xF21B4140;
+  private static final int SYNC_FTOC_NON_SYNC_LE = 0xE842C471;
   private static final byte FIRST_BYTE_BE = (byte) (SYNC_VALUE_BE >>> 24);
   private static final byte FIRST_BYTE_14B_BE = (byte) (SYNC_VALUE_14B_BE >>> 24);
   private static final byte FIRST_BYTE_LE = (byte) (SYNC_VALUE_LE >>> 24);
@@ -149,6 +152,19 @@ public final class DtsUtil {
    * @return The number of audio samples represented by the syncframe.
    */
   public static int parseDtsAudioSampleCount(ByteBuffer buffer) {
+
+    // Check for sync or non sync word for DTS:X Profile 2.
+    // DTS:X Profile 2's FrameSize = 1024.
+    if ((buffer.getInt(0) == SYNC_FTOC_LE) ||
+        (buffer.getInt(0) == SYNC_FTOC_NON_SYNC_LE)) {
+      return 1024;
+    }
+    // Check for sync word for DTS Express.
+    // DTS Express's FrameSize = 4096.
+    else if (buffer.getInt(0) == SYNC_EXT_SUB_LE) {
+      return 4096;
+    }
+
     // See ETSI TS 102 114 subsection 5.4.1.
     int position = buffer.position();
     int nblks;

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
@@ -41,7 +41,15 @@ public final class DtsUtil {
   private static final int SYNC_VALUE_14B_BE = 0x1FFFE800;
   private static final int SYNC_VALUE_LE = 0xFE7F0180;
   private static final int SYNC_VALUE_14B_LE = 0xFF1F00E8;
+  /**
+   * DTS Extension Substream Syncword (in different Endianness) is defined in Section 7.4.1 of:
+   * https://www.etsi.org/deliver/etsi_ts/102100_102199/102114/01.06.01_60/ts_102114v010601p.pdf
+   */
   private static final int SYNC_EXT_SUB_LE = 0x25205864;
+  /**
+   * The two DTS FTOC Sync words below (in different Endianness) is defined in Section 6.4.4.1 of
+   * https://www.etsi.org/deliver/etsi_ts/103400_103499/103491/01.02.01_60/ts_103491v010201p.pdf
+   */
   private static final int SYNC_FTOC_LE = 0xF21B4140;
   private static final int SYNC_FTOC_NON_SYNC_LE = 0xE842C471;
   private static final byte FIRST_BYTE_BE = (byte) (SYNC_VALUE_BE >>> 24);
@@ -153,14 +161,15 @@ public final class DtsUtil {
    */
   public static int parseDtsAudioSampleCount(ByteBuffer buffer) {
 
-    // Check for sync or non sync word for DTS:X Profile 2.
-    // DTS:X Profile 2's FrameSize = 1024.
+    // Check for DTS:X Profile 2 sync or non sync word and return
+    // 1024 if found. This is the only audio sample count that is used by DTS:X Streaming Encoder.
     if ((buffer.getInt(0) == SYNC_FTOC_LE) ||
         (buffer.getInt(0) == SYNC_FTOC_NON_SYNC_LE)) {
       return 1024;
     }
-    // Check for sync word for DTS Express.
-    // DTS Express's FrameSize = 4096.
+
+    // Check for DTS Express sync word and return 4096 if found. This is the only audio
+    // sample count that is used by DTS Streaming Encoder.
     else if (buffer.getInt(0) == SYNC_EXT_SUB_LE) {
       return 4096;
     }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
@@ -161,12 +161,12 @@ public final class DtsUtil {
    */
   public static int parseDtsAudioSampleCount(ByteBuffer buffer) {
     if ((buffer.getInt(0) == SYNC_FTOC_LE) || (buffer.getInt(0) == SYNC_FTOC_NON_SYNC_LE)) {
-      // Check for DTS:X Profile 2 sync or non sync word and return
-      // 1024 if found. This is the only audio sample count that is used by DTS:X Streaming Encoder.
+      // Check for DTS:X Profile 2 sync or non sync word and return 1024 if found. This is the only
+      // audio sample count that is used by DTS:X Streaming Encoder.
       return 1024;
     } else if (buffer.getInt(0) == SYNC_EXT_SUB_LE) {
-      // Check for DTS Express sync word and return 4096 if found. This is the only audio
-      // sample count that is used by DTS Streaming Encoder.
+      // Check for DTS Express sync word and return 4096 if found. This is the only audio sample
+      // count that is used by DTS Streaming Encoder.
       return 4096;
     }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
@@ -47,10 +47,10 @@ public final class DtsUtil {
    */
   private static final int SYNC_EXT_SUB_LE = 0x25205864;
   /**
-   * DTS FTOC Sync words (in different Endianness). See ETSI TS 103 491 (V1.2.1)
-   * Section 6.4.4.1.
+   * DTS FTOC Sync words (in different Endianness). See ETSI TS 103 491 (V1.2.1) Section 6.4.4.1.
    */
   private static final int SYNC_FTOC_LE = 0xF21B4140;
+
   private static final int SYNC_FTOC_NON_SYNC_LE = 0xE842C471;
   private static final byte FIRST_BYTE_BE = (byte) (SYNC_VALUE_BE >>> 24);
   private static final byte FIRST_BYTE_14B_BE = (byte) (SYNC_VALUE_14B_BE >>> 24);
@@ -163,8 +163,7 @@ public final class DtsUtil {
 
     // Check for DTS:X Profile 2 sync or non sync word and return
     // 1024 if found. This is the only audio sample count that is used by DTS:X Streaming Encoder.
-    if ((buffer.getInt(0) == SYNC_FTOC_LE) ||
-        (buffer.getInt(0) == SYNC_FTOC_NON_SYNC_LE)) {
+    if ((buffer.getInt(0) == SYNC_FTOC_LE) || (buffer.getInt(0) == SYNC_FTOC_NON_SYNC_LE)) {
       return 1024;
     }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
@@ -160,16 +160,13 @@ public final class DtsUtil {
    * @return The number of audio samples represented by the syncframe.
    */
   public static int parseDtsAudioSampleCount(ByteBuffer buffer) {
-
-    // Check for DTS:X Profile 2 sync or non sync word and return
-    // 1024 if found. This is the only audio sample count that is used by DTS:X Streaming Encoder.
     if ((buffer.getInt(0) == SYNC_FTOC_LE) || (buffer.getInt(0) == SYNC_FTOC_NON_SYNC_LE)) {
+      // Check for DTS:X Profile 2 sync or non sync word and return
+      // 1024 if found. This is the only audio sample count that is used by DTS:X Streaming Encoder.
       return 1024;
-    }
-
-    // Check for DTS Express sync word and return 4096 if found. This is the only audio
-    // sample count that is used by DTS Streaming Encoder.
-    else if (buffer.getInt(0) == SYNC_EXT_SUB_LE) {
+    } else if (buffer.getInt(0) == SYNC_EXT_SUB_LE) {
+      // Check for DTS Express sync word and return 4096 if found. This is the only audio
+      // sample count that is used by DTS Streaming Encoder.
       return 4096;
     }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
@@ -42,13 +42,13 @@ public final class DtsUtil {
   private static final int SYNC_VALUE_LE = 0xFE7F0180;
   private static final int SYNC_VALUE_14B_LE = 0xFF1F00E8;
   /**
-   * DTS Extension Substream Syncword (in different Endianness) is defined in Section 7.4.1 of:
-   * https://www.etsi.org/deliver/etsi_ts/102100_102199/102114/01.06.01_60/ts_102114v010601p.pdf
+   * DTS Extension Substream Syncword (in different Endianness). See ETSI TS 102 114 (V1.6.1)
+   * Section 7.4.1.
    */
   private static final int SYNC_EXT_SUB_LE = 0x25205864;
   /**
-   * The two DTS FTOC Sync words below (in different Endianness) is defined in Section 6.4.4.1 of
-   * https://www.etsi.org/deliver/etsi_ts/103400_103499/103491/01.02.01_60/ts_103491v010201p.pdf
+   * DTS FTOC Sync words (in different Endianness). See ETSI TS 103 491 (V1.2.1)
+   * Section 6.4.4.1.
    */
   private static final int SYNC_FTOC_LE = 0xF21B4140;
   private static final int SYNC_FTOC_NON_SYNC_LE = 0xE842C471;


### PR DESCRIPTION
This adds DTS Audio Support for Direct Passthrough playback. This is required for Tunnel mode playback on Android TVs that supports tunnel mode playback (e.g. MTK and Realtek based TVs). Test streams will be provided during the review if required.
Thanks.