### PR TITLE
extract mp3 bitrate from synchronized header

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/Mp3Extractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/Mp3Extractor.java
@@ -278,6 +278,8 @@ public final class Mp3Extractor implements Extractor {
               .setEncoderDelay(gaplessInfoHolder.encoderDelay)
               .setEncoderPadding(gaplessInfoHolder.encoderPadding)
               .setMetadata((flags & FLAG_DISABLE_ID3_METADATA) != 0 ? null : metadata)
+              .setPeakBitrate(synchronizedHeader.bitrate)
+              .setAverageBitrate(synchronizedHeader.bitrate)
               .build());
       firstSamplePosition = input.getPosition();
     } else if (firstSamplePosition != 0) {


### PR DESCRIPTION
This helps determining bitrate of the first frame synchronized.