### PR TITLE
Fix DTS:X P2 Direct Passthrough Playback.

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioOffloadSupportProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioOffloadSupportProvider.java
@@ -81,17 +81,16 @@ public final class DefaultAudioOffloadSupportProvider
 
     @C.Encoding
     int encoding = MimeTypes.getEncoding(checkNotNull(format.sampleMimeType), format.codecs);
-    if (encoding == C.ENCODING_INVALID) {
+    // AudioFormat.ENCODING_DTS_UHD_P2 is defined from API 34 onwards. We return offload
+    // unsupported to prevent crash in Util.getAudioFormat() below when it tries to create
+    // an AudioFormat with ENCODING_DTS_UHD_P2.
+    if ((encoding == C.ENCODING_INVALID) ||
+        ((Util.SDK_INT < 34) && (encoding == C.ENCODING_DTS_UHD_P2))) {
       return AudioOffloadSupport.DEFAULT_UNSUPPORTED;
     }
     int channelConfig = Util.getAudioTrackChannelConfig(format.channelCount);
     if (channelConfig == AudioFormat.CHANNEL_INVALID) {
       return AudioOffloadSupport.DEFAULT_UNSUPPORTED;
-    }
-    // AudioFormat.ENCODING_DTS_UHD_P2 is defined from API 34 onwards. Before that encoding should
-    // be set to C.ENCODING_DTS, which is supported by TV ICs for offload playback.
-    if ((Util.SDK_INT < 34) && (encoding == C.ENCODING_DTS_UHD_P2)) {
-      encoding = C.ENCODING_DTS;
     }
     AudioFormat audioFormat = Util.getAudioFormat(format.sampleRate, channelConfig, encoding);
     if (Util.SDK_INT >= 31) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioOffloadSupportProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioOffloadSupportProvider.java
@@ -88,7 +88,11 @@ public final class DefaultAudioOffloadSupportProvider
     if (channelConfig == AudioFormat.CHANNEL_INVALID) {
       return AudioOffloadSupport.DEFAULT_UNSUPPORTED;
     }
-
+    // AudioFormat.ENCODING_DTS_UHD_P2 is defined from API 34 onwards. Before that encoding should
+    // be set to C.ENCODING_DTS, which is supported by TV ICs for offload playback.
+    if ((Util.SDK_INT < 34) && (encoding == C.ENCODING_DTS_UHD_P2)) {
+      encoding = C.ENCODING_DTS;
+    }
     AudioFormat audioFormat = Util.getAudioFormat(format.sampleRate, channelConfig, encoding);
     if (Util.SDK_INT >= 31) {
       return Api31.getOffloadedPlaybackSupport(

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioOffloadSupportProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioOffloadSupportProvider.java
@@ -81,11 +81,13 @@ public final class DefaultAudioOffloadSupportProvider
 
     @C.Encoding
     int encoding = MimeTypes.getEncoding(checkNotNull(format.sampleMimeType), format.codecs);
+    if (encoding == C.ENCODING_INVALID) {
+      return AudioOffloadSupport.DEFAULT_UNSUPPORTED;
+    }
     // AudioFormat.ENCODING_DTS_UHD_P2 is defined from API 34 onwards. We return offload
     // unsupported to prevent crash in Util.getAudioFormat() below when it tries to create
     // an AudioFormat with ENCODING_DTS_UHD_P2.
-    if ((encoding == C.ENCODING_INVALID) ||
-        ((Util.SDK_INT < 34) && (encoding == C.ENCODING_DTS_UHD_P2))) {
+    if ((Util.SDK_INT < 34) && (encoding == C.ENCODING_DTS_UHD_P2)) {
       return AudioOffloadSupport.DEFAULT_UNSUPPORTED;
     }
     int channelConfig = Util.getAudioTrackChannelConfig(format.channelCount);


### PR DESCRIPTION
DTS:X P2 audio will currently fail in direct passthrough playback. 

It will fail at DefaultAudioOffloadSupportProvide.java,  around line 96
_**AudioFormat audioFormat = Util.getAudioFormat(format.sampleRate, channelConfig, encoding);**_ when trying to build an AudioFormat with encoding == ENCODING_DTS_UHD_P2.
 
 AudioFormat.ENCODING_DTS_UHD_P2 is only defined from API 34 onwards. Before that encoding should
 be set to C.ENCODING_DTS, which is supported by TV ICs for direct passthrough playback. 
@tianyif 