### PR TITLE
Catch errors and OOM when decoding ID3 frames.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -97,6 +97,9 @@
     *   Fix bug where `MediaMetadata` was only populated from Vorbis comments
         with upper-case keys
         ([#876](https://github.com/androidx/media/issues/876)).
+    *   Catch `OutOfMemoryError` when parsing very large ID3 frames, meaning
+        playback can continue without the tag info instead of playback failing
+        completely.
 *   DRM:
     *   Extend workaround for spurious ClearKey `https://default.url` license
         URL to API 33+ (previously the workaround only applied on API 33

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/Id3Decoder.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/Id3Decoder.java
@@ -372,8 +372,9 @@ public final class Id3Decoder extends SimpleMetadataDecoder {
       frameSize = removeUnsynchronization(id3Data, frameSize);
     }
 
+    String error = "";
+    Id3Frame frame = null;
     try {
-      Id3Frame frame;
       if (frameId0 == 'T'
           && frameId1 == 'X'
           && frameId2 == 'X'
@@ -430,18 +431,24 @@ public final class Id3Decoder extends SimpleMetadataDecoder {
         String id = getFrameId(majorVersion, frameId0, frameId1, frameId2, frameId3);
         frame = decodeBinaryFrame(id3Data, frameSize, id);
       }
-      if (frame == null) {
-        Log.w(
-            TAG,
-            "Failed to decode frame: id="
-                + getFrameId(majorVersion, frameId0, frameId1, frameId2, frameId3)
-                + ", frameSize="
-                + frameSize);
-      }
-      return frame;
-    } finally {
+    } catch (Exception e) {
+      error = ",error=" + e.getMessage();
+    } catch (OutOfMemoryError e) {
+      error = ",error=" + e.getMessage();
+    }
+    finally {
       id3Data.setPosition(nextFramePosition);
     }
+    if (frame == null) {
+      Log.w(
+          TAG,
+          "Failed to decode frame: id="
+              + getFrameId(majorVersion, frameId0, frameId1, frameId2, frameId3)
+              + ", frameSize="
+              + frameSize
+              + error);
+    }
+    return frame;
   }
 
   @Nullable

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/Id3Decoder.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/Id3Decoder.java
@@ -435,8 +435,7 @@ public final class Id3Decoder extends SimpleMetadataDecoder {
       error = ",error=" + e.getMessage();
     } catch (OutOfMemoryError e) {
       error = ",error=" + e.getMessage();
-    }
-    finally {
+    } finally {
       id3Data.setPosition(nextFramePosition);
     }
     if (frame == null) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/Id3Decoder.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/Id3Decoder.java
@@ -372,8 +372,8 @@ public final class Id3Decoder extends SimpleMetadataDecoder {
       frameSize = removeUnsynchronization(id3Data, frameSize);
     }
 
-    String error = "";
     Id3Frame frame = null;
+    Throwable error = null;
     try {
       if (frameId0 == 'T'
           && frameId1 == 'X'
@@ -431,10 +431,8 @@ public final class Id3Decoder extends SimpleMetadataDecoder {
         String id = getFrameId(majorVersion, frameId0, frameId1, frameId2, frameId3);
         frame = decodeBinaryFrame(id3Data, frameSize, id);
       }
-    } catch (Exception e) {
-      error = ",error=" + e.getMessage();
-    } catch (OutOfMemoryError e) {
-      error = ",error=" + e.getMessage();
+    } catch (OutOfMemoryError | Exception e) {
+      error = e;
     } finally {
       id3Data.setPosition(nextFramePosition);
     }
@@ -444,8 +442,8 @@ public final class Id3Decoder extends SimpleMetadataDecoder {
           "Failed to decode frame: id="
               + getFrameId(majorVersion, frameId0, frameId1, frameId2, frameId3)
               + ", frameSize="
-              + frameSize
-              + error);
+              + frameSize,
+          error);
     }
     return frame;
   }


### PR DESCRIPTION
Invalid frames have no impact on ExoPlayer ability to play the media and should not fail on errors. 

Some tools can add 100Mb images in the tags that will trigger recoverable OOM with this fix, previously the load would fail and the OOM caught too late.