### PR TITLE
Dont cache in OkHttpDataSource

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -23,6 +23,8 @@
 *   UI:
 *   Downloads:
 *   OkHttp Extension:
+    *   Disable internal caching of OkHttp
+        ([#441](https://github.com/androidx/media/pull/441)).
 *   Cronet Extension:
 *   RTMP Extension:
 *   DASH Extension:

--- a/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
+++ b/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
@@ -198,6 +198,9 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
   private long bytesToRead;
   private long bytesRead;
 
+  private static final CacheControl DISABLE_CACHE = new CacheControl.Builder().noCache().noStore()
+      .build();
+
   /**
    * @deprecated Use {@link OkHttpDataSource.Factory} instead.
    */
@@ -458,6 +461,10 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
       requestBody = RequestBody.create(null, Util.EMPTY_BYTE_ARRAY);
     }
     builder.method(dataSpec.getHttpMethodString(), requestBody);
+
+    // ExoPlayer implements it's own caching, so avoid a second cache.
+    builder.cacheControl(DISABLE_CACHE);
+
     return builder.build();
   }
 

--- a/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
+++ b/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
@@ -462,7 +462,7 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
     }
     builder.method(dataSpec.getHttpMethodString(), requestBody);
 
-    // ExoPlayer implements it's own caching, so avoid a second cache.
+    // ExoPlayer implements its own caching, so avoid a second cache.
     builder.cacheControl(DISABLE_CACHE);
 
     return builder.build();

--- a/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
+++ b/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
@@ -69,6 +69,9 @@ import okhttp3.ResponseBody;
  */
 public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
 
+  private static final CacheControl DISABLE_CACHE =
+      new CacheControl.Builder().noCache().noStore().build();
+
   static {
     MediaLibraryInfo.registerModule("media3.datasource.okhttp");
   }
@@ -197,9 +200,6 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
   private boolean opened;
   private long bytesToRead;
   private long bytesRead;
-
-  private static final CacheControl DISABLE_CACHE =
-      new CacheControl.Builder().noCache().noStore().build();
 
   /**
    * @deprecated Use {@link OkHttpDataSource.Factory} instead.

--- a/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
+++ b/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
@@ -198,8 +198,8 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
   private long bytesToRead;
   private long bytesRead;
 
-  private static final CacheControl DISABLE_CACHE = new CacheControl.Builder().noCache().noStore()
-      .build();
+  private static final CacheControl DISABLE_CACHE =
+      new CacheControl.Builder().noCache().noStore().build();
 
   /**
    * @deprecated Use {@link OkHttpDataSource.Factory} instead.

--- a/libraries/datasource_okhttp/src/test/java/androidx/media3/datasource/okhttp/OkHttpDataSourceTest.java
+++ b/libraries/datasource_okhttp/src/test/java/androidx/media3/datasource/okhttp/OkHttpDataSourceTest.java
@@ -40,8 +40,7 @@ import org.junit.runner.RunWith;
 /** Unit tests for {@link OkHttpDataSource}. */
 @RunWith(AndroidJUnit4.class)
 public class OkHttpDataSourceTest {
-  @Rule
-  public TemporaryFolder tempFolder = new TemporaryFolder();
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
   /**
    * This test will set HTTP default request parameters (1) in the OkHttpDataSource, (2) via
@@ -148,16 +147,13 @@ public class OkHttpDataSourceTest {
   @Test
   public void does_not_cache_in_okhttp() throws Exception {
     MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.enqueue(new MockResponse()
-        .setBody("1234")
-        .addHeader("Cache-Control: max-age=60"));
+    mockWebServer.enqueue(
+        new MockResponse().setBody("1234").addHeader("Cache-Control: max-age=60"));
     DataSpec dataSpec =
         new DataSpec.Builder().setUri(mockWebServer.url("/test-path").toString()).build();
 
     Cache cache = new Cache(tempFolder.getRoot(), 10_000_000);
-    OkHttpClient okHttpClient = new OkHttpClient.Builder()
-        .cache(cache)
-        .build();
+    OkHttpClient okHttpClient = new OkHttpClient.Builder().cache(cache).build();
     OkHttpDataSource.Factory factory = new OkHttpDataSource.Factory((Call.Factory) okHttpClient);
     OkHttpDataSource dataSource = factory.createDataSource();
 

--- a/libraries/datasource_okhttp/src/test/java/androidx/media3/datasource/okhttp/OkHttpDataSourceTest.java
+++ b/libraries/datasource_okhttp/src/test/java/androidx/media3/datasource/okhttp/OkHttpDataSourceTest.java
@@ -127,25 +127,7 @@ public class OkHttpDataSourceTest {
   }
 
   @Test
-  public void factory_setRequestPropertyAfterCreation_setsCorrectHeaders() throws Exception {
-    MockWebServer mockWebServer = new MockWebServer();
-    mockWebServer.enqueue(new MockResponse());
-    DataSpec dataSpec =
-        new DataSpec.Builder().setUri(mockWebServer.url("/test-path").toString()).build();
-    OkHttpDataSource.Factory factory = new OkHttpDataSource.Factory(new OkHttpClient());
-    OkHttpDataSource dataSource = factory.createDataSource();
-
-    Map<String, String> defaultRequestProperties = new HashMap<>();
-    defaultRequestProperties.put("0", "afterCreation");
-    factory.setDefaultRequestProperties(defaultRequestProperties);
-    dataSource.open(dataSpec);
-
-    Headers headers = mockWebServer.takeRequest(10, SECONDS).getHeaders();
-    assertThat(headers.get("0")).isEqualTo("afterCreation");
-  }
-
-  @Test
-  public void does_not_cache_in_okhttp() throws Exception {
+  public void open_doesNotCacheInOkHttp() throws Exception {
     MockWebServer mockWebServer = new MockWebServer();
     mockWebServer.enqueue(
         new MockResponse().setBody("1234").addHeader("Cache-Control: max-age=60"));
@@ -161,5 +143,23 @@ public class OkHttpDataSourceTest {
     dataSource.close();
 
     assertThat(cache.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void factory_setRequestPropertyAfterCreation_setsCorrectHeaders() throws Exception {
+    MockWebServer mockWebServer = new MockWebServer();
+    mockWebServer.enqueue(new MockResponse());
+    DataSpec dataSpec =
+        new DataSpec.Builder().setUri(mockWebServer.url("/test-path").toString()).build();
+    OkHttpDataSource.Factory factory = new OkHttpDataSource.Factory(new OkHttpClient());
+    OkHttpDataSource dataSource = factory.createDataSource();
+
+    Map<String, String> defaultRequestProperties = new HashMap<>();
+    defaultRequestProperties.put("0", "afterCreation");
+    factory.setDefaultRequestProperties(defaultRequestProperties);
+    dataSource.open(dataSpec);
+
+    Headers headers = mockWebServer.takeRequest(10, SECONDS).getHeaders();
+    assertThat(headers.get("0")).isEqualTo("afterCreation");
   }
 }


### PR DESCRIPTION
ExoPlayer has it's own cache, so OkHttp caching should be disabled to avoid storing twice.