### PR TITLE
Fix initial network type

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/NetworkTypeObserver.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/NetworkTypeObserver.java
@@ -91,7 +91,7 @@ public final class NetworkTypeObserver {
     mainHandler = new Handler(Looper.getMainLooper());
     listeners = new CopyOnWriteArrayList<>();
     networkTypeLock = new Object();
-    networkType = C.NETWORK_TYPE_UNKNOWN;
+    networkType = getNetworkTypeFromConnectivityManager(context);
     IntentFilter filter = new IntentFilter();
     filter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
     context.registerReceiver(new Receiver(), filter);

--- a/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/DefaultDashChunkSourceTest.java
+++ b/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/DefaultDashChunkSourceTest.java
@@ -249,9 +249,9 @@ public class DefaultDashChunkSourceTest {
     }
     assertThat(Lists.transform(chunks, (chunk) -> chunk.dataSpec.uri.toString()))
         .containsExactly(
-            "http://video.com/baseUrl/a/video/video_0_700000.m4s",
             "http://video.com/baseUrl/a/video/video_0_452000.m4s",
             "http://video.com/baseUrl/a/video/video_0_250000.m4s",
+            "http://video.com/baseUrl/a/video/video_0_700000.m4s",
             "http://video.com/baseUrl/a/video/video_0_1300000.m4s")
         .inOrder();
   }


### PR DESCRIPTION
**Issue:**
[NetworkTypeObserver](https://github.com/androidx/media/blob/9baa6f6be54716271505fa159854afb457977e3c/libraries/common/src/main/java/androidx/media3/common/util/NetworkTypeObserver.java#L94) initialises the default network type as `C.NETWORK_TYPE_UNKNOWN` and then registers for connectivity change callback. This works fine if we receive a connectivity change update quickly.

But, sometimes this callback takes time and so [DefaultBandwidthMeter](https://github.com/androidx/media/blob/9baa6f6be54716271505fa159854afb457977e3c/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/DefaultBandwidthMeter.java#LL327C8-L327C8) assumes network type as unknown and initialises the initial bitrateEstimate as 1Mbps ([DEFAULT_INITIAL_BITRATE_ESTIMATE](https://github.com/androidx/media/blob/9baa6f6be54716271505fa159854afb457977e3c/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/DefaultBandwidthMeter.java#LL77C28-L77C60)). This initial bitrate estimate is used to select the initial track in playback and so it is vital to get the correct initial bitrate estimate based on the network type. Otherwise even when using a high-speed Wifi connection, initial bitrate estimate will be 1Mbps and forces the player to select a representation with initial bitrate as 1 Mbps (1Mbps X BANDWIDTH_FRACTION).

Eg from Pixel2: 
```
15:33:36.221 12556-12556 DefaultBandwidthMeter          D  InitialBitrateEstimate: 1000000
15:33:36.348 12556-12556 NetworkTypeObserver            D  Network type changed from 0 to 2
```
Note that there was a 127ms interval between the time when the `NetworkTypeObserver` was queried by `DefaultBandwidthMeter` and the time when the `NetworkTypeObserver` was able to update itself based on the connectivity change update.

Related [discussion](https://github.com/google/ExoPlayer/issues/9307#issuecomment-900423196) explains that it was done this way to differentiate between 4G and 5G NSA. But it affects more playbacks as we get network type as unknown even for wifi or ethernet connections. 

**Solution:**
Use `ConnectivityManager#ActiveNetworkInfo` to pick an optimal initial network type and then let connectivity-change-update callbacks to alter the network type.