### PR TITLE
Support cast live seekable ranges and seek to the live position.

### DIFF
--- a/libraries/cast/src/main/java/androidx/media3/cast/CastPlayer.java
+++ b/libraries/cast/src/main/java/androidx/media3/cast/CastPlayer.java
@@ -422,12 +422,18 @@ public final class CastPlayer extends BasePlayer {
       return;
     }
     MediaStatus mediaStatus = getMediaStatus();
-    // We assume the default position is 0. There is no support for seeking to the default position
-    // in RemoteMediaClient.
-    positionMs = positionMs != C.TIME_UNSET ? positionMs : 0;
     if (mediaStatus != null && remoteMediaClient != null) {
-      // The cast live content start position might not bet at 0, add offset if set.
       currentTimeline.getPeriod(mediaItemIndex, period, true);
+
+      // Resolve the default position for the window.
+      if (positionMs == C.TIME_UNSET) {
+        currentTimeline.getWindow(mediaItemIndex, window);
+        positionMs = window.defaultPositionUs != C.TIME_UNSET
+            ? Util.usToMs(window.defaultPositionUs)
+            : 0;
+      }
+
+      // The cast live content start position might not bet at 0, add offset if set.
       long periodPosInWindow = Util.usToMs(period.positionInWindowUs);
       long targetPosMs = positionMs - periodPosInWindow;
 

--- a/libraries/cast/src/main/java/androidx/media3/cast/CastTimeline.java
+++ b/libraries/cast/src/main/java/androidx/media3/cast/CastTimeline.java
@@ -15,14 +15,17 @@
  */
 package androidx.media3.cast;
 
+import android.os.SystemClock;
 import android.util.SparseArray;
 import android.util.SparseIntArray;
 import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.Timeline;
+import androidx.media3.common.util.Util;
 import com.google.android.gms.cast.MediaInfo;
 import java.util.Arrays;
+import java.util.Objects;
 
 /** A {@link Timeline} for Cast media queues. */
 /* package */ final class CastTimeline extends Timeline {
@@ -35,20 +38,36 @@ import java.util.Arrays;
     /** Holds no media information. */
     public static final ItemData EMPTY =
         new ItemData(
-            /* durationUs= */ C.TIME_UNSET,
+            /* windowDurationUs= */ C.TIME_UNSET,
+            /* periodDurationUs= */ C.TIME_UNSET,
+            /* windowStartOffsetUs= */ C.TIME_UNSET,
             /* defaultPositionUs= */ C.TIME_UNSET,
             /* isLive= */ false,
+            /* isMovingLiveWindow= */ false,
             MediaItem.EMPTY,
             UNKNOWN_CONTENT_ID);
 
     /** The duration of the item in microseconds, or {@link C#TIME_UNSET} if unknown. */
-    public final long durationUs;
+    public final long windowDurationUs;
+    /** The window offset from the beginning of the period in microseconds. */
+    public final long windowStartOffsetUs;
+    /**
+     * The duration of the underlying period in microseconds, or {@link C#TIME_UNSET} if unknown.
+     * For vod content this will match the window duration. For live content this will be
+     * {@link C#TIME_UNSET} or the duration from 0 until the end of the stream.
+     */
+    public final long periodDurationUs;
     /**
      * The default start position of the item in microseconds, or {@link C#TIME_UNSET} if unknown.
      */
     public final long defaultPositionUs;
     /** Whether the item is live content, or {@code false} if unknown. */
     public final boolean isLive;
+    /**
+     * Whether the current seekable range is a fixed-length moving window (true) or if it is an
+     * expanding range (false). Only applicable if {@link #isLive} is true.
+     */
+    public final boolean isMovingLiveWindow;
     /** The original media item that has been set or added to the playlist. */
     public final MediaItem mediaItem;
     /** The {@linkplain MediaInfo#getContentId() content ID} of the cast media queue item. */
@@ -57,21 +76,30 @@ import java.util.Arrays;
     /**
      * Creates an instance.
      *
-     * @param durationUs See {@link #durationsUs}.
+     * @param windowDurationUs See {@link #windowDurationsUs}.
+     * @param periodDurationUs See {@link #periodDurationUs}.
+     * @param windowStartOffsetUs See {@link #windowStartOffsetUs}
      * @param defaultPositionUs See {@link #defaultPositionUs}.
      * @param isLive See {@link #isLive}.
+     * @param isMovingLiveWindow See {@link #isMovingLiveWindow}.
      * @param mediaItem See {@link #mediaItem}.
      * @param contentId See {@link #contentId}.
      */
     public ItemData(
-        long durationUs,
+        long windowDurationUs,
+        long periodDurationUs,
+        long windowStartOffsetUs,
         long defaultPositionUs,
         boolean isLive,
+        boolean isMovingLiveWindow,
         MediaItem mediaItem,
         String contentId) {
-      this.durationUs = durationUs;
+      this.windowDurationUs = windowDurationUs;
+      this.periodDurationUs = periodDurationUs;
+      this.windowStartOffsetUs = windowStartOffsetUs;
       this.defaultPositionUs = defaultPositionUs;
       this.isLive = isLive;
+      this.isMovingLiveWindow = isMovingLiveWindow;
       this.mediaItem = mediaItem;
       this.contentId = contentId;
     }
@@ -79,27 +107,36 @@ import java.util.Arrays;
     /**
      * Returns a copy of this instance with the given values.
      *
-     * @param durationUs The duration in microseconds, or {@link C#TIME_UNSET} if unknown.
-     * @param defaultPositionUs The default start position in microseconds, or {@link C#TIME_UNSET}
-     *     if unknown.
-     * @param isLive Whether the item is live, or {@code false} if unknown.
-     * @param mediaItem The media item.
-     * @param contentId The content ID.
+     * @param windowDurationUs See {@link #windowDurationsUs}.
+     * @param periodDurationUs See {@link #periodDurationUs}.
+     * @param windowStartOffsetUs See {@link #windowStartOffsetUs}
+     * @param defaultPositionUs See {@link #defaultPositionUs}.
+     * @param isLive See {@link #isLive}.
+     * @param isMovingLiveWindow See {@link #isMovingLiveWindow}.
+     * @param mediaItem See {@link #mediaItem}.
+     * @param contentId See {@link #contentId}.
      */
     public ItemData copyWithNewValues(
-        long durationUs,
+        long windowDurationUs,
+        long periodDurationUs,
+        long windowStartOffsetUs,
         long defaultPositionUs,
         boolean isLive,
+        boolean isMovingLiveWindow,
         MediaItem mediaItem,
         String contentId) {
-      if (durationUs == this.durationUs
+      if (windowDurationUs == this.windowDurationUs
+          && periodDurationUs == this.periodDurationUs
+          && windowStartOffsetUs == this.windowStartOffsetUs
           && defaultPositionUs == this.defaultPositionUs
           && isLive == this.isLive
+          && isMovingLiveWindow == this.isMovingLiveWindow
           && contentId.equals(this.contentId)
           && mediaItem.equals(this.mediaItem)) {
         return this;
       }
-      return new ItemData(durationUs, defaultPositionUs, isLive, mediaItem, contentId);
+      return new ItemData(windowDurationUs, periodDurationUs, windowStartOffsetUs,
+          defaultPositionUs, isLive, isMovingLiveWindow, mediaItem, contentId);
     }
   }
 
@@ -110,9 +147,13 @@ import java.util.Arrays;
   private final SparseIntArray idsToIndex;
   private final MediaItem[] mediaItems;
   private final int[] ids;
-  private final long[] durationsUs;
+  private final long[] windowDurationsUs;
+  private final long[] periodDurationsUs;
+  private final long[] windowStartOffsetUs;
   private final long[] defaultPositionsUs;
   private final boolean[] isLive;
+  private final boolean[] isMovingLiveWindow;
+  private final long creationUnixTimeMs;
 
   /**
    * Creates a Cast timeline from the given data.
@@ -121,21 +162,28 @@ import java.util.Arrays;
    * @param itemIdToData Maps item ids to {@link ItemData}.
    */
   public CastTimeline(int[] itemIds, SparseArray<ItemData> itemIdToData) {
+    creationUnixTimeMs = SystemClock.elapsedRealtime();
     int itemCount = itemIds.length;
     idsToIndex = new SparseIntArray(itemCount);
     ids = Arrays.copyOf(itemIds, itemCount);
-    durationsUs = new long[itemCount];
+    windowDurationsUs = new long[itemCount];
+    periodDurationsUs = new long[itemCount];
+    windowStartOffsetUs = new long[itemCount];
     defaultPositionsUs = new long[itemCount];
     isLive = new boolean[itemCount];
+    isMovingLiveWindow = new boolean[itemCount];
     mediaItems = new MediaItem[itemCount];
     for (int i = 0; i < ids.length; i++) {
       int id = ids[i];
       idsToIndex.put(id, i);
       ItemData data = itemIdToData.get(id, ItemData.EMPTY);
       mediaItems[i] = data.mediaItem;
-      durationsUs[i] = data.durationUs;
+      windowDurationsUs[i] = data.windowDurationUs;
+      periodDurationsUs[i] = data.periodDurationUs;
+      windowStartOffsetUs[i] = data.windowStartOffsetUs;
       defaultPositionsUs[i] = data.defaultPositionUs == C.TIME_UNSET ? 0 : data.defaultPositionUs;
       isLive[i] = data.isLive;
+      isMovingLiveWindow[i] = data.isMovingLiveWindow;
     }
   }
 
@@ -148,8 +196,22 @@ import java.util.Arrays;
 
   @Override
   public Window getWindow(int windowIndex, Window window, long defaultPositionProjectionUs) {
-    long durationUs = durationsUs[windowIndex];
-    boolean isDynamic = durationUs == C.TIME_UNSET;
+    long windowDurationUs = windowDurationsUs[windowIndex];
+    long periodDurationsUs = this.periodDurationsUs[windowIndex];
+    long windowStartOffsetUs = this.windowStartOffsetUs[windowIndex];
+
+    // Account for the elapsed time since this Timeline was created.
+    boolean windowIsLive = isLive[windowIndex];
+    if (windowIsLive && windowDurationUs != C.TIME_UNSET) {
+      long elapsedTimeUs = Util.msToUs(SystemClock.elapsedRealtime() - creationUnixTimeMs);
+      if (isMovingLiveWindow[windowIndex]) {
+        windowStartOffsetUs += elapsedTimeUs;
+      } else {
+        windowDurationUs += elapsedTimeUs;
+      }
+    }
+
+    boolean isDynamic = windowDurationUs == C.TIME_UNSET || windowDurationUs != periodDurationsUs;
     return window.set(
         /* uid= */ ids[windowIndex],
         /* mediaItem= */ mediaItems[windowIndex],
@@ -157,14 +219,14 @@ import java.util.Arrays;
         /* presentationStartTimeMs= */ C.TIME_UNSET,
         /* windowStartTimeMs= */ C.TIME_UNSET,
         /* elapsedRealtimeEpochOffsetMs= */ C.TIME_UNSET,
-        /* isSeekable= */ !isDynamic,
-        isDynamic,
-        isLive[windowIndex] ? mediaItems[windowIndex].liveConfiguration : null,
-        defaultPositionsUs[windowIndex],
-        durationUs,
+        /* isSeekable= */ windowDurationUs != C.TIME_UNSET,
+        /* isDynamic= */ isDynamic,
+        /* liveConfiguration= */ windowIsLive ? mediaItems[windowIndex].liveConfiguration : null,
+        /* defaultPositionUs= */ defaultPositionsUs[windowIndex],
+        /* durationUs= */ windowDurationUs,
         /* firstPeriodIndex= */ windowIndex,
         /* lastPeriodIndex= */ windowIndex,
-        /* positionInFirstPeriodUs= */ 0);
+        /* positionInFirstPeriodUs= */ windowStartOffsetUs);
   }
 
   @Override
@@ -175,7 +237,12 @@ import java.util.Arrays;
   @Override
   public Period getPeriod(int periodIndex, Period period, boolean setIds) {
     int id = ids[periodIndex];
-    return period.set(id, id, periodIndex, durationsUs[periodIndex], 0);
+    long positionInWindowUs = -windowStartOffsetUs[periodIndex];
+    if (isLive[periodIndex] && isMovingLiveWindow[periodIndex]) {
+      long elapsedTimeUs = Util.msToUs(SystemClock.elapsedRealtime() - creationUnixTimeMs);
+      positionInWindowUs -= elapsedTimeUs;
+    }
+    return period.set(id, id, periodIndex, periodDurationsUs[periodIndex], positionInWindowUs);
   }
 
   @Override
@@ -199,17 +266,25 @@ import java.util.Arrays;
     }
     CastTimeline that = (CastTimeline) other;
     return Arrays.equals(ids, that.ids)
