### PR TITLE
Improve track index adjustment logic by adding index comparison

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelection.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelection.java
@@ -457,7 +457,8 @@ public class AdaptiveTrackSelection extends BaseTrackSelection {
       previousReason = Iterables.getLast(queue).trackSelectionReason;
     }
     int newSelectedIndex = determineIdealSelectedIndex(nowMs, chunkDurationUs);
-    if (!isTrackExcluded(previousSelectedIndex, nowMs)) {
+    if (newSelectedIndex != previousSelectedIndex
+        && !isTrackExcluded(previousSelectedIndex, nowMs)) {
       // Revert back to the previous selection if conditions are not suitable for switching.
       Format currentFormat = getFormat(previousSelectedIndex);
       Format selectedFormat = getFormat(newSelectedIndex);


### PR DESCRIPTION
If the conditions are not suitable, it will use the value of the previousSelectedIndex.
so if the previousSelectedIndex and newSelectedIndex are the same, there is no need to perform that logic.

current implementation
```java
if (!isTrackExcluded(previousSelectedIndex, nowMs)) {
  // Revert back to the previous selection if conditions are not suitable for switching.
  Format currentFormat = getFormat(previousSelectedIndex);
  Format selectedFormat = getFormat(newSelectedIndex);
  long minDurationForQualityIncreaseUs =
      minDurationForQualityIncreaseUs(availableDurationUs, chunkDurationUs);
  if (selectedFormat.bitrate > currentFormat.bitrate
      && bufferedDurationUs < minDurationForQualityIncreaseUs) {
    // The selected track is a higher quality, but we have insufficient buffer to safely switch
    // up. Defer switching up for now.
    newSelectedIndex = previousSelectedIndex;
  } else if (selectedFormat.bitrate < currentFormat.bitrate
      && bufferedDurationUs >= maxDurationForQualityDecreaseUs) {
    // The selected track is a lower quality, but we have sufficient buffer to defer switching
    // down for now.
    newSelectedIndex = previousSelectedIndex;
  }
}
```