### PR TITLE
Save state throwsWhenUsingWrongThread when ListenerSet::copy()

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/ListenerSet.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/ListenerSet.java
@@ -99,7 +99,12 @@ public final class ListenerSet<T extends @NonNull Object> {
    *     during one {@link Looper} message queue iteration were handled by the listeners.
    */
   public ListenerSet(Looper looper, Clock clock, IterationFinishedEvent<T> iterationFinishedEvent) {
-    this(/* listeners= */ new CopyOnWriteArraySet<>(), looper, clock, iterationFinishedEvent, true);
+    this(
+        /* listeners= */ new CopyOnWriteArraySet<>(),
+        looper,
+        clock,
+        iterationFinishedEvent,
+        /* throwsWhenUsingWrongThread= */ true);
   }
 
   private ListenerSet(
@@ -107,7 +112,7 @@ public final class ListenerSet<T extends @NonNull Object> {
       Looper looper,
       Clock clock,
       IterationFinishedEvent<T> iterationFinishedEvent,
-      Boolean throwsWhenUsingWrongThread) {
+      boolean throwsWhenUsingWrongThread) {
     this.clock = clock;
     this.listeners = listeners;
     this.iterationFinishedEvent = iterationFinishedEvent;
@@ -150,7 +155,8 @@ public final class ListenerSet<T extends @NonNull Object> {
   @CheckResult
   public ListenerSet<T> copy(
       Looper looper, Clock clock, IterationFinishedEvent<T> iterationFinishedEvent) {
-    return new ListenerSet<>(listeners, looper, clock, iterationFinishedEvent, throwsWhenUsingWrongThread);
+    return new ListenerSet<>(
+        listeners, looper, clock, iterationFinishedEvent, throwsWhenUsingWrongThread);
   }
 
   /**

--- a/libraries/common/src/main/java/androidx/media3/common/util/ListenerSet.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/ListenerSet.java
@@ -99,14 +99,15 @@ public final class ListenerSet<T extends @NonNull Object> {
    *     during one {@link Looper} message queue iteration were handled by the listeners.
    */
   public ListenerSet(Looper looper, Clock clock, IterationFinishedEvent<T> iterationFinishedEvent) {
-    this(/* listeners= */ new CopyOnWriteArraySet<>(), looper, clock, iterationFinishedEvent);
+    this(/* listeners= */ new CopyOnWriteArraySet<>(), looper, clock, iterationFinishedEvent, true);
   }
 
   private ListenerSet(
       CopyOnWriteArraySet<ListenerHolder<T>> listeners,
       Looper looper,
       Clock clock,
-      IterationFinishedEvent<T> iterationFinishedEvent) {
+      IterationFinishedEvent<T> iterationFinishedEvent,
+      Boolean throwsWhenUsingWrongThread) {
     this.clock = clock;
     this.listeners = listeners;
     this.iterationFinishedEvent = iterationFinishedEvent;
@@ -117,7 +118,7 @@ public final class ListenerSet<T extends @NonNull Object> {
     @SuppressWarnings("nullness:methodref.receiver.bound")
     HandlerWrapper handler = clock.createHandler(looper, this::handleMessage);
     this.handler = handler;
-    throwsWhenUsingWrongThread = true;
+    this.throwsWhenUsingWrongThread = throwsWhenUsingWrongThread;
   }
 
   /**
@@ -149,7 +150,7 @@ public final class ListenerSet<T extends @NonNull Object> {
   @CheckResult
   public ListenerSet<T> copy(
       Looper looper, Clock clock, IterationFinishedEvent<T> iterationFinishedEvent) {
-    return new ListenerSet<>(listeners, looper, clock, iterationFinishedEvent);
+    return new ListenerSet<>(listeners, looper, clock, iterationFinishedEvent, throwsWhenUsingWrongThread);
   }
 
   /**


### PR DESCRIPTION
Our code
```
DefaultAnalyticsCollector collector = new DefaultAnalyticsCollector();
collector.setThrowsWhenUsingWrongThread(false);

// This function call ListenerSet.copy(), which ignores the state set in the above line
collector.setPlayer(myPlayer, myLooper);
```

The implementation of DefaultAnalyticsCollector.setPlayer(), which calls `ListenerSet.copy()`
![image](https://github.com/androidx/media/assets/5352145/e703e782-ce60-4b4c-acbe-fd616f65cbb3)