-        && Arrays.equals(durationsUs, that.durationsUs)
+        && creationUnixTimeMs == that.creationUnixTimeMs
+        && Arrays.equals(windowDurationsUs, that.windowDurationsUs)
+        && Arrays.equals(periodDurationsUs, that.periodDurationsUs)
+        && Arrays.equals(windowStartOffsetUs, that.windowStartOffsetUs)
         && Arrays.equals(defaultPositionsUs, that.defaultPositionsUs)
-        && Arrays.equals(isLive, that.isLive);
+        && Arrays.equals(isLive, that.isLive)
+        && Arrays.equals(isMovingLiveWindow, that.isMovingLiveWindow);
   }
 
   @Override
   public int hashCode() {
-    int result = Arrays.hashCode(ids);
-    result = 31 * result + Arrays.hashCode(durationsUs);
+    int result = Objects.hash(super.hashCode(), creationUnixTimeMs);
+    result = 31 * result + Arrays.hashCode(ids);
+    result = 31 * result + Arrays.hashCode(windowDurationsUs);
+    result = 31 * result + Arrays.hashCode(periodDurationsUs);
+    result = 31 * result + Arrays.hashCode(windowStartOffsetUs);
     result = 31 * result + Arrays.hashCode(defaultPositionsUs);
     result = 31 * result + Arrays.hashCode(isLive);
+    result = 31 * result + Arrays.hashCode(isMovingLiveWindow);
     return result;
   }
 }

