### PR TITLE
Fix missing last frame of MPEG-TS content

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -34,6 +34,9 @@
     *   Parse EXIF rotation data for image inputs.
 *   Track Selection:
 *   Extractors:
+    *   MPEG-TS: Ensure the last frame is rendered by passing the last access
+        unit of a stream to the sample queue
+        ([#7909](https://github.com/google/ExoPlayer/issues/7909)).
 *   Audio:
 *   Audio Offload:
     *   Add `AudioSink.getFormatOffloadSupport(Format)` that retrieves level of

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/Ac3Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/Ac3Reader.java
@@ -157,7 +157,7 @@ public final class Ac3Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
+  public void packetFinished(boolean isEndOfInput) {
     // Do nothing.
   }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/Ac4Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/Ac4Reader.java
@@ -159,7 +159,7 @@ public final class Ac4Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
+  public void packetFinished(boolean isEndOfInput) {
     // Do nothing.
   }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/AdtsReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/AdtsReader.java
@@ -192,7 +192,7 @@ public final class AdtsReader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
+  public void packetFinished(boolean isEndOfInput) {
     // Do nothing.
   }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/DtsReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/DtsReader.java
@@ -131,7 +131,7 @@ public final class DtsReader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
+  public void packetFinished(boolean isEndOfInput) {
     // Do nothing.
   }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/DvbSubtitleReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/DvbSubtitleReader.java
@@ -87,7 +87,7 @@ public final class DvbSubtitleReader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
+  public void packetFinished(boolean isEndOfInput) {
     if (writingSample) {
       if (sampleTimeUs != C.TIME_UNSET) {
         for (TrackOutput output : outputs) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/ElementaryStreamReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/ElementaryStreamReader.java
@@ -54,5 +54,5 @@ public interface ElementaryStreamReader {
   void consume(ParsableByteArray data) throws ParserException;
 
   /** Called when a packet ends. */
-  void packetFinished();
+  void packetFinished(boolean isEndOfInput);
 }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H262Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H262Reader.java
@@ -218,7 +218,11 @@ public final class H262Reader implements ElementaryStreamReader {
 
   @Override
   public void packetFinished(boolean isEndOfInput) {
-    // Do nothing.
+    if (isEndOfInput) {
+      @C.BufferFlags int flags = sampleIsKeyframe ? C.BUFFER_FLAG_KEY_FRAME : 0;
+      int size = (int) (totalBytesWritten - samplePosition);
+      output.sampleMetadata(sampleTimeUs, flags, size, 0, null);
+    }
   }
 
   /**

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H262Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H262Reader.java
@@ -217,7 +217,7 @@ public final class H262Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
+  public void packetFinished(boolean isEndOfInput) {
     // Do nothing.
   }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H262Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H262Reader.java
@@ -218,10 +218,11 @@ public final class H262Reader implements ElementaryStreamReader {
 
   @Override
   public void packetFinished(boolean isEndOfInput) {
+    checkStateNotNull(output); // Asserts that createTracks has been called.
     if (isEndOfInput) {
       @C.BufferFlags int flags = sampleIsKeyframe ? C.BUFFER_FLAG_KEY_FRAME : 0;
       int size = (int) (totalBytesWritten - samplePosition);
-      output.sampleMetadata(sampleTimeUs, flags, size, 0, null);
+      output.sampleMetadata(sampleTimeUs, flags, size, /* offset= */ 0, /* cryptoData= */ null);
     }
   }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H263Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H263Reader.java
@@ -218,8 +218,10 @@ public final class H263Reader implements ElementaryStreamReader {
 
   @Override
   public void packetFinished(boolean isEndOfInput) {
+    // Assert that createTracks has been called.
+    checkStateNotNull(sampleReader);
     if (isEndOfInput) {
-      sampleReader.onDataEnd(totalBytesWritten, 0, hasOutputFormat);
+      sampleReader.onDataEnd(totalBytesWritten, /* bytesWrittenPastPosition= */ 0, hasOutputFormat);
       sampleReader.reset();
     }
   }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H263Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H263Reader.java
@@ -220,6 +220,7 @@ public final class H263Reader implements ElementaryStreamReader {
   public void packetFinished(boolean isEndOfInput) {
     if (isEndOfInput) {
       sampleReader.onDataEnd(totalBytesWritten, 0, hasOutputFormat);
+      sampleReader.reset();
     }
   }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H263Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H263Reader.java
@@ -217,7 +217,7 @@ public final class H263Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
+  public void packetFinished(boolean isEndOfInput) {
     // Do nothing.
   }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H263Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H263Reader.java
@@ -218,7 +218,9 @@ public final class H263Reader implements ElementaryStreamReader {
 
   @Override
   public void packetFinished(boolean isEndOfInput) {
-    // Do nothing.
+    if (isEndOfInput) {
+      sampleReader.onDataEnd(totalBytesWritten, 0, hasOutputFormat);
+    }
   }
 
   /**

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
@@ -168,8 +168,10 @@ public final class H264Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
-    // Do nothing.
+  public void packetFinished(boolean isEndOfInput) {
+    if (isEndOfInput) {
+      sampleReader.end(totalBytesWritten);
+    }
   }
 
   @RequiresNonNull("sampleReader")
@@ -498,6 +500,12 @@ public final class H264Reader implements ElementaryStreamReader {
       @C.BufferFlags int flags = sampleIsKeyframe ? C.BUFFER_FLAG_KEY_FRAME : 0;
       int size = (int) (nalUnitStartPosition - samplePosition);
       output.sampleMetadata(sampleTimeUs, flags, size, offset, null);
+    }
+
+    public void end(long position) {
+      // Output a final sample with the nal units currently held
+      nalUnitStartPosition = position;
+      outputSample(0);
     }
 
     private static final class SliceHeaderData {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
@@ -506,6 +506,7 @@ public final class H264Reader implements ElementaryStreamReader {
       // Output a final sample with the nal units currently held
       nalUnitStartPosition = position;
       outputSample(0);
+      readingSample = false;
     }
 
     private static final class SliceHeaderData {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
@@ -169,6 +169,7 @@ public final class H264Reader implements ElementaryStreamReader {
 
   @Override
   public void packetFinished(boolean isEndOfInput) {
+    assertTracksCreated();
     if (isEndOfInput) {
       sampleReader.end(totalBytesWritten);
     }
@@ -503,9 +504,9 @@ public final class H264Reader implements ElementaryStreamReader {
     }
 
     public void end(long position) {
-      // Output a final sample with the nal units currently held
+      // Output a final sample with the NAL units currently held
       nalUnitStartPosition = position;
-      outputSample(0);
+      outputSample(/* offset= */ 0);
       readingSample = false;
     }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
@@ -382,6 +382,7 @@ public final class H265Reader implements ElementaryStreamReader {
       // Output a final sample with the nal units currently held
       nalUnitPosition = position;
       outputSample(0);
+      readingSample = false;
     }
 
     /** Returns whether a NAL unit type is one that occurs before any VCL NAL units in a sample. */

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
@@ -173,8 +173,10 @@ public final class H265Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
-    // Do nothing.
+  public void packetFinished(boolean isEndOfInput) {
+    if (isEndOfInput) {
+      sampleReader.end(totalBytesWritten);
+    }
   }
 
   @RequiresNonNull("sampleReader")
@@ -374,6 +376,12 @@ public final class H265Reader implements ElementaryStreamReader {
       @C.BufferFlags int flags = sampleIsKeyframe ? C.BUFFER_FLAG_KEY_FRAME : 0;
       int size = (int) (nalUnitPosition - samplePosition);
       output.sampleMetadata(sampleTimeUs, flags, size, offset, null);
+    }
+
+    public void end(long position) {
+      // Output a final sample with the nal units currently held
+      nalUnitPosition = position;
+      outputSample(0);
     }
 
     /** Returns whether a NAL unit type is one that occurs before any VCL NAL units in a sample. */

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
@@ -174,6 +174,7 @@ public final class H265Reader implements ElementaryStreamReader {
 
   @Override
   public void packetFinished(boolean isEndOfInput) {
+    assertTracksCreated();
     if (isEndOfInput) {
       sampleReader.end(totalBytesWritten);
     }
@@ -379,9 +380,9 @@ public final class H265Reader implements ElementaryStreamReader {
     }
 
     public void end(long position) {
-      // Output a final sample with the nal units currently held
+      // Output a final sample with the NAL units currently held
       nalUnitPosition = position;
-      outputSample(0);
+      outputSample(/* offset= */ 0);
       readingSample = false;
     }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/Id3Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/Id3Reader.java
@@ -121,7 +121,7 @@ public final class Id3Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
+  public void packetFinished(boolean isEndOfInput) {
     Assertions.checkStateNotNull(output); // Asserts that createTracks has been called.
     if (!writingSample || sampleSize == 0 || sampleBytesRead != sampleSize) {
       return;

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/LatmReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/LatmReader.java
@@ -151,7 +151,7 @@ public final class LatmReader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
+  public void packetFinished(boolean isEndOfInput) {
     // Do nothing.
   }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/MpegAudioReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/MpegAudioReader.java
@@ -118,7 +118,7 @@ public final class MpegAudioReader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
+  public void packetFinished(boolean isEndOfInput) {
     // Do nothing.
   }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PesReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PesReader.java
@@ -149,7 +149,7 @@ public final class PesReader implements TsPayloadReader {
             payloadSize -= readLength;
             if (payloadSize == 0) {
               // There are bytes left in data, see above, so this is not the end of input
-              reader.packetFinished(false);
+              reader.packetFinished(/* isEndOfInput= */ false);
               setState(STATE_READING_HEADER);
             }
           }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PesReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PesReader.java
@@ -107,7 +107,8 @@ public final class PesReader implements TsPayloadReader {
             Log.w(TAG, "Unexpected start indicator: expected " + payloadSize + " more bytes");
           }
           // Either way, notify the reader that it has now finished.
-          reader.packetFinished();
+          boolean isEndOfInput = (data.limit() == 0);
+          reader.packetFinished(isEndOfInput);
           break;
         default:
           throw new IllegalStateException();
@@ -147,7 +148,8 @@ public final class PesReader implements TsPayloadReader {
           if (payloadSize != C.LENGTH_UNSET) {
             payloadSize -= readLength;
             if (payloadSize == 0) {
-              reader.packetFinished();
+              // There are bytes left in data, see above, so this is not the end of input
+              reader.packetFinished(false);
               setState(STATE_READING_HEADER);
             }
           }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PsExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PsExtractor.java
@@ -357,7 +357,7 @@ public final class PsExtractor implements Extractor {
       pesPayloadReader.packetStarted(timeUs, TsPayloadReader.FLAG_DATA_ALIGNMENT_INDICATOR);
       pesPayloadReader.consume(data);
       // We always have complete PES packets with program stream.
-      pesPayloadReader.packetFinished();
+      pesPayloadReader.packetFinished(false);
     }
 
     private void parseHeader() {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PsExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PsExtractor.java
@@ -357,7 +357,7 @@ public final class PsExtractor implements Extractor {
       pesPayloadReader.packetStarted(timeUs, TsPayloadReader.FLAG_DATA_ALIGNMENT_INDICATOR);
       pesPayloadReader.consume(data);
       // We always have complete PES packets with program stream.
-      pesPayloadReader.packetFinished(false);
+      pesPayloadReader.packetFinished(/* isEndOfInput= */ false);
     }
 
     private void parseHeader() {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/TsExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/TsExtractor.java
@@ -323,7 +323,7 @@ public final class TsExtractor implements Extractor {
     }
 
     if (!fillBufferWithAtLeastOnePacket(input)) {
-      // Send a dummy pusi to allow for packetFinished to be triggered on the last unit
+      // Send a synthesised empty pusi to allow for packetFinished to be triggered on the last unit.
       for (int i = 0; i < tsPayloadReaders.size(); i++) {
         TsPayloadReader payloadReader = tsPayloadReaders.valueAt(i);
         if (payloadReader instanceof PesReader) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/TsExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/TsExtractor.java
@@ -323,7 +323,14 @@ public final class TsExtractor implements Extractor {
     }
 
     if (!fillBufferWithAtLeastOnePacket(input)) {
-      return RESULT_END_OF_INPUT;
+      if (mode != MODE_HLS) {
+        // Send a dummy pusi to allow for packetFinished to be triggered on the last unit
+        for (int i = 0; i < tsPayloadReaders.size(); i++) {
+          TsPayloadReader payloadReader = tsPayloadReaders.valueAt(i);
+          int pid = tsPayloadReaders.keyAt(i);
+          payloadReader.consume(new ParsableByteArray(), FLAG_PAYLOAD_UNIT_START_INDICATOR);
+        }
+      }      return RESULT_END_OF_INPUT;
     }
 
     int endOfPacket = findEndOfFirstTsPacketInBuffer();

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/TsExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/TsExtractor.java
@@ -331,7 +331,8 @@ public final class TsExtractor implements Extractor {
             payloadReader.consume(new ParsableByteArray(), FLAG_PAYLOAD_UNIT_START_INDICATOR);
           }
         }
-      }      return RESULT_END_OF_INPUT;
+      }
+      return RESULT_END_OF_INPUT;
     }
 
     int endOfPacket = findEndOfFirstTsPacketInBuffer();

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/TsExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/TsExtractor.java
@@ -327,8 +327,9 @@ public final class TsExtractor implements Extractor {
         // Send a dummy pusi to allow for packetFinished to be triggered on the last unit
         for (int i = 0; i < tsPayloadReaders.size(); i++) {
           TsPayloadReader payloadReader = tsPayloadReaders.valueAt(i);
-          int pid = tsPayloadReaders.keyAt(i);
-          payloadReader.consume(new ParsableByteArray(), FLAG_PAYLOAD_UNIT_START_INDICATOR);
+          if (payloadReader instanceof PesReader) {
+            payloadReader.consume(new ParsableByteArray(), FLAG_PAYLOAD_UNIT_START_INDICATOR);
+          }
         }
       }      return RESULT_END_OF_INPUT;
     }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/TsExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/TsExtractor.java
@@ -323,13 +323,11 @@ public final class TsExtractor implements Extractor {
     }
 
     if (!fillBufferWithAtLeastOnePacket(input)) {
-      if (mode != MODE_HLS) {
-        // Send a dummy pusi to allow for packetFinished to be triggered on the last unit
-        for (int i = 0; i < tsPayloadReaders.size(); i++) {
-          TsPayloadReader payloadReader = tsPayloadReaders.valueAt(i);
-          if (payloadReader instanceof PesReader) {
-            payloadReader.consume(new ParsableByteArray(), FLAG_PAYLOAD_UNIT_START_INDICATOR);
-          }
+      // Send a dummy pusi to allow for packetFinished to be triggered on the last unit
+      for (int i = 0; i < tsPayloadReaders.size(); i++) {
+        TsPayloadReader payloadReader = tsPayloadReaders.valueAt(i);
+        if (payloadReader instanceof PesReader) {
+          payloadReader.consume(new ParsableByteArray(), FLAG_PAYLOAD_UNIT_START_INDICATOR);
         }
       }
       return RESULT_END_OF_INPUT;

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/ts/TsExtractorTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/ts/TsExtractorTest.java
@@ -287,7 +287,7 @@ public final class TsExtractorTest {
     public void consume(ParsableByteArray data) {}
 
     @Override
-    public void packetFinished() {
+    public void packetFinished(boolean isEndOfInput) {
       packetsRead++;
     }
 

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h263.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h263.ts.0.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 39002
-  sample count = 24
+  sample count = 25
   format 0:
     id = 1/256
     sampleMimeType = video/mp4v-es
@@ -112,4 +112,8 @@ track 256:
     time = 920000
     flags = 0
     data = length 222, hash 7E77BF79
+  sample 24:
+    time = 960000
+    flags = 1
+    data = length 11769, hash D94C80C0
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h263.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h263.ts.1.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 27354
-  sample count = 18
+  sample count = 19
   format 0:
     id = 1/256
     sampleMimeType = video/mp4v-es
@@ -88,4 +88,8 @@ track 256:
     time = 920000
     flags = 0
     data = length 222, hash 7E77BF79
+  sample 18:
+    time = 960000
+    flags = 1
+    data = length 11769, hash D94C80C0
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h263.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h263.ts.2.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 13592
-  sample count = 8
+  sample count = 9
   format 0:
     id = 1/256
     sampleMimeType = video/mp4v-es
@@ -48,4 +48,8 @@ track 256:
     time = 920000
     flags = 0
     data = length 222, hash 7E77BF79
+  sample 8:
+    time = 960000
+    flags = 1
+    data = length 11769, hash D94C80C0
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h263.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h263.ts.unknown_length.dump
@@ -5,7 +5,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 39002
-  sample count = 24
+  sample count = 25
   format 0:
     id = 1/256
     sampleMimeType = video/mp4v-es
@@ -109,4 +109,8 @@ track 256:
     time = 920000
     flags = 0
     data = length 222, hash 7E77BF79
+  sample 24:
+    time = 960000
+    flags = 1
+    data = length 11769, hash D94C80C0
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_dts_audio.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_dts_audio.ts.0.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 13650
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     sampleMimeType = video/avc
@@ -26,6 +26,10 @@ track 256:
     time = 100100
     flags = 0
     data = length 813, hash 99F7B4FA
+  sample 2:
+    time = 133466
+    flags = 0
+    data = length 442, hash A7367ECF
 track 257:
   total output bytes = 18432
   sample count = 9

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_dts_audio.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_dts_audio.ts.unknown_length.dump
@@ -5,7 +5,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 13650
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     sampleMimeType = video/avc
@@ -23,6 +23,10 @@ track 256:
     time = 100100
     flags = 0
     data = length 813, hash 99F7B4FA
+  sample 2:
+    time = 133466
+    flags = 0
+    data = length 442, hash A7367ECF
 track 257:
   total output bytes = 18432
   sample count = 9

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.0.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 13650
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     sampleMimeType = video/avc
@@ -26,6 +26,10 @@ track 256:
     time = 100100
     flags = 0
     data = length 813, hash 99F7B4FA
+  sample 2:
+    time = 133466
+    flags = 0
+    data = length 442, hash A7367ECF
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.1.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 13650
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     sampleMimeType = video/avc
@@ -26,6 +26,10 @@ track 256:
     time = 100100
     flags = 0
     data = length 813, hash 99F7B4FA
+  sample 2:
+    time = 133466
+    flags = 0
+    data = length 442, hash A7367ECF
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.2.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 13650
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     sampleMimeType = video/avc
@@ -26,6 +26,10 @@ track 256:
     time = 100100
     flags = 0
     data = length 813, hash 99F7B4FA
+  sample 2:
+    time = 133466
+    flags = 0
+    data = length 442, hash A7367ECF
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.unknown_length.dump
@@ -5,7 +5,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 13650
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     sampleMimeType = video/avc
@@ -23,6 +23,10 @@ track 256:
     time = 100100
     flags = 0
     data = length 813, hash 99F7B4FA
+  sample 2:
+    time = 133466
+    flags = 0
+    data = length 442, hash A7367ECF
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.0.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 12451
-  sample count = 4
+  sample count = 5
   format 0:
     id = 1/256
     sampleMimeType = video/avc
@@ -34,4 +34,8 @@ track 256:
     time = 133466
     flags = 0
     data = length 518, hash 546C177
+  sample 4:
+    time = 100100
+    flags = 0
+    data = length 254, hash 36EBDA1
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.1.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 12451
-  sample count = 4
+  sample count = 5
   format 0:
     id = 1/256
     sampleMimeType = video/avc
@@ -34,4 +34,8 @@ track 256:
     time = 133466
     flags = 0
     data = length 518, hash 546C177
+  sample 4:
+    time = 100100
+    flags = 0
+    data = length 254, hash 36EBDA1
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.2.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 12451
-  sample count = 4
+  sample count = 5
   format 0:
     id = 1/256
     sampleMimeType = video/avc
@@ -34,4 +34,8 @@ track 256:
     time = 133466
     flags = 0
     data = length 518, hash 546C177
+  sample 4:
+    time = 100100
+    flags = 0
+    data = length 254, hash 36EBDA1
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.3.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 255
-  sample count = 0
+  sample count = 1
   format 0:
     id = 1/256
     sampleMimeType = video/avc
@@ -18,4 +18,8 @@ track 256:
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89
+  sample 0:
+    time = 100100
+    flags = 0
+    data = length 254, hash 36EBDA1
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.unknown_length.dump
@@ -5,7 +5,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 12451
-  sample count = 4
+  sample count = 5
   format 0:
     id = 1/256
     sampleMimeType = video/avc
@@ -31,4 +31,8 @@ track 256:
     time = 133466
     flags = 0
     data = length 518, hash 546C177
+  sample 4:
+    time = 100100
+    flags = 0
+    data = length 254, hash 36EBDA1
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.0.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 19364
-  sample count = 29
+  sample count = 30
   format 0:
     id = 1/256
     sampleMimeType = video/hevc
@@ -133,4 +133,8 @@ track 256:
     time = 933333
     flags = 0
     data = length 87, hash EEC4D98C
+  sample 29:
+    time = 1000000
+    flags = 0
+    data = length 167, hash EAE2DF9A
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.1.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 3806
-  sample count = 20
+  sample count = 21
   format 0:
     id = 1/256
     sampleMimeType = video/hevc
@@ -97,4 +97,8 @@ track 256:
     time = 933333
     flags = 0
     data = length 87, hash EEC4D98C
+  sample 20:
+    time = 1000000
+    flags = 0
+    data = length 167, hash EAE2DF9A
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.2.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 1796
-  sample count = 11
+  sample count = 12
   format 0:
     id = 1/256
     sampleMimeType = video/hevc
@@ -61,4 +61,8 @@ track 256:
     time = 933333
     flags = 0
     data = length 87, hash EEC4D98C
+  sample 11:
+    time = 1000000
+    flags = 0
+    data = length 167, hash EAE2DF9A
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.3.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 396
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     sampleMimeType = video/hevc
@@ -25,4 +25,8 @@ track 256:
     time = 933333
     flags = 0
     data = length 87, hash EEC4D98C
+  sample 2:
+    time = 1000000
+    flags = 0
+    data = length 167, hash EAE2DF9A
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.unknown_length.dump
@@ -5,7 +5,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 19364
-  sample count = 29
+  sample count = 30
   format 0:
     id = 1/256
     sampleMimeType = video/hevc
@@ -130,4 +130,8 @@ track 256:
     time = 933333
     flags = 0
     data = length 87, hash EEC4D98C
+  sample 29:
+    time = 1000000
+    flags = 0
+    data = length 167, hash EAE2DF9A
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.0.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 10004
-  sample count = 15
+  sample count = 16
   format 0:
     id = 1/256
     sampleMimeType = video/hevc
@@ -78,4 +78,8 @@ track 256:
     time = 1133333
     flags = 0
     data = length 46, hash CE770A40
+  sample 15:
+    time = 1266666
+    flags = 0
+    data = length 99, hash CD8A8477
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.1.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 856
-  sample count = 11
+  sample count = 12
   format 0:
     id = 1/256
     sampleMimeType = video/hevc
@@ -62,4 +62,8 @@ track 256:
     time = 1133333
     flags = 0
     data = length 46, hash CE770A40
+  sample 11:
+    time = 1266666
+    flags = 0
+    data = length 99, hash CD8A8477
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.2.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 563
-  sample count = 6
+  sample count = 7
   format 0:
     id = 1/256
     sampleMimeType = video/hevc
@@ -42,4 +42,8 @@ track 256:
     time = 1133333
     flags = 0
     data = length 46, hash CE770A40
+  sample 6:
+    time = 1266666
+    flags = 0
+    data = length 99, hash CD8A8477
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.3.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 146
-  sample count = 1
+  sample count = 2
   format 0:
     id = 1/256
     sampleMimeType = video/hevc
@@ -22,4 +22,8 @@ track 256:
     time = 1133333
     flags = 0
     data = length 46, hash CE770A40
+  sample 1:
+    time = 1266666
+    flags = 0
+    data = length 99, hash CD8A8477
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.unknown_length.dump
@@ -5,7 +5,7 @@ seekMap:
 numberOfTracks = 1
 track 256:
   total output bytes = 10004
-  sample count = 15
+  sample count = 16
   format 0:
     id = 1/256
     sampleMimeType = video/hevc
@@ -75,4 +75,8 @@ track 256:
     time = 1133333
     flags = 0
     data = length 46, hash CE770A40
+  sample 15:
+    time = 1266666
+    flags = 0
+    data = length 99, hash CD8A8477
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/playbackdumps/ts/bbb_2500ms.ts.dump
+++ b/libraries/test_data/src/test/assets/playbackdumps/ts/bbb_2500ms.ts.dump
@@ -95,7 +95,7 @@ MediaCodecAdapter (exotest.audio.mpegl2):
   buffers[92] = length 1254, hash 1D10AC24
   buffers[93] = length 0, hash 1
 MediaCodecAdapter (exotest.video.mpeg2):
-  buffers.length = 58
+  buffers.length = 59
   buffers[0] = length 32732, hash 7B7C01FD
   buffers[1] = length 1302, hash CE206BF9
   buffers[2] = length 923, hash 94689DE8
@@ -153,4 +153,5 @@ MediaCodecAdapter (exotest.video.mpeg2):
   buffers[54] = length 2195, hash 65E63F42
   buffers[55] = length 2404, hash BA5E2CEA
   buffers[56] = length 2738, hash 8F8FDE0A
-  buffers[57] = length 0, hash 1
+  buffers[57] = length 2970, hash 78651B41
+  buffers[58] = length 0, hash 1

--- a/libraries/test_data/src/test/assets/playbackdumps/ts/sample_h264_dts_audio.ts.dump
+++ b/libraries/test_data/src/test/assets/playbackdumps/ts/sample_h264_dts_audio.ts.dump
@@ -1,5 +1,6 @@
 MediaCodecAdapter (exotest.video.avc):
-  buffers.length = 3
+  buffers.length = 4
   buffers[0] = length 12394, hash A39F5311
   buffers[1] = length 813, hash 99F7B4FA
-  buffers[2] = length 0, hash 1
+  buffers[2] = length 442, hash A7367ECF
+  buffers[3] = length 0, hash 1

--- a/libraries/test_data/src/test/assets/playbackdumps/ts/sample_h264_mpeg_audio.ts.dump
+++ b/libraries/test_data/src/test/assets/playbackdumps/ts/sample_h264_mpeg_audio.ts.dump
@@ -6,7 +6,8 @@ MediaCodecAdapter (exotest.audio.mpegl2):
   buffers[3] = length 1254, hash 73FB07B8
   buffers[4] = length 0, hash 1
 MediaCodecAdapter (exotest.video.avc):
-  buffers.length = 3
+  buffers.length = 4
   buffers[0] = length 12394, hash A39F5311
   buffers[1] = length 813, hash 99F7B4FA
-  buffers[2] = length 0, hash 1
+  buffers[2] = length 442, hash A7367ECF
+  buffers[3] = length 0, hash 1

--- a/libraries/test_data/src/test/assets/playbackdumps/ts/sample_h264_no_access_unit_delimiters.ts.dump
+++ b/libraries/test_data/src/test/assets/playbackdumps/ts/sample_h264_no_access_unit_delimiters.ts.dump
@@ -1,5 +1,6 @@
 MediaCodecAdapter (exotest.video.avc):
-  buffers.length = 3
+  buffers.length = 4
   buffers[0] = length 11672, hash 476AEFF9
   buffers[1] = length 524, hash 184416EF
-  buffers[2] = length 0, hash 1
+  buffers[2] = length 254, hash 36EBDA1
+  buffers[3] = length 0, hash 1


### PR DESCRIPTION
**Issue**
With TS contents, any codec, the last access unit is never passed on to the input sample queue. The reason is that the end of the sample is currently triggered by the payload_unit_start_indicator (pusi) of the first TS packet of the following access unit, which doesn't exist for the very last access unit. As a result the playback of any TS content always misses the last frame.

For frame accurate applications this seems a non negligible issue.

This problem was already discussed here https://github.com/google/ExoPlayer/issues/7909 and that ticket is still open.

**Proposed solution**
In our understanding, for a file based case, it is reasonable to assume that the end of stream is a valid end of the last access unit, provided all the accumulated TS packets of the access unit have correct TS header parameters such as transport_error_indicator (=0) and continuity_counter.

This pull request comes from a fix we implemented in our LCEVC-Exo fork. The idea is that on end of stream:
- TsExtractor sends an empty data payload with flagged pusi to PesReader;
- PesReader recognises the end of input case from the empty payload and calls a modified packetFinished() with boolean endOfInput parameter to the ES reader;
- The ES reader calls a new SampleReader method called end() that flushes the accumulated access unit;