--- a/libraries/cast/src/main/java/androidx/media3/cast/CastTimeline.java
+++ b/libraries/cast/src/main/java/androidx/media3/cast/CastTimeline.java
@@ -41,7 +41,6 @@ import java.util.Objects;
             /* windowDurationUs= */ C.TIME_UNSET,
             /* periodDurationUs= */ C.TIME_UNSET,
             /* windowStartOffsetUs= */ C.TIME_UNSET,
-            /* defaultPositionUs= */ C.TIME_UNSET,
             /* isLive= */ false,
             /* isMovingLiveWindow= */ false,
             MediaItem.EMPTY,
@@ -57,10 +56,6 @@ import java.util.Objects;
      * {@link C#TIME_UNSET} or the duration from 0 until the end of the stream.
      */
     public final long periodDurationUs;
-    /**
-     * The default start position of the item in microseconds, or {@link C#TIME_UNSET} if unknown.
-     */
-    public final long defaultPositionUs;
     /** Whether the item is live content, or {@code false} if unknown. */
     public final boolean isLive;
     /**
@@ -79,7 +74,6 @@ import java.util.Objects;
      * @param windowDurationUs See {@link #windowDurationsUs}.
      * @param periodDurationUs See {@link #periodDurationUs}.
      * @param windowStartOffsetUs See {@link #windowStartOffsetUs}
-     * @param defaultPositionUs See {@link #defaultPositionUs}.
      * @param isLive See {@link #isLive}.
      * @param isMovingLiveWindow See {@link #isMovingLiveWindow}.
      * @param mediaItem See {@link #mediaItem}.
@@ -89,7 +83,6 @@ import java.util.Objects;
         long windowDurationUs,
         long periodDurationUs,
         long windowStartOffsetUs,
-        long defaultPositionUs,
         boolean isLive,
         boolean isMovingLiveWindow,
         MediaItem mediaItem,
@@ -97,7 +90,6 @@ import java.util.Objects;
       this.windowDurationUs = windowDurationUs;
       this.periodDurationUs = periodDurationUs;
       this.windowStartOffsetUs = windowStartOffsetUs;
-      this.defaultPositionUs = defaultPositionUs;
       this.isLive = isLive;
       this.isMovingLiveWindow = isMovingLiveWindow;
       this.mediaItem = mediaItem;
@@ -110,7 +102,6 @@ import java.util.Objects;
      * @param windowDurationUs See {@link #windowDurationsUs}.
      * @param periodDurationUs See {@link #periodDurationUs}.
      * @param windowStartOffsetUs See {@link #windowStartOffsetUs}
-     * @param defaultPositionUs See {@link #defaultPositionUs}.
      * @param isLive See {@link #isLive}.
      * @param isMovingLiveWindow See {@link #isMovingLiveWindow}.
      * @param mediaItem See {@link #mediaItem}.
@@ -120,7 +111,6 @@ import java.util.Objects;
         long windowDurationUs,
         long periodDurationUs,
         long windowStartOffsetUs,
-        long defaultPositionUs,
         boolean isLive,
         boolean isMovingLiveWindow,
         MediaItem mediaItem,
@@ -128,7 +118,6 @@ import java.util.Objects;
       if (windowDurationUs == this.windowDurationUs
           && periodDurationUs == this.periodDurationUs
           && windowStartOffsetUs == this.windowStartOffsetUs
-          && defaultPositionUs == this.defaultPositionUs
           && isLive == this.isLive
           && isMovingLiveWindow == this.isMovingLiveWindow
           && contentId.equals(this.contentId)
@@ -136,7 +125,7 @@ import java.util.Objects;
         return this;
       }
       return new ItemData(windowDurationUs, periodDurationUs, windowStartOffsetUs,
-          defaultPositionUs, isLive, isMovingLiveWindow, mediaItem, contentId);
+          isLive, isMovingLiveWindow, mediaItem, contentId);
     }
   }
 
@@ -150,7 +139,6 @@ import java.util.Objects;
   private final long[] windowDurationsUs;
   private final long[] periodDurationsUs;
   private final long[] windowStartOffsetUs;
-  private final long[] defaultPositionsUs;
   private final boolean[] isLive;
   private final boolean[] isMovingLiveWindow;
   private final long creationUnixTimeMs;
@@ -169,7 +157,6 @@ import java.util.Objects;
     windowDurationsUs = new long[itemCount];
     periodDurationsUs = new long[itemCount];
     windowStartOffsetUs = new long[itemCount];
-    defaultPositionsUs = new long[itemCount];
     isLive = new boolean[itemCount];
     isMovingLiveWindow = new boolean[itemCount];
     mediaItems = new MediaItem[itemCount];
@@ -181,7 +168,6 @@ import java.util.Objects;
       windowDurationsUs[i] = data.windowDurationUs;
       periodDurationsUs[i] = data.periodDurationUs;
       windowStartOffsetUs[i] = data.windowStartOffsetUs;
-      defaultPositionsUs[i] = data.defaultPositionUs == C.TIME_UNSET ? 0 : data.defaultPositionUs;
       isLive[i] = data.isLive;
       isMovingLiveWindow[i] = data.isMovingLiveWindow;
     }
@@ -222,7 +208,7 @@ import java.util.Objects;
         /* isSeekable= */ windowDurationUs != C.TIME_UNSET,
         /* isDynamic= */ isDynamic,
         /* liveConfiguration= */ windowIsLive ? mediaItems[windowIndex].liveConfiguration : null,
-        /* defaultPositionUs= */ defaultPositionsUs[windowIndex],
+        /* defaultPositionUs= */ (windowIsLive && isDynamic) ? windowDurationUs : 0,
         /* durationUs= */ windowDurationUs,
         /* firstPeriodIndex= */ windowIndex,
         /* lastPeriodIndex= */ windowIndex,
@@ -270,7 +256,6 @@ import java.util.Objects;
         && Arrays.equals(windowDurationsUs, that.windowDurationsUs)
         && Arrays.equals(periodDurationsUs, that.periodDurationsUs)
         && Arrays.equals(windowStartOffsetUs, that.windowStartOffsetUs)
-        && Arrays.equals(defaultPositionsUs, that.defaultPositionsUs)
         && Arrays.equals(isLive, that.isLive)
         && Arrays.equals(isMovingLiveWindow, that.isMovingLiveWindow);
   }
@@ -282,7 +267,6 @@ import java.util.Objects;
     result = 31 * result + Arrays.hashCode(windowDurationsUs);
     result = 31 * result + Arrays.hashCode(periodDurationsUs);
     result = 31 * result + Arrays.hashCode(windowStartOffsetUs);
-    result = 31 * result + Arrays.hashCode(defaultPositionsUs);
     result = 31 * result + Arrays.hashCode(isLive);
     result = 31 * result + Arrays.hashCode(isMovingLiveWindow);
     return result;

--- a/libraries/cast/src/main/java/androidx/media3/cast/CastTimelineTracker.java
+++ b/libraries/cast/src/main/java/androidx/media3/cast/CastTimelineTracker.java
@@ -117,7 +117,6 @@ import java.util.List;
 
     for (MediaQueueItem queueItem : mediaStatus.getQueueItems()) {
       int itemId = queueItem.getItemId();
-      long defaultPositionUs = (long) (queueItem.getStartTime() * C.MICROS_PER_SECOND);
       @Nullable MediaInfo mediaInfo = queueItem.getMedia();
       String contentId = mediaInfo != null ? mediaInfo.getContentId() : UNKNOWN_CONTENT_ID;
       @Nullable MediaItem existingMediaItem = mediaItemsByContentId.get(contentId);
@@ -131,8 +130,7 @@ import java.util.List;
             contentId,
             mediaItem,
             mediaStatus.getMediaInfo(),
-            mediaStatus.getLiveSeekableRange(),
-            defaultPositionUs);
+            mediaStatus.getLiveSeekableRange());
         currentItemDataSet = true;
       } else {
         updateItemData(
@@ -140,8 +138,7 @@ import java.util.List;
             contentId,
             mediaItem,
             mediaInfo,
-            null,
-            defaultPositionUs);
+            null);
       }
     }
 
@@ -154,8 +151,7 @@ import java.util.List;
           currentContentId,
           mediaItem != null ? mediaItem : MediaItem.EMPTY,
           mediaStatus.getMediaInfo(),
-          mediaStatus.getLiveSeekableRange(),
-          C.TIME_UNSET);
+          mediaStatus.getLiveSeekableRange());
     }
     return new CastTimeline(itemIds, itemIdToData);
   }
@@ -165,8 +161,7 @@ import java.util.List;
       String contentId,
       MediaItem mediaItem,
       @Nullable MediaInfo mediaInfo,
-      @Nullable MediaLiveSeekableRange liveSeekableRange,
-      long defaultPositionUs) {
+      @Nullable MediaLiveSeekableRange liveSeekableRange) {
     CastTimeline.ItemData previousData = itemIdToData.get(itemId, CastTimeline.ItemData.EMPTY);
     boolean isLive = mediaInfo == null
             ? previousData.isLive
@@ -203,8 +198,8 @@ import java.util.List;
     }
 
     CastTimeline.ItemData itemData = previousData
-        .copyWithNewValues(windowDurationUs, periodDurationUs, windowOffsetUs, defaultPositionUs,
-            isLive, isMovingLiveWindow, mediaItem, contentId);
+        .copyWithNewValues(windowDurationUs, periodDurationUs, windowOffsetUs, isLive,
+            isMovingLiveWindow, mediaItem, contentId);
     itemIdToData.put(itemId, itemData);
   }
 


### PR DESCRIPTION
Currently the seekable range of live streams is not exposed in the CastPlayer.
The duration is always reported as C.TIME_UNSET.

This PR checks the media status of the active item for a LiveSeekableRange and exposes it over the `CastTimeline`.  
Because the Timeline is only updated on status changed callbacks from the cast sdk (which are not send for livestream range changes) it would be outdated immediately.
To avoid this issue the `CastTimeline` stores it's creation timestamp and adjusts the reported window according to the elapsed time. This is similar to the internal behavior of the `RemoteMediaClient`.