### PR TITLE
Add luma & chroma bit depths to Format

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,8 @@
 
 *   Common Library:
 *   ExoPlayer:
+    *   Add luma and chroma bitdepth to `ColorInfo`
+        [#491](https://github.com/androidx/media/pull/491).
 *   Transformer:
 *   Track Selection:
     *   Add `DefaultTrackSelector.Parameters.allowAudioNonSeamlessAdaptiveness`

--- a/libraries/common/src/main/java/androidx/media3/common/ColorInfo.java
+++ b/libraries/common/src/main/java/androidx/media3/common/ColorInfo.java
@@ -288,10 +288,27 @@ public final class ColorInfo implements Bundleable {
   /**
    * Returns whether this instance is valid.
    *
-   * <p>This instance is valid if no color members are {@link Format#NO_VALUE}, while bit depths may
-   * be unset.
+   * <p>This instance is valid if at least one between bitdepths and color info are valid.
    */
   public boolean isValid() {
+    return isBitdepthValid() || isColorValid();
+  }
+
+  /**
+   * Returns whether this instance has valid bitdepths.
+   *
+   * <p>This instance has valid bitdepths if none of them is {@link Format#NO_VALUE}.
+   */
+  public boolean isBitdepthValid() {
+    return lumaBitdepth != Format.NO_VALUE && chromaBitdepth != Format.NO_VALUE;
+  }
+
+  /**
+   * Returns whether this instance is color valid.
+   *
+   * <p>This instance is valid if no color members are {@link Format#NO_VALUE}.
+   */
+  public boolean isColorValid() {
     return colorSpace != Format.NO_VALUE
         && colorRange != Format.NO_VALUE
         && colorTransfer != Format.NO_VALUE;
@@ -302,29 +319,17 @@ public final class ColorInfo implements Bundleable {
    *
    * @see Format#toLogString(Format)
    */
-  public String toColorString() {
+  public String toLogString() {
     if (!isValid()) {
       return "NA";
     }
 
-    return Util.formatInvariant(
-        "%s/%s/%s",
+    String bitdepthsString = isBitdepthValid() ? lumaBitdepth + "/" + chromaBitdepth : "NA";
+    String colorString = isColorValid() ? Util.formatInvariant("%s/%s/%s",
         colorSpaceToString(colorSpace),
         colorRangeToString(colorRange),
-        colorTransferToString(colorTransfer));
-  }
-
-  /**
-   * Returns whether this instance has valid bitdepths.
-   *
-   * <p>This instance has valid bitdepths if none of them is {@link Format#NO_VALUE}.
-   */
-  public boolean isBppValid() {
-    return lumaBitdepth != Format.NO_VALUE && chromaBitdepth != Format.NO_VALUE;
-  }
-
-  public String toBppString() {
-    return isBppValid() ? lumaBitdepth + "," + chromaBitdepth : "NA";
+        colorTransferToString(colorTransfer)) : "NA";
+    return bitdepthsString + "/" + colorString;
   }
 
   @Override
@@ -347,9 +352,9 @@ public final class ColorInfo implements Bundleable {
   @Override
   public String toString() {
     return "ColorInfo("
-        + lumaBitdepth
+        + lumaBitdepthToString(lumaBitdepth)
         + ", "
-        + chromaBitdepth
+        + chromaBitdepthToString(chromaBitdepth)
         + ", "
         + colorSpaceToString(colorSpace)
         + ", "
@@ -359,6 +364,14 @@ public final class ColorInfo implements Bundleable {
         + ", "
         + (hdrStaticInfo != null)
         + ")";
+  }
+
+  private static String lumaBitdepthToString(int val) {
+    return val != Format.NO_VALUE ? val + "bit Luma" : "NA";
+  }
+
+  private static String chromaBitdepthToString(int val) {
+    return val != Format.NO_VALUE ? val + "bit Chroma" : "NA";
   }
 
   private static String colorSpaceToString(@C.ColorSpace int colorSpace) {

--- a/libraries/common/src/main/java/androidx/media3/common/ColorInfo.java
+++ b/libraries/common/src/main/java/androidx/media3/common/ColorInfo.java
@@ -22,6 +22,9 @@ import androidx.media3.common.util.Util;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Arrays;
 import org.checkerframework.dataflow.qual.Pure;
+// copybara:exo-only import com.google.android.exoplayer2.Bundleable;
+// copybara:exo-only import com.google.android.exoplayer2.C;
+// copybara:exo-only import com.google.android.exoplayer2.Format;
 
 /**
  * Stores color info.
@@ -320,11 +323,6 @@ public final class ColorInfo implements Bundleable {
    * @see Format#toLogString(Format)
    */
   public String toLogString() {
-    if (!isValid()) {
-      return "NA";
-    }
-
-    String bitdepthsString = isBitdepthValid() ? lumaBitdepth + "/" + chromaBitdepth : "NA";
     String dataspaceString =
         isDataSpaceValid()
             ? Util.formatInvariant(
@@ -332,8 +330,9 @@ public final class ColorInfo implements Bundleable {
                 colorSpaceToString(colorSpace),
                 colorRangeToString(colorRange),
                 colorTransferToString(colorTransfer))
-            : "NA";
-    return bitdepthsString + "/" + dataspaceString;
+            : "NA/NA/NA";
+    String bitdepthsString = isBitdepthValid() ? lumaBitdepth + "/" + chromaBitdepth : "NA/NA";
+    return dataspaceString + "/" + bitdepthsString;
   }
 
   @Override
@@ -354,12 +353,23 @@ public final class ColorInfo implements Bundleable {
   }
 
   @Override
+  public int hashCode() {
+    if (hashCode == 0) {
+      int result = 17;
+      result = 31 * result + colorSpace;
+      result = 31 * result + colorRange;
+      result = 31 * result + colorTransfer;
+      result = 31 * result + Arrays.hashCode(hdrStaticInfo);
+      result = 31 * result + lumaBitdepth;
+      result = 31 * result + chromaBitdepth;
+      hashCode = result;
+    }
+    return hashCode;
+  }
+
+  @Override
   public String toString() {
     return "ColorInfo("
-        + lumaBitdepthToString(lumaBitdepth)
-        + ", "
-        + chromaBitdepthToString(chromaBitdepth)
-        + ", "
         + colorSpaceToString(colorSpace)
         + ", "
         + colorRangeToString(colorRange)
@@ -367,6 +377,10 @@ public final class ColorInfo implements Bundleable {
         + colorTransferToString(colorTransfer)
         + ", "
         + (hdrStaticInfo != null)
+        + ", "
+        + lumaBitdepthToString(lumaBitdepth)
+        + ", "
+        + chromaBitdepthToString(chromaBitdepth)
         + ")";
   }
 
@@ -392,6 +406,7 @@ public final class ColorInfo implements Bundleable {
       default:
         return "Undefined color space";
     }
+    // LINT.ThenChange(C.java:color_space)
   }
 
   private static String colorTransferToString(@C.ColorTransfer int colorTransfer) {
@@ -414,6 +429,7 @@ public final class ColorInfo implements Bundleable {
       default:
         return "Undefined color transfer";
     }
+    // LINT.ThenChange(C.java:color_transfer)
   }
 
   private static String colorRangeToString(@C.ColorRange int colorRange) {
@@ -428,21 +444,7 @@ public final class ColorInfo implements Bundleable {
       default:
         return "Undefined color range";
     }
-  }
-
-  @Override
-  public int hashCode() {
-    if (hashCode == 0) {
-      int result = 17;
-      result = 31 * result + colorSpace;
-      result = 31 * result + colorRange;
-      result = 31 * result + colorTransfer;
-      result = 31 * result + Arrays.hashCode(hdrStaticInfo);
-      result = 31 * result + lumaBitdepth;
-      result = 31 * result + chromaBitdepth;
-      hashCode = result;
-    }
-    return hashCode;
+    // LINT.ThenChange(C.java:color_range)
   }
 
   // Bundleable implementation

--- a/libraries/common/src/main/java/androidx/media3/common/ColorInfo.java
+++ b/libraries/common/src/main/java/androidx/media3/common/ColorInfo.java
@@ -288,10 +288,10 @@ public final class ColorInfo implements Bundleable {
   /**
    * Returns whether this instance is valid.
    *
-   * <p>This instance is valid if at least one between bitdepths and color info are valid.
+   * <p>This instance is valid if at least one between bitdepths and DataSpace info are valid.
    */
   public boolean isValid() {
-    return isBitdepthValid() || isColorValid();
+    return isBitdepthValid() || isDataSpaceValid();
   }
 
   /**
@@ -304,11 +304,11 @@ public final class ColorInfo implements Bundleable {
   }
 
   /**
-   * Returns whether this instance is color valid.
+   * Returns whether this instance has valid DataSpace members.
    *
-   * <p>This instance is valid if no color members are {@link Format#NO_VALUE}.
+   * <p>This instance is valid if no DataSpace members are {@link Format#NO_VALUE}.
    */
-  public boolean isColorValid() {
+  public boolean isDataSpaceValid() {
     return colorSpace != Format.NO_VALUE
         && colorRange != Format.NO_VALUE
         && colorTransfer != Format.NO_VALUE;
@@ -325,11 +325,11 @@ public final class ColorInfo implements Bundleable {
     }
 
     String bitdepthsString = isBitdepthValid() ? lumaBitdepth + "/" + chromaBitdepth : "NA";
-    String colorString = isColorValid() ? Util.formatInvariant("%s/%s/%s",
+    String dataspaceString = isDataSpaceValid() ? Util.formatInvariant("%s/%s/%s",
         colorSpaceToString(colorSpace),
         colorRangeToString(colorRange),
         colorTransferToString(colorTransfer)) : "NA";
-    return bitdepthsString + "/" + colorString;
+    return bitdepthsString + "/" + dataspaceString;
   }
 
   @Override

--- a/libraries/common/src/main/java/androidx/media3/common/ColorInfo.java
+++ b/libraries/common/src/main/java/androidx/media3/common/ColorInfo.java
@@ -125,7 +125,7 @@ public final class ColorInfo implements Bundleable {
     /**
      * Sets the luma bit depth.
      *
-     * @param lumaBitdepth The lumaBitdepth.  The default value is {@link Format#NO_VALUE}.
+     * @param lumaBitdepth The lumaBitdepth. The default value is {@link Format#NO_VALUE}.
      * @return The builder.
      */
     @CanIgnoreReturnValue
@@ -148,7 +148,8 @@ public final class ColorInfo implements Bundleable {
 
     /** Builds a new {@link ColorInfo} instance. */
     public ColorInfo build() {
-      return new ColorInfo(colorSpace, colorRange, colorTransfer, hdrStaticInfo, lumaBitdepth, chromaBitdepth);
+      return new ColorInfo(
+          colorSpace, colorRange, colorTransfer, hdrStaticInfo, lumaBitdepth, chromaBitdepth);
     }
   }
 
@@ -245,6 +246,7 @@ public final class ColorInfo implements Bundleable {
 
   /** The bit depth of the luma samples of the video. */
   public final int lumaBitdepth;
+
   /** The bit depth of the chroma samples of the video. It may differ from the luma bit depth. */
   public final int chromaBitdepth;
 
@@ -286,8 +288,8 @@ public final class ColorInfo implements Bundleable {
   /**
    * Returns whether this instance is valid.
    *
-   * <p>This instance is valid if no color members are {@link Format#NO_VALUE},
-   *  while bit depths may be unset.
+   * <p>This instance is valid if no color members are {@link Format#NO_VALUE}, while bit depths may
+   * be unset.
    */
   public boolean isValid() {
     return colorSpace != Format.NO_VALUE
@@ -318,8 +320,7 @@ public final class ColorInfo implements Bundleable {
    * <p>This instance has valid bitdepths if none of them is {@link Format#NO_VALUE}.
    */
   public boolean isBppValid() {
-    return lumaBitdepth != Format.NO_VALUE
-        && chromaBitdepth != Format.NO_VALUE;
+    return lumaBitdepth != Format.NO_VALUE && chromaBitdepth != Format.NO_VALUE;
   }
 
   public String toBppString() {

--- a/libraries/common/src/main/java/androidx/media3/common/ColorInfo.java
+++ b/libraries/common/src/main/java/androidx/media3/common/ColorInfo.java
@@ -22,6 +22,7 @@ import androidx.media3.common.util.Util;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Arrays;
 import org.checkerframework.dataflow.qual.Pure;
+
 // copybara:exo-only import com.google.android.exoplayer2.Bundleable;
 // copybara:exo-only import com.google.android.exoplayer2.C;
 // copybara:exo-only import com.google.android.exoplayer2.Format;
@@ -255,6 +256,24 @@ public final class ColorInfo implements Bundleable {
 
   // Lazily initialized hashcode.
   private int hashCode;
+
+  /**
+   * Constructs the ColorInfo.
+   *
+   * @param colorSpace The color space of the video.
+   * @param colorRange The color range of the video.
+   * @param colorTransfer The color transfer characteristics of the video.
+   * @param hdrStaticInfo HdrStaticInfo as defined in CTA-861.3, or null if none specified.
+   * @deprecated Use {@link Builder}.
+   */
+  @Deprecated
+  public ColorInfo(
+      @C.ColorSpace int colorSpace,
+      @C.ColorRange int colorRange,
+      @C.ColorTransfer int colorTransfer,
+      @Nullable byte[] hdrStaticInfo) {
+    this(colorSpace, colorRange, colorTransfer, hdrStaticInfo, Format.NO_VALUE, Format.NO_VALUE);
+  }
 
   /**
    * Constructs the ColorInfo.

--- a/libraries/common/src/main/java/androidx/media3/common/ColorInfo.java
+++ b/libraries/common/src/main/java/androidx/media3/common/ColorInfo.java
@@ -325,10 +325,14 @@ public final class ColorInfo implements Bundleable {
     }
 
     String bitdepthsString = isBitdepthValid() ? lumaBitdepth + "/" + chromaBitdepth : "NA";
-    String dataspaceString = isDataSpaceValid() ? Util.formatInvariant("%s/%s/%s",
-        colorSpaceToString(colorSpace),
-        colorRangeToString(colorRange),
-        colorTransferToString(colorTransfer)) : "NA";
+    String dataspaceString =
+        isDataSpaceValid()
+            ? Util.formatInvariant(
+                "%s/%s/%s",
+                colorSpaceToString(colorSpace),
+                colorRangeToString(colorRange),
+                colorTransferToString(colorTransfer))
+            : "NA";
     return bitdepthsString + "/" + dataspaceString;
   }
 

--- a/libraries/common/src/main/java/androidx/media3/common/Format.java
+++ b/libraries/common/src/main/java/androidx/media3/common/Format.java
@@ -1260,7 +1260,7 @@ public final class Format implements Bundleable {
       builder.append(", res=").append(format.width).append("x").append(format.height);
     }
     if (format.colorInfo != null && format.colorInfo.isValid()) {
-      builder.append(", color=").append(format.colorInfo.toColorString());
+      builder.append(", color=").append(format.colorInfo.toLogString());
     }
     if (format.frameRate != NO_VALUE) {
       builder.append(", fps=").append(format.frameRate);

--- a/libraries/common/src/main/java/androidx/media3/common/Format.java
+++ b/libraries/common/src/main/java/androidx/media3/common/Format.java
@@ -96,8 +96,6 @@ import java.util.UUID;
  *   <li>{@link #projectionData}
  *   <li>{@link #stereoMode}
  *   <li>{@link #colorInfo}
- *   <li>{@link #lumaBitdepth}
- *   <li>{@link #chromaBitdepth}
  * </ul>
  *
  * <h2 id="audio-formats">Fields relevant to audio formats</h2>
@@ -169,8 +167,6 @@ public final class Format implements Bundleable {
     @Nullable private byte[] projectionData;
     private @C.StereoMode int stereoMode;
     @Nullable private ColorInfo colorInfo;
-    private int lumaBitdepth;
-    private int chromaBitdepth;
 
     // Audio specific.
 
@@ -207,8 +203,6 @@ public final class Format implements Bundleable {
       frameRate = NO_VALUE;
       pixelWidthHeightRatio = 1.0f;
       stereoMode = NO_VALUE;
-      lumaBitdepth = 8;
-      chromaBitdepth = 8;
       // Audio specific.
       channelCount = NO_VALUE;
       sampleRate = NO_VALUE;
@@ -255,8 +249,6 @@ public final class Format implements Bundleable {
       this.projectionData = format.projectionData;
       this.stereoMode = format.stereoMode;
       this.colorInfo = format.colorInfo;
-      this.lumaBitdepth = format.lumaBitdepth;
-      this.chromaBitdepth = format.chromaBitdepth;
       // Audio specific.
       this.channelCount = format.channelCount;
       this.sampleRate = format.sampleRate;
@@ -565,30 +557,6 @@ public final class Format implements Bundleable {
     @CanIgnoreReturnValue
     public Builder setColorInfo(@Nullable ColorInfo colorInfo) {
       this.colorInfo = colorInfo;
-      return this;
-    }
-
-    /**
-     * Sets {@link Format#lumaBitdepth}. The default value is 8.
-     *
-     * @param lumaBitdepth The {@link Format#lumaBitdepth}.
-     * @return The builder.
-     */
-    @CanIgnoreReturnValue
-    public Builder setLumaBitdepth(int lumaBitdepth) {
-      this.lumaBitdepth = lumaBitdepth;
-      return this;
-    }
-
-    /**
-     * Sets {@link Format#chromaBitdepth}. The default value is 8.
-     *
-     * @param chromaBitdepth The {@link Format#chromaBitdepth}.
-     * @return The builder.
-     */
-    @CanIgnoreReturnValue
-    public Builder setChromaBitdepth(int chromaBitdepth) {
-      this.chromaBitdepth = chromaBitdepth;
       return this;
     }
 
@@ -904,10 +872,6 @@ public final class Format implements Bundleable {
 
   /** The color metadata associated with the video, or null if not applicable. */
   @UnstableApi @Nullable public final ColorInfo colorInfo;
-  /** The bit depth of the luma samples of the video. */
-  public final int lumaBitdepth;
-  /** The bit depth of the chroma samples of the video. It might differ from the luma bit depth. */
-  public final int chromaBitdepth;
 
   // Audio specific.
 
@@ -995,8 +959,6 @@ public final class Format implements Bundleable {
     projectionData = builder.projectionData;
     stereoMode = builder.stereoMode;
     colorInfo = builder.colorInfo;
-    lumaBitdepth = builder.lumaBitdepth;
-    chromaBitdepth = builder.chromaBitdepth;
     // Audio specific.
     channelCount = builder.channelCount;
     sampleRate = builder.sampleRate;
@@ -1130,10 +1092,6 @@ public final class Format implements Bundleable {
         + ", "
         + frameRate
         + ", "
-        + lumaBitdepth
-        + ", "
-        + chromaBitdepth
-        + ", "
         + colorInfo
         + "]"
         + ", ["
@@ -1174,8 +1132,6 @@ public final class Format implements Bundleable {
       // [Omitted] projectionData.
       result = 31 * result + stereoMode;
       // [Omitted] colorInfo.
-      result = 31 * result + lumaBitdepth;
-      result = 31 * result + chromaBitdepth;
       // Audio specific.
       result = 31 * result + channelCount;
       result = 31 * result + sampleRate;
@@ -1217,8 +1173,6 @@ public final class Format implements Bundleable {
         && height == other.height
         && rotationDegrees == other.rotationDegrees
         && stereoMode == other.stereoMode
-        && lumaBitdepth == other.lumaBitdepth
-        && chromaBitdepth == other.chromaBitdepth
         && channelCount == other.channelCount
         && sampleRate == other.sampleRate
         && pcmEncoding == other.pcmEncoding
@@ -1305,11 +1259,8 @@ public final class Format implements Bundleable {
     if (format.width != NO_VALUE && format.height != NO_VALUE) {
       builder.append(", res=").append(format.width).append("x").append(format.height);
     }
-    if (format.lumaBitdepth != NO_VALUE && format.chromaBitdepth != NO_VALUE) {
-      builder.append(", bitdepth=[").append(format.lumaBitdepth).append(",").append(format.chromaBitdepth).append(']');
-    }
     if (format.colorInfo != null && format.colorInfo.isValid()) {
-      builder.append(", color=").append(format.colorInfo.toLogString());
+      builder.append(", color=").append(format.colorInfo.toColorString());
     }
     if (format.frameRate != NO_VALUE) {
       builder.append(", fps=").append(format.frameRate);
@@ -1422,17 +1373,15 @@ public final class Format implements Bundleable {
   private static final String FIELD_PROJECTION_DATA = Util.intToStringMaxRadix(20);
   private static final String FIELD_STEREO_MODE = Util.intToStringMaxRadix(21);
   private static final String FIELD_COLOR_INFO = Util.intToStringMaxRadix(22);
-  private static final String FIELD_LUMA_BITDEPTH = Util.intToStringMaxRadix(23);
-  private static final String FIELD_CHROMA_BITDEPTH = Util.intToStringMaxRadix(24);
-  private static final String FIELD_CHANNEL_COUNT = Util.intToStringMaxRadix(25);
-  private static final String FIELD_SAMPLE_RATE = Util.intToStringMaxRadix(26);
-  private static final String FIELD_PCM_ENCODING = Util.intToStringMaxRadix(27);
-  private static final String FIELD_ENCODER_DELAY = Util.intToStringMaxRadix(28);
-  private static final String FIELD_ENCODER_PADDING = Util.intToStringMaxRadix(29);
-  private static final String FIELD_ACCESSIBILITY_CHANNEL = Util.intToStringMaxRadix(30);
-  private static final String FIELD_CRYPTO_TYPE = Util.intToStringMaxRadix(31);
-  private static final String FIELD_TILE_COUNT_HORIZONTAL = Util.intToStringMaxRadix(32);
-  private static final String FIELD_TILE_COUNT_VERTICAL = Util.intToStringMaxRadix(33);
+  private static final String FIELD_CHANNEL_COUNT = Util.intToStringMaxRadix(23);
+  private static final String FIELD_SAMPLE_RATE = Util.intToStringMaxRadix(24);
+  private static final String FIELD_PCM_ENCODING = Util.intToStringMaxRadix(25);
+  private static final String FIELD_ENCODER_DELAY = Util.intToStringMaxRadix(26);
+  private static final String FIELD_ENCODER_PADDING = Util.intToStringMaxRadix(27);
+  private static final String FIELD_ACCESSIBILITY_CHANNEL = Util.intToStringMaxRadix(28);
+  private static final String FIELD_CRYPTO_TYPE = Util.intToStringMaxRadix(29);
+  private static final String FIELD_TILE_COUNT_HORIZONTAL = Util.intToStringMaxRadix(30);
+  private static final String FIELD_TILE_COUNT_VERTICAL = Util.intToStringMaxRadix(31);
 
   @UnstableApi
   @Override
@@ -1482,8 +1431,6 @@ public final class Format implements Bundleable {
     if (colorInfo != null) {
       bundle.putBundle(FIELD_COLOR_INFO, colorInfo.toBundle());
     }
-    bundle.putInt(FIELD_LUMA_BITDEPTH, lumaBitdepth);
-    bundle.putInt(FIELD_CHROMA_BITDEPTH, chromaBitdepth);
     // Audio specific.
     bundle.putInt(FIELD_CHANNEL_COUNT, channelCount);
     bundle.putInt(FIELD_SAMPLE_RATE, sampleRate);
@@ -1549,8 +1496,6 @@ public final class Format implements Bundleable {
     if (colorInfoBundle != null) {
       builder.setColorInfo(ColorInfo.CREATOR.fromBundle(colorInfoBundle));
     }
-    builder.setLumaBitdepth(bundle.getInt(FIELD_LUMA_BITDEPTH, DEFAULT.lumaBitdepth));
-    builder.setChromaBitdepth(bundle.getInt(FIELD_CHROMA_BITDEPTH, DEFAULT.chromaBitdepth));
     // Audio specific.
     builder
         .setChannelCount(bundle.getInt(FIELD_CHANNEL_COUNT, DEFAULT.channelCount))

--- a/libraries/common/src/main/java/androidx/media3/common/Format.java
+++ b/libraries/common/src/main/java/androidx/media3/common/Format.java
@@ -96,6 +96,8 @@ import java.util.UUID;
  *   <li>{@link #projectionData}
  *   <li>{@link #stereoMode}
  *   <li>{@link #colorInfo}
+ *   <li>{@link #lumaBitdepth}
+ *   <li>{@link #chromaBitdepth}
  * </ul>
  *
  * <h2 id="audio-formats">Fields relevant to audio formats</h2>
@@ -167,6 +169,8 @@ public final class Format implements Bundleable {
     @Nullable private byte[] projectionData;
     private @C.StereoMode int stereoMode;
     @Nullable private ColorInfo colorInfo;
+    private int lumaBitdepth;
+    private int chromaBitdepth;
 
     // Audio specific.
 
@@ -203,6 +207,8 @@ public final class Format implements Bundleable {
       frameRate = NO_VALUE;
       pixelWidthHeightRatio = 1.0f;
       stereoMode = NO_VALUE;
+      lumaBitdepth = 8;
+      chromaBitdepth = 8;
       // Audio specific.
       channelCount = NO_VALUE;
       sampleRate = NO_VALUE;
@@ -249,6 +255,8 @@ public final class Format implements Bundleable {
       this.projectionData = format.projectionData;
       this.stereoMode = format.stereoMode;
       this.colorInfo = format.colorInfo;
+      this.lumaBitdepth = format.lumaBitdepth;
+      this.chromaBitdepth = format.chromaBitdepth;
       // Audio specific.
       this.channelCount = format.channelCount;
       this.sampleRate = format.sampleRate;
@@ -557,6 +565,30 @@ public final class Format implements Bundleable {
     @CanIgnoreReturnValue
     public Builder setColorInfo(@Nullable ColorInfo colorInfo) {
       this.colorInfo = colorInfo;
+      return this;
+    }
+
+    /**
+     * Sets {@link Format#lumaBitdepth}. The default value is 8.
+     *
+     * @param lumaBitdepth The {@link Format#lumaBitdepth}.
+     * @return The builder.
+     */
+    @CanIgnoreReturnValue
+    public Builder setLumaBitdepth(int lumaBitdepth) {
+      this.lumaBitdepth = lumaBitdepth;
+      return this;
+    }
+
+    /**
+     * Sets {@link Format#chromaBitdepth}. The default value is 8.
+     *
+     * @param chromaBitdepth The {@link Format#chromaBitdepth}.
+     * @return The builder.
+     */
+    @CanIgnoreReturnValue
+    public Builder setChromaBitdepth(int chromaBitdepth) {
+      this.chromaBitdepth = chromaBitdepth;
       return this;
     }
 
@@ -872,6 +904,10 @@ public final class Format implements Bundleable {
 
   /** The color metadata associated with the video, or null if not applicable. */
   @UnstableApi @Nullable public final ColorInfo colorInfo;
+  /** The bit depth of the luma samples of the video. */
+  public final int lumaBitdepth;
+  /** The bit depth of the chroma samples of the video. It might differ from the luma bit depth. */
+  public final int chromaBitdepth;
 
   // Audio specific.
 
@@ -959,6 +995,8 @@ public final class Format implements Bundleable {
     projectionData = builder.projectionData;
     stereoMode = builder.stereoMode;
     colorInfo = builder.colorInfo;
+    lumaBitdepth = builder.lumaBitdepth;
+    chromaBitdepth = builder.chromaBitdepth;
     // Audio specific.
     channelCount = builder.channelCount;
     sampleRate = builder.sampleRate;
@@ -1092,6 +1130,10 @@ public final class Format implements Bundleable {
         + ", "
         + frameRate
         + ", "
+        + lumaBitdepth
+        + ", "
+        + chromaBitdepth
+        + ", "
         + colorInfo
         + "]"
         + ", ["
@@ -1132,6 +1174,8 @@ public final class Format implements Bundleable {
       // [Omitted] projectionData.
       result = 31 * result + stereoMode;
       // [Omitted] colorInfo.
+      result = 31 * result + lumaBitdepth;
+      result = 31 * result + chromaBitdepth;
       // Audio specific.
       result = 31 * result + channelCount;
       result = 31 * result + sampleRate;
@@ -1173,6 +1217,8 @@ public final class Format implements Bundleable {
         && height == other.height
         && rotationDegrees == other.rotationDegrees
         && stereoMode == other.stereoMode
+        && lumaBitdepth == other.lumaBitdepth
+        && chromaBitdepth == other.chromaBitdepth
         && channelCount == other.channelCount
         && sampleRate == other.sampleRate
         && pcmEncoding == other.pcmEncoding
@@ -1258,6 +1304,9 @@ public final class Format implements Bundleable {
     }
     if (format.width != NO_VALUE && format.height != NO_VALUE) {
       builder.append(", res=").append(format.width).append("x").append(format.height);
+    }
+    if (format.lumaBitdepth != NO_VALUE && format.chromaBitdepth != NO_VALUE) {
+      builder.append(", bitdepth=[").append(format.lumaBitdepth).append(",").append(format.chromaBitdepth).append(']');
     }
     if (format.colorInfo != null && format.colorInfo.isValid()) {
       builder.append(", color=").append(format.colorInfo.toLogString());
@@ -1373,15 +1422,17 @@ public final class Format implements Bundleable {
   private static final String FIELD_PROJECTION_DATA = Util.intToStringMaxRadix(20);
   private static final String FIELD_STEREO_MODE = Util.intToStringMaxRadix(21);
   private static final String FIELD_COLOR_INFO = Util.intToStringMaxRadix(22);
-  private static final String FIELD_CHANNEL_COUNT = Util.intToStringMaxRadix(23);
-  private static final String FIELD_SAMPLE_RATE = Util.intToStringMaxRadix(24);
-  private static final String FIELD_PCM_ENCODING = Util.intToStringMaxRadix(25);
-  private static final String FIELD_ENCODER_DELAY = Util.intToStringMaxRadix(26);
-  private static final String FIELD_ENCODER_PADDING = Util.intToStringMaxRadix(27);
-  private static final String FIELD_ACCESSIBILITY_CHANNEL = Util.intToStringMaxRadix(28);
-  private static final String FIELD_CRYPTO_TYPE = Util.intToStringMaxRadix(29);
-  private static final String FIELD_TILE_COUNT_HORIZONTAL = Util.intToStringMaxRadix(30);
-  private static final String FIELD_TILE_COUNT_VERTICAL = Util.intToStringMaxRadix(31);
+  private static final String FIELD_LUMA_BITDEPTH = Util.intToStringMaxRadix(23);
+  private static final String FIELD_CHROMA_BITDEPTH = Util.intToStringMaxRadix(24);
+  private static final String FIELD_CHANNEL_COUNT = Util.intToStringMaxRadix(25);
+  private static final String FIELD_SAMPLE_RATE = Util.intToStringMaxRadix(26);
+  private static final String FIELD_PCM_ENCODING = Util.intToStringMaxRadix(27);
+  private static final String FIELD_ENCODER_DELAY = Util.intToStringMaxRadix(28);
+  private static final String FIELD_ENCODER_PADDING = Util.intToStringMaxRadix(29);
+  private static final String FIELD_ACCESSIBILITY_CHANNEL = Util.intToStringMaxRadix(30);
+  private static final String FIELD_CRYPTO_TYPE = Util.intToStringMaxRadix(31);
+  private static final String FIELD_TILE_COUNT_HORIZONTAL = Util.intToStringMaxRadix(32);
+  private static final String FIELD_TILE_COUNT_VERTICAL = Util.intToStringMaxRadix(33);
 
   @UnstableApi
   @Override
@@ -1431,6 +1482,8 @@ public final class Format implements Bundleable {
     if (colorInfo != null) {
       bundle.putBundle(FIELD_COLOR_INFO, colorInfo.toBundle());
     }
+    bundle.putInt(FIELD_LUMA_BITDEPTH, lumaBitdepth);
+    bundle.putInt(FIELD_CHROMA_BITDEPTH, chromaBitdepth);
     // Audio specific.
     bundle.putInt(FIELD_CHANNEL_COUNT, channelCount);
     bundle.putInt(FIELD_SAMPLE_RATE, sampleRate);
@@ -1496,6 +1549,8 @@ public final class Format implements Bundleable {
     if (colorInfoBundle != null) {
       builder.setColorInfo(ColorInfo.CREATOR.fromBundle(colorInfoBundle));
     }
+    builder.setLumaBitdepth(bundle.getInt(FIELD_LUMA_BITDEPTH, DEFAULT.lumaBitdepth));
+    builder.setChromaBitdepth(bundle.getInt(FIELD_CHROMA_BITDEPTH, DEFAULT.chromaBitdepth));
     // Audio specific.
     builder
         .setChannelCount(bundle.getInt(FIELD_CHANNEL_COUNT, DEFAULT.channelCount))

--- a/libraries/common/src/test/java/androidx/media3/common/FormatTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/FormatTest.java
@@ -28,6 +28,10 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+// copybara:exo-only import com.google.android.exoplayer2.drm.DrmInitData;
+// copybara:exo-only import com.google.android.exoplayer2.util.MimeTypes;
+// copybara:exo-only import com.google.android.exoplayer2.video.ColorInfo;
+// copybara:exo-only import com.google.android.exoplayer2.metadata.Metadata;
 
 /** Unit test for {@link Format}. */
 @RunWith(AndroidJUnit4.class)

--- a/libraries/common/src/test/java/androidx/media3/common/FormatTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/FormatTest.java
@@ -104,6 +104,8 @@ public final class FormatTest {
         .setProjectionData(projectionData)
         .setStereoMode(C.STEREO_MODE_TOP_BOTTOM)
         .setColorInfo(colorInfo)
+        .setLumaBitdepth(9)
+        .setChromaBitdepth(11)
         .setChannelCount(6)
         .setSampleRate(44100)
         .setPcmEncoding(C.ENCODING_PCM_24BIT)

--- a/libraries/common/src/test/java/androidx/media3/common/FormatTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/FormatTest.java
@@ -78,7 +78,9 @@ public final class FormatTest {
             C.COLOR_SPACE_BT709,
             C.COLOR_RANGE_LIMITED,
             C.COLOR_TRANSFER_SDR,
-            new byte[] {1, 2, 3, 4, 5, 6, 7});
+            new byte[] {1, 2, 3, 4, 5, 6, 7},
+            /* lumaBitdepth */ 9,
+            /* chromaBitdepth */ 11);
 
     return new Format.Builder()
         .setId("id")
@@ -104,8 +106,6 @@ public final class FormatTest {
         .setProjectionData(projectionData)
         .setStereoMode(C.STEREO_MODE_TOP_BOTTOM)
         .setColorInfo(colorInfo)
-        .setLumaBitdepth(9)
-        .setChromaBitdepth(11)
         .setChannelCount(6)
         .setSampleRate(44100)
         .setPcmEncoding(C.ENCODING_PCM_24BIT)

--- a/libraries/common/src/test/java/androidx/media3/common/util/MediaFormatUtilTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/util/MediaFormatUtilTest.java
@@ -150,11 +150,12 @@ public class MediaFormatUtilTest {
             .setAverageBitrate(1)
             .setChannelCount(2)
             .setColorInfo(
-                new ColorInfo(
-                    /* colorSpace= */ C.COLOR_SPACE_BT601,
-                    /* colorRange= */ C.COLOR_RANGE_FULL,
-                    /* colorTransfer= */ C.COLOR_TRANSFER_HLG,
-                    new byte[] {3}))
+                new ColorInfo.Builder()
+                    .setColorSpace(C.COLOR_SPACE_BT601)
+                    .setColorRange(C.COLOR_RANGE_FULL)
+                    .setColorTransfer(C.COLOR_TRANSFER_HLG)
+                    .setHdrStaticInfo(new byte[] {3})
+                    .build())
             .setSampleMimeType(MimeTypes.VIDEO_H264)
             .setCodecs("avc.123")
             .setFrameRate(4)

--- a/libraries/container/src/main/java/androidx/media3/container/NalUnitUtil.java
+++ b/libraries/container/src/main/java/androidx/media3/container/NalUnitUtil.java
@@ -33,28 +33,21 @@ import java.util.Arrays;
 public final class NalUnitUtil {
 
   private static final String TAG = "NalUnitUtil";
-
   /** Coded slice of a non-IDR picture. */
   public static final int NAL_UNIT_TYPE_NON_IDR = 1;
-
   /** Coded slice data partition A. */
   public static final int NAL_UNIT_TYPE_PARTITION_A = 2;
-
   /** Coded slice of an IDR picture. */
   public static final int NAL_UNIT_TYPE_IDR = 5;
-
   /** Supplemental enhancement information. */
   public static final int NAL_UNIT_TYPE_SEI = 6;
-
   /** Sequence parameter set. */
   public static final int NAL_UNIT_TYPE_SPS = 7;
-
   /** Picture parameter set. */
   public static final int NAL_UNIT_TYPE_PPS = 8;
-
   /** Access unit delimiter. */
   public static final int NAL_UNIT_TYPE_AUD = 9;
-
+  
   /** Holds data parsed from a H.264 sequence parameter set NAL unit. */
   public static final class SpsData {
 

--- a/libraries/container/src/main/java/androidx/media3/container/NalUnitUtil.java
+++ b/libraries/container/src/main/java/androidx/media3/container/NalUnitUtil.java
@@ -66,6 +66,8 @@ public final class NalUnitUtil {
     public final int width;
     public final int height;
     public final float pixelWidthHeightRatio;
+    public final int bitDepthLumaMinus8;
+    public final int bitDepthChromaMinus8;
     public final boolean separateColorPlaneFlag;
     public final boolean frameMbsOnlyFlag;
     public final int frameNumLength;
@@ -85,6 +87,8 @@ public final class NalUnitUtil {
         int width,
         int height,
         float pixelWidthHeightRatio,
+        int bitDepthLumaMinus8,
+        int bitDepthChromaMinus8,
         boolean separateColorPlaneFlag,
         boolean frameMbsOnlyFlag,
         int frameNumLength,
@@ -102,6 +106,8 @@ public final class NalUnitUtil {
       this.width = width;
       this.height = height;
       this.pixelWidthHeightRatio = pixelWidthHeightRatio;
+      this.bitDepthLumaMinus8 = bitDepthLumaMinus8;
+      this.bitDepthChromaMinus8 = bitDepthChromaMinus8;
       this.separateColorPlaneFlag = separateColorPlaneFlag;
       this.frameMbsOnlyFlag = frameMbsOnlyFlag;
       this.frameNumLength = frameNumLength;
@@ -382,6 +388,8 @@ public final class NalUnitUtil {
 
     int chromaFormatIdc = 1; // Default is 4:2:0
     boolean separateColorPlaneFlag = false;
+    int bitDepthLumaMinus8 = 0;
+    int bitDepthChromaMinus8 = 0;
     if (profileIdc == 100
         || profileIdc == 110
         || profileIdc == 122
@@ -396,8 +404,8 @@ public final class NalUnitUtil {
       if (chromaFormatIdc == 3) {
         separateColorPlaneFlag = data.readBit();
       }
-      data.readUnsignedExpGolombCodedInt(); // bit_depth_luma_minus8
-      data.readUnsignedExpGolombCodedInt(); // bit_depth_chroma_minus8
+      bitDepthLumaMinus8 = data.readUnsignedExpGolombCodedInt();
+      bitDepthChromaMinus8 = data.readUnsignedExpGolombCodedInt();
       data.skipBit(); // qpprime_y_zero_transform_bypass_flag
       boolean seqScalingMatrixPresentFlag = data.readBit();
       if (seqScalingMatrixPresentFlag) {
@@ -511,6 +519,8 @@ public final class NalUnitUtil {
         frameWidth,
         frameHeight,
         pixelWidthHeightRatio,
+        bitDepthLumaMinus8,
+        bitDepthChromaMinus8,
         separateColorPlaneFlag,
         frameMbsOnlyFlag,
         frameNumLength,

--- a/libraries/effect/src/main/java/androidx/media3/effect/DefaultVideoFrameProcessor.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/DefaultVideoFrameProcessor.java
@@ -253,9 +253,9 @@ public final class DefaultVideoFrameProcessor implements VideoFrameProcessor {
         throws VideoFrameProcessingException {
       // TODO(b/261188041) Add tests to verify the Listener is invoked on the given Executor.
 
-      checkArgument(inputColorInfo.isColorValid());
+      checkArgument(inputColorInfo.isDataSpaceValid());
       checkArgument(inputColorInfo.colorTransfer != C.COLOR_TRANSFER_LINEAR);
-      checkArgument(outputColorInfo.isColorValid());
+      checkArgument(outputColorInfo.isDataSpaceValid());
       checkArgument(outputColorInfo.colorTransfer != C.COLOR_TRANSFER_LINEAR);
       if (ColorInfo.isTransferHdr(inputColorInfo) || ColorInfo.isTransferHdr(outputColorInfo)) {
         checkArgument(enableColorTransfers);

--- a/libraries/effect/src/main/java/androidx/media3/effect/DefaultVideoFrameProcessor.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/DefaultVideoFrameProcessor.java
@@ -253,9 +253,9 @@ public final class DefaultVideoFrameProcessor implements VideoFrameProcessor {
         throws VideoFrameProcessingException {
       // TODO(b/261188041) Add tests to verify the Listener is invoked on the given Executor.
 
-      checkArgument(inputColorInfo.isValid());
+      checkArgument(inputColorInfo.isColorValid());
       checkArgument(inputColorInfo.colorTransfer != C.COLOR_TRANSFER_LINEAR);
-      checkArgument(outputColorInfo.isValid());
+      checkArgument(outputColorInfo.isColorValid());
       checkArgument(outputColorInfo.colorTransfer != C.COLOR_TRANSFER_LINEAR);
       if (ColorInfo.isTransferHdr(inputColorInfo) || ColorInfo.isTransferHdr(outputColorInfo)) {
         checkArgument(enableColorTransfers);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/DebugTextViewHelper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/DebugTextViewHelper.java
@@ -189,8 +189,10 @@ public class DebugTextViewHelper {
   }
 
   private static String getColorInfoString(@Nullable ColorInfo colorInfo) {
-    return colorInfo != null ? (colorInfo.isBppValid() ? " b:" + colorInfo.toBppString() : "")
-        + (colorInfo.isValid() ? " colr:" + colorInfo.toColorString() : "") : "";
+    return colorInfo != null
+        ? (colorInfo.isBppValid() ? " b:" + colorInfo.toBppString() : "")
+            + (colorInfo.isValid() ? " colr:" + colorInfo.toColorString() : "")
+        : "";
   }
 
   private static String getPixelAspectRatioString(float pixelAspectRatio) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/DebugTextViewHelper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/DebugTextViewHelper.java
@@ -139,6 +139,7 @@ public class DebugTextViewHelper {
         + format.width
         + "x"
         + format.height
+        + getBitdepthInfoString(format.lumaBitdepth)
         + getColorInfoString(format.colorInfo)
         + getPixelAspectRatioString(format.pixelWidthHeightRatio)
         + getDecoderCountersBufferCountString(decoderCounters)
@@ -186,6 +187,10 @@ public class DebugTextViewHelper {
         + counters.maxConsecutiveDroppedBufferCount
         + " dk:"
         + counters.droppedToKeyframeCount;
+  }
+
+  private static String getBitdepthInfoString(int lumaBitdepth) {
+    return lumaBitdepth != -1 ? " b:" + lumaBitdepth : "";
   }
 
   private static String getColorInfoString(@Nullable ColorInfo colorInfo) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/DebugTextViewHelper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/DebugTextViewHelper.java
@@ -190,7 +190,7 @@ public class DebugTextViewHelper {
   }
 
   private static String getBitdepthInfoString(int lumaBitdepth) {
-    return lumaBitdepth != -1 ? " b:" + lumaBitdepth : "";
+    return lumaBitdepth != Format.NO_VALUE ? " b:" + lumaBitdepth : "";
   }
 
   private static String getColorInfoString(@Nullable ColorInfo colorInfo) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/DebugTextViewHelper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/DebugTextViewHelper.java
@@ -189,10 +189,7 @@ public class DebugTextViewHelper {
   }
 
   private static String getColorInfoString(@Nullable ColorInfo colorInfo) {
-    return colorInfo != null
-        ? (colorInfo.isBppValid() ? " b:" + colorInfo.toBppString() : "")
-            + (colorInfo.isValid() ? " colr:" + colorInfo.toColorString() : "")
-        : "";
+    return colorInfo != null && colorInfo.isValid() ? " colr:" + colorInfo.toLogString() : "";
   }
 
   private static String getPixelAspectRatioString(float pixelAspectRatio) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/DebugTextViewHelper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/DebugTextViewHelper.java
@@ -139,7 +139,6 @@ public class DebugTextViewHelper {
         + format.width
         + "x"
         + format.height
-        + getBitdepthInfoString(format.lumaBitdepth)
         + getColorInfoString(format.colorInfo)
         + getPixelAspectRatioString(format.pixelWidthHeightRatio)
         + getDecoderCountersBufferCountString(decoderCounters)
@@ -189,12 +188,9 @@ public class DebugTextViewHelper {
         + counters.droppedToKeyframeCount;
   }
 
-  private static String getBitdepthInfoString(int lumaBitdepth) {
-    return lumaBitdepth != Format.NO_VALUE ? " b:" + lumaBitdepth : "";
-  }
-
   private static String getColorInfoString(@Nullable ColorInfo colorInfo) {
-    return colorInfo != null && colorInfo.isValid() ? " colr:" + colorInfo.toLogString() : "";
+    return colorInfo != null ? (colorInfo.isBppValid() ? " b:" + colorInfo.toBppString() : "")
+        + (colorInfo.isValid() ? " colr:" + colorInfo.toColorString() : "") : "";
   }
 
   private static String getPixelAspectRatioString(float pixelAspectRatio) {

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfoTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfoTest.java
@@ -430,7 +430,10 @@ public final class MediaCodecInfoTest {
   }
 
   private static ColorInfo buildColorInfo(@C.ColorSpace int colorSpace) {
-    return new ColorInfo.Builder().setColorSpace(
-        colorSpace).setColorRange(C.COLOR_RANGE_FULL).setColorTransfer(C.COLOR_TRANSFER_HLG).build();
+    return new ColorInfo.Builder()
+        .setColorSpace(colorSpace)
+        .setColorRange(C.COLOR_RANGE_FULL)
+        .setColorTransfer(C.COLOR_TRANSFER_HLG)
+        .build();
   }
 }

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfoTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfoTest.java
@@ -430,7 +430,7 @@ public final class MediaCodecInfoTest {
   }
 
   private static ColorInfo buildColorInfo(@C.ColorSpace int colorSpace) {
-    return new ColorInfo(
-        colorSpace, C.COLOR_RANGE_FULL, C.COLOR_TRANSFER_HLG, /* hdrStaticInfo= */ null);
+    return new ColorInfo.Builder().setColorSpace(
+        colorSpace).setColorRange(C.COLOR_RANGE_FULL).setColorTransfer(C.COLOR_TRANSFER_HLG).build();
   }
 }

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtilTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtilTest.java
@@ -90,11 +90,12 @@ public final class MediaCodecUtilTest {
   @Test
   public void getCodecProfileAndLevel_handlesAv1ProfileMain10HDRWithHdrInfoSet() {
     ColorInfo colorInfo =
-        new ColorInfo(
-            /* colorSpace= */ C.COLOR_SPACE_BT709,
-            /* colorRange= */ C.COLOR_RANGE_LIMITED,
-            /* colorTransfer= */ C.COLOR_TRANSFER_SDR,
-            /* hdrStaticInfo= */ new byte[] {1, 2, 3, 4, 5, 6, 7});
+        new ColorInfo.Builder()
+            .setColorSpace(C.COLOR_SPACE_BT709)
+            .setColorRange(C.COLOR_RANGE_LIMITED)
+            .setColorTransfer(C.COLOR_TRANSFER_SDR)
+            .setHdrStaticInfo(new byte[] {1, 2, 3, 4, 5, 6, 7})
+            .build();
     Format format =
         new Format.Builder()
             .setSampleMimeType(MimeTypes.VIDEO_AV1)
@@ -110,11 +111,11 @@ public final class MediaCodecUtilTest {
   @Test
   public void getCodecProfileAndLevel_handlesAv1ProfileMain10HDRWithoutHdrInfoSet() {
     ColorInfo colorInfo =
-        new ColorInfo(
-            /* colorSpace= */ C.COLOR_SPACE_BT709,
-            /* colorRange= */ C.COLOR_RANGE_LIMITED,
-            /* colorTransfer= */ C.COLOR_TRANSFER_HLG,
-            /* hdrStaticInfo= */ null);
+        new ColorInfo.Builder()
+            .setColorSpace(C.COLOR_SPACE_BT709)
+            .setColorRange(C.COLOR_RANGE_LIMITED)
+            .setColorTransfer(C.COLOR_TRANSFER_HLG)
+            .build();
     Format format =
         new Format.Builder()
             .setSampleMimeType(MimeTypes.VIDEO_AV1)

--- a/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMediaTrack.java
+++ b/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMediaTrack.java
@@ -413,13 +413,14 @@ import com.google.common.collect.ImmutableMap;
     formatBuilder.setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio);
     formatBuilder.setHeight(spsData.height);
     formatBuilder.setWidth(spsData.width);
-    formatBuilder.setColorInfo(new ColorInfo.Builder()
-        .setColorSpace(spsData.colorSpace)
+    formatBuilder.setColorInfo(
+        new ColorInfo.Builder()
+            .setColorSpace(spsData.colorSpace)
             .setColorRange(spsData.colorRange)
             .setColorTransfer(spsData.colorTransfer)
             .setLumaBitdepth(spsData.bitDepthLumaMinus8 + 8)
             .setChromaBitdepth(spsData.bitDepthChromaMinus8 + 8)
-        .build());
+            .build());
 
     @Nullable String profileLevel = fmtpAttributes.get(PARAMETER_PROFILE_LEVEL_ID);
     if (profileLevel != null) {
@@ -463,13 +464,14 @@ import com.google.common.collect.ImmutableMap;
             spsNalDataWithStartCode, NAL_START_CODE.length, spsNalDataWithStartCode.length);
     formatBuilder.setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio);
     formatBuilder.setHeight(spsData.height).setWidth(spsData.width);
-    formatBuilder.setColorInfo(new ColorInfo.Builder()
-        .setColorSpace(spsData.colorSpace)
-        .setColorRange(spsData.colorRange)
-        .setColorTransfer(spsData.colorTransfer)
-        .setLumaBitdepth(spsData.bitDepthLumaMinus8 + 8)
-        .setChromaBitdepth(spsData.bitDepthChromaMinus8 + 8)
-        .build());
+    formatBuilder.setColorInfo(
+        new ColorInfo.Builder()
+            .setColorSpace(spsData.colorSpace)
+            .setColorRange(spsData.colorRange)
+            .setColorTransfer(spsData.colorTransfer)
+            .setLumaBitdepth(spsData.bitDepthLumaMinus8 + 8)
+            .setChromaBitdepth(spsData.bitDepthChromaMinus8 + 8)
+            .build());
 
     formatBuilder.setCodecs(
         CodecSpecificDataUtil.buildHevcCodecString(

--- a/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMediaTrack.java
+++ b/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMediaTrack.java
@@ -51,7 +51,6 @@ import com.google.common.collect.ImmutableMap;
   // Format specific parameter names.
   private static final String PARAMETER_PROFILE_LEVEL_ID = "profile-level-id";
   private static final String PARAMETER_SPROP_PARAMS = "sprop-parameter-sets";
-
   private static final String PARAMETER_AMR_OCTET_ALIGN = "octet-align";
   private static final String PARAMETER_AMR_INTERLEAVING = "interleaving";
   private static final String PARAMETER_H265_SPROP_SPS = "sprop-sps";
@@ -60,16 +59,12 @@ import com.google.common.collect.ImmutableMap;
   private static final String PARAMETER_H265_SPROP_MAX_DON_DIFF = "sprop-max-don-diff";
   private static final String PARAMETER_MP4A_CONFIG = "config";
   private static final String PARAMETER_MP4A_C_PRESENT = "cpresent";
-
   /** Prefix for the RFC6381 codecs string for AAC formats. */
   private static final String AAC_CODECS_PREFIX = "mp4a.40.";
-
   /** Prefix for the RFC6381 codecs string for AVC formats. */
   private static final String H264_CODECS_PREFIX = "avc1.";
-
   /** Prefix for the RFC6416 codecs string for MPEG4V-ES formats. */
   private static final String MPEG4_CODECS_PREFIX = "mp4v.";
-
   private static final String GENERIC_CONTROL_ATTR = "*";
 
   /**
@@ -101,7 +96,6 @@ import com.google.common.collect.ImmutableMap;
    * software VP8 decoder</a>.
    */
   private static final int DEFAULT_VP8_WIDTH = 320;
-
   /**
    * Default height for VP8.
    *
@@ -125,7 +119,6 @@ import com.google.common.collect.ImmutableMap;
    * software VP9 decoder</a>.
    */
   private static final int DEFAULT_VP9_WIDTH = 320;
-
   /**
    * Default height for VP9.
    *
@@ -146,7 +139,6 @@ import com.google.common.collect.ImmutableMap;
    * >Android's software H263 decoder</a>.
    */
   private static final int DEFAULT_H263_WIDTH = 352;
-
   /**
    * Default height for H263.
    *
@@ -159,7 +151,6 @@ import com.google.common.collect.ImmutableMap;
 
   /** The track's associated {@link RtpPayloadFormat}. */
   public final RtpPayloadFormat payloadFormat;
-
   /** The track's URI. */
   public final Uri uri;
 
@@ -422,14 +413,13 @@ import com.google.common.collect.ImmutableMap;
     formatBuilder.setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio);
     formatBuilder.setHeight(spsData.height);
     formatBuilder.setWidth(spsData.width);
-    formatBuilder.setColorInfo(
-        new ColorInfo(
-            spsData.colorSpace,
-            spsData.colorRange,
-            spsData.colorTransfer,
-            null,
-            spsData.bitDepthLumaMinus8 + 8,
-            spsData.bitDepthChromaMinus8 + 8));
+    formatBuilder.setColorInfo(new ColorInfo.Builder()
+        .setColorSpace(spsData.colorSpace)
+            .setColorRange(spsData.colorRange)
+            .setColorTransfer(spsData.colorTransfer)
+            .setLumaBitdepth(spsData.bitDepthLumaMinus8 + 8)
+            .setChromaBitdepth(spsData.bitDepthChromaMinus8 + 8)
+        .build());
 
     @Nullable String profileLevel = fmtpAttributes.get(PARAMETER_PROFILE_LEVEL_ID);
     if (profileLevel != null) {
@@ -473,14 +463,13 @@ import com.google.common.collect.ImmutableMap;
             spsNalDataWithStartCode, NAL_START_CODE.length, spsNalDataWithStartCode.length);
     formatBuilder.setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio);
     formatBuilder.setHeight(spsData.height).setWidth(spsData.width);
-    formatBuilder.setColorInfo(
-        new ColorInfo(
-            spsData.colorSpace,
-            spsData.colorRange,
-            spsData.colorTransfer,
-            null,
-            spsData.bitDepthLumaMinus8 + 8,
-            spsData.bitDepthChromaMinus8 + 8));
+    formatBuilder.setColorInfo(new ColorInfo.Builder()
+        .setColorSpace(spsData.colorSpace)
+        .setColorRange(spsData.colorRange)
+        .setColorTransfer(spsData.colorTransfer)
+        .setLumaBitdepth(spsData.bitDepthLumaMinus8 + 8)
+        .setChromaBitdepth(spsData.bitDepthChromaMinus8 + 8)
+        .build());
 
     formatBuilder.setCodecs(
         CodecSpecificDataUtil.buildHevcCodecString(

--- a/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMediaTrack.java
+++ b/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMediaTrack.java
@@ -32,6 +32,7 @@ import android.util.Pair;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.media3.common.C;
+import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.ParserException;
@@ -421,10 +422,14 @@ import com.google.common.collect.ImmutableMap;
     formatBuilder.setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio);
     formatBuilder.setHeight(spsData.height);
     formatBuilder.setWidth(spsData.width);
-    int bitdepthLuma = spsData.bitDepthLumaMinus8 + 8;
-    formatBuilder.setLumaBitdepth(bitdepthLuma);
-    int bitdepthChroma = spsData.bitDepthChromaMinus8 + 8;
-    formatBuilder.setChromaBitdepth(bitdepthChroma);
+    formatBuilder.setColorInfo(
+        new ColorInfo(
+            spsData.colorSpace,
+            spsData.colorRange,
+            spsData.colorTransfer,
+            null,
+            spsData.bitDepthLumaMinus8 + 8,
+            spsData.bitDepthChromaMinus8 + 8));
 
     @Nullable String profileLevel = fmtpAttributes.get(PARAMETER_PROFILE_LEVEL_ID);
     if (profileLevel != null) {
@@ -468,10 +473,14 @@ import com.google.common.collect.ImmutableMap;
             spsNalDataWithStartCode, NAL_START_CODE.length, spsNalDataWithStartCode.length);
     formatBuilder.setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio);
     formatBuilder.setHeight(spsData.height).setWidth(spsData.width);
-    int bitdepthLuma = spsData.bitDepthLumaMinus8 + 8;
-    formatBuilder.setLumaBitdepth(bitdepthLuma);
-    int bitdepthChroma = spsData.bitDepthChromaMinus8 + 8;
-    formatBuilder.setChromaBitdepth(bitdepthChroma);
+    formatBuilder.setColorInfo(
+        new ColorInfo(
+            spsData.colorSpace,
+            spsData.colorRange,
+            spsData.colorTransfer,
+            null,
+            spsData.bitDepthLumaMinus8 + 8,
+            spsData.bitDepthChromaMinus8 + 8));
 
     formatBuilder.setCodecs(
         CodecSpecificDataUtil.buildHevcCodecString(

--- a/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMediaTrack.java
+++ b/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMediaTrack.java
@@ -421,6 +421,10 @@ import com.google.common.collect.ImmutableMap;
     formatBuilder.setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio);
     formatBuilder.setHeight(spsData.height);
     formatBuilder.setWidth(spsData.width);
+    int bitdepthLuma = spsData.bitDepthLumaMinus8 + 8;
+    formatBuilder.setLumaBitdepth(bitdepthLuma);
+    int bitdepthChroma = spsData.bitDepthChromaMinus8 + 8;
+    formatBuilder.setChromaBitdepth(bitdepthChroma);
 
     @Nullable String profileLevel = fmtpAttributes.get(PARAMETER_PROFILE_LEVEL_ID);
     if (profileLevel != null) {
@@ -464,6 +468,10 @@ import com.google.common.collect.ImmutableMap;
             spsNalDataWithStartCode, NAL_START_CODE.length, spsNalDataWithStartCode.length);
     formatBuilder.setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio);
     formatBuilder.setHeight(spsData.height).setWidth(spsData.width);
+    int bitdepthLuma = spsData.bitDepthLumaMinus8 + 8;
+    formatBuilder.setLumaBitdepth(bitdepthLuma);
+    int bitdepthChroma = spsData.bitDepthChromaMinus8 + 8;
+    formatBuilder.setChromaBitdepth(bitdepthChroma);
 
     formatBuilder.setCodecs(
         CodecSpecificDataUtil.buildHevcCodecString(

--- a/libraries/exoplayer_rtsp/src/test/java/androidx/media3/exoplayer/rtsp/RtspMediaTrackTest.java
+++ b/libraries/exoplayer_rtsp/src/test/java/androidx/media3/exoplayer/rtsp/RtspMediaTrackTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertThrows;
 
 import android.net.Uri;
 import androidx.media3.common.C;
+import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.extractor.AacUtil;
@@ -73,6 +74,11 @@ public class RtspMediaTrackTest {
                 .setHeight(544)
                 .setWidth(960)
                 .setCodecs("avc1.64001F")
+                .setColorInfo(new ColorInfo.Builder()
+                    .setColorRange(1)
+                    .setLumaBitdepth(8)
+                    .setChromaBitdepth(8)
+                    .build())
                 .setInitializationData(
                     ImmutableList.of(
                         new byte[] {
@@ -246,6 +252,12 @@ public class RtspMediaTrackTest {
                 .setHeight(544)
                 .setWidth(960)
                 .setCodecs("avc1.64001F")
+                .setColorInfo(
+                    new ColorInfo.Builder()
+                        .setColorRange(1)
+                        .setChromaBitdepth(8)
+                        .setLumaBitdepth(8)
+                        .build())
                 .setInitializationData(
                     ImmutableList.of(
                         new byte[] {

--- a/libraries/exoplayer_rtsp/src/test/java/androidx/media3/exoplayer/rtsp/RtspMediaTrackTest.java
+++ b/libraries/exoplayer_rtsp/src/test/java/androidx/media3/exoplayer/rtsp/RtspMediaTrackTest.java
@@ -74,11 +74,12 @@ public class RtspMediaTrackTest {
                 .setHeight(544)
                 .setWidth(960)
                 .setCodecs("avc1.64001F")
-                .setColorInfo(new ColorInfo.Builder()
-                    .setColorRange(1)
-                    .setLumaBitdepth(8)
-                    .setChromaBitdepth(8)
-                    .build())
+                .setColorInfo(
+                    new ColorInfo.Builder()
+                        .setColorRange(1)
+                        .setLumaBitdepth(8)
+                        .setChromaBitdepth(8)
+                        .build())
                 .setInitializationData(
                     ImmutableList.of(
                         new byte[] {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/AvcConfig.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/AvcConfig.java
@@ -58,6 +58,8 @@ public final class AvcConfig {
 
       int width = Format.NO_VALUE;
       int height = Format.NO_VALUE;
+      int bitdepthLuma = Format.NO_VALUE;
+      int bitdepthChroma = Format.NO_VALUE;
       @C.ColorSpace int colorSpace = Format.NO_VALUE;
       @C.ColorRange int colorRange = Format.NO_VALUE;
       @C.ColorTransfer int colorTransfer = Format.NO_VALUE;
@@ -70,6 +72,8 @@ public final class AvcConfig {
                 initializationData.get(0), nalUnitLengthFieldLength, sps.length);
         width = spsData.width;
         height = spsData.height;
+        bitdepthLuma = spsData.bitDepthLumaMinus8 + 8;
+        bitdepthChroma = spsData.bitDepthChromaMinus8 + 8;
         colorSpace = spsData.colorSpace;
         colorRange = spsData.colorRange;
         colorTransfer = spsData.colorTransfer;
@@ -84,6 +88,8 @@ public final class AvcConfig {
           nalUnitLengthFieldLength,
           width,
           height,
+          bitdepthLuma,
+          bitdepthChroma,
           colorSpace,
           colorRange,
           colorTransfer,
@@ -109,6 +115,12 @@ public final class AvcConfig {
 
   /** The height of each decoded frame, or {@link Format#NO_VALUE} if unknown. */
   public final int height;
+
+  /** The bit depth of the luma samples, or {@link Format#NO_VALUE} if unknown. */
+  public final int bitdepthLuma;
+
+  /** The bit depth of the chroma samples, or {@link Format#NO_VALUE} if unknown. */
+  public final int bitdepthChroma;
 
   /**
    * The {@link C.ColorSpace} of the video, or {@link Format#NO_VALUE} if unknown or not applicable.
@@ -141,6 +153,8 @@ public final class AvcConfig {
       int nalUnitLengthFieldLength,
       int width,
       int height,
+      int bitdepthLuma,
+      int bitdepthChroma,
       @C.ColorSpace int colorSpace,
       @C.ColorRange int colorRange,
       @C.ColorTransfer int colorTransfer,
@@ -150,6 +164,8 @@ public final class AvcConfig {
     this.nalUnitLengthFieldLength = nalUnitLengthFieldLength;
     this.width = width;
     this.height = height;
+    this.bitdepthLuma = bitdepthLuma;
+    this.bitdepthChroma = bitdepthChroma;
     this.colorSpace = colorSpace;
     this.colorRange = colorRange;
     this.colorTransfer = colorTransfer;

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/AvcConfig.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/AvcConfig.java
@@ -26,6 +26,7 @@ import androidx.media3.container.NalUnitUtil;
 import androidx.media3.container.NalUnitUtil.SpsData;
 import java.util.ArrayList;
 import java.util.List;
+// copybara:exo-only  import com.google.android.exoplayer2.util.NalUnitUtil;
 
 /** AVC configuration data. */
 @UnstableApi

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/HevcConfig.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/HevcConfig.java
@@ -63,6 +63,8 @@ public final class HevcConfig {
       int bufferPosition = 0;
       int width = Format.NO_VALUE;
       int height = Format.NO_VALUE;
+      int bitdepthLuma = Format.NO_VALUE;
+      int bitdepthChroma = Format.NO_VALUE;
       @C.ColorSpace int colorSpace = Format.NO_VALUE;
       @C.ColorRange int colorRange = Format.NO_VALUE;
       @C.ColorTransfer int colorTransfer = Format.NO_VALUE;
@@ -89,6 +91,8 @@ public final class HevcConfig {
                     buffer, bufferPosition, bufferPosition + nalUnitLength);
             width = spsData.width;
             height = spsData.height;
+            bitdepthLuma = spsData.bitDepthLumaMinus8 + 8;
+            bitdepthChroma = spsData.bitDepthChromaMinus8 + 8;
             colorSpace = spsData.colorSpace;
             colorRange = spsData.colorRange;
             colorTransfer = spsData.colorTransfer;
@@ -114,6 +118,8 @@ public final class HevcConfig {
           lengthSizeMinusOne + 1,
           width,
           height,
+          bitdepthLuma,
+          bitdepthChroma,
           colorSpace,
           colorRange,
           colorTransfer,
@@ -141,6 +147,12 @@ public final class HevcConfig {
 
   /** The height of each decoded frame, or {@link Format#NO_VALUE} if unknown. */
   public final int height;
+
+  /** The bit depth of the luma samples, or {@link Format#NO_VALUE} if unknown. */
+  public final int bitdepthLuma;
+
+  /** The bit depth of the chroma samples, or {@link Format#NO_VALUE} if unknown. */
+  public final int bitdepthChroma;
 
   /**
    * The {@link C.ColorSpace} of the video or {@link Format#NO_VALUE} if unknown or not applicable.
@@ -173,6 +185,8 @@ public final class HevcConfig {
       int nalUnitLengthFieldLength,
       int width,
       int height,
+      int bitdepthLuma,
+      int bitdepthChroma,
       @C.ColorSpace int colorSpace,
       @C.ColorRange int colorRange,
       @C.ColorTransfer int colorTransfer,
@@ -182,6 +196,8 @@ public final class HevcConfig {
     this.nalUnitLengthFieldLength = nalUnitLengthFieldLength;
     this.width = width;
     this.height = height;
+    this.bitdepthLuma = bitdepthLuma;
+    this.bitdepthChroma = bitdepthChroma;
     this.colorSpace = colorSpace;
     this.colorRange = colorRange;
     this.colorTransfer = colorTransfer;

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/HevcConfig.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/HevcConfig.java
@@ -25,6 +25,7 @@ import androidx.media3.common.util.UnstableApi;
 import androidx.media3.container.NalUnitUtil;
 import java.util.Collections;
 import java.util.List;
+// copybara:exo-only  import com.google.android.exoplayer2.util.NalUnitUtil;
 
 /** HEVC configuration data. */
 @UnstableApi

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
@@ -2295,14 +2295,15 @@ public class MatroskaExtractor implements Extractor {
         @Nullable ColorInfo colorInfo = null;
         if (hasColorInfo) {
           @Nullable byte[] hdrStaticInfo = getHdrStaticInfo();
-          colorInfo = new ColorInfo.Builder()
-              .setColorSpace(colorSpace)
-              .setColorRange(colorRange)
-              .setColorTransfer(colorTransfer)
-              .setHdrStaticInfo(hdrStaticInfo)
-              .setLumaBitdepth(bitsPerChannel)
-              .setChromaBitdepth(bitsPerChannel)
-              .build();
+          colorInfo =
+              new ColorInfo.Builder()
+                  .setColorSpace(colorSpace)
+                  .setColorRange(colorRange)
+                  .setColorTransfer(colorTransfer)
+                  .setHdrStaticInfo(hdrStaticInfo)
+                  .setLumaBitdepth(bitsPerChannel)
+                  .setChromaBitdepth(bitsPerChannel)
+                  .build();
         }
         int rotationDegrees = Format.NO_VALUE;
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
@@ -1022,7 +1022,7 @@ public class MatroskaExtractor implements Extractor {
       case ID_COLOUR_BITS_PER_CHANNEL:
         assertInTrackEntry(id);
         currentTrack.hasColorInfo = true;
-        currentTrack.bitsPerChannel = (int)value;
+        currentTrack.bitsPerChannel = (int) value;
         break;
       case ID_COLOUR_RANGE:
         assertInTrackEntry(id);
@@ -2308,7 +2308,14 @@ public class MatroskaExtractor implements Extractor {
         @Nullable ColorInfo colorInfo = null;
         if (hasColorInfo) {
           @Nullable byte[] hdrStaticInfo = getHdrStaticInfo();
-          colorInfo = new ColorInfo(colorSpace, colorRange, colorTransfer, hdrStaticInfo, bitsPerChannel, bitsPerChannel);
+          colorInfo =
+              new ColorInfo(
+                  colorSpace,
+                  colorRange,
+                  colorTransfer,
+                  hdrStaticInfo,
+                  bitsPerChannel,
+                  bitsPerChannel);
         }
         int rotationDegrees = Format.NO_VALUE;
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
@@ -1021,6 +1021,7 @@ public class MatroskaExtractor implements Extractor {
         break;
       case ID_COLOUR_BITS_PER_CHANNEL:
         assertInTrackEntry(id);
+        currentTrack.hasColorInfo = true;
         currentTrack.bitsPerChannel = (int)value;
         break;
       case ID_COLOUR_RANGE:
@@ -2307,7 +2308,7 @@ public class MatroskaExtractor implements Extractor {
         @Nullable ColorInfo colorInfo = null;
         if (hasColorInfo) {
           @Nullable byte[] hdrStaticInfo = getHdrStaticInfo();
-          colorInfo = new ColorInfo(colorSpace, colorRange, colorTransfer, hdrStaticInfo);
+          colorInfo = new ColorInfo(colorSpace, colorRange, colorTransfer, hdrStaticInfo, bitsPerChannel, bitsPerChannel);
         }
         int rotationDegrees = Format.NO_VALUE;
 
@@ -2332,8 +2333,6 @@ public class MatroskaExtractor implements Extractor {
         formatBuilder
             .setWidth(width)
             .setHeight(height)
-            .setLumaBitdepth(bitsPerChannel)
-            .setChromaBitdepth(bitsPerChannel)
             .setPixelWidthHeightRatio(pixelWidthHeightRatio)
             .setRotationDegrees(rotationDegrees)
             .setProjectionData(projectionData)

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
@@ -232,6 +232,7 @@ public class MatroskaExtractor implements Extractor {
   private static final int ID_STEREO_MODE = 0x53B8;
   private static final int ID_COLOUR = 0x55B0;
   private static final int ID_COLOUR_RANGE = 0x55B9;
+  private static final int ID_COLOUR_BITS_PER_CHANNEL = 0x55B2;
   private static final int ID_COLOUR_TRANSFER = 0x55BA;
   private static final int ID_COLOUR_PRIMARIES = 0x55BB;
   private static final int ID_MAX_CLL = 0x55BC;
@@ -608,6 +609,7 @@ public class MatroskaExtractor implements Extractor {
       case ID_CUE_CLUSTER_POSITION:
       case ID_REFERENCE_BLOCK:
       case ID_STEREO_MODE:
+      case ID_COLOUR_BITS_PER_CHANNEL:
       case ID_COLOUR_RANGE:
       case ID_COLOUR_TRANSFER:
       case ID_COLOUR_PRIMARIES:
@@ -1016,6 +1018,10 @@ public class MatroskaExtractor implements Extractor {
         if (colorTransfer != Format.NO_VALUE) {
           currentTrack.colorTransfer = colorTransfer;
         }
+        break;
+      case ID_COLOUR_BITS_PER_CHANNEL:
+        assertInTrackEntry(id);
+        currentTrack.bitsPerChannel = (int)value;
         break;
       case ID_COLOUR_RANGE:
         assertInTrackEntry(id);
@@ -2013,6 +2019,7 @@ public class MatroskaExtractor implements Extractor {
     // Video elements.
     public int width = Format.NO_VALUE;
     public int height = Format.NO_VALUE;
+    public int bitsPerChannel = Format.NO_VALUE;
     public int displayWidth = Format.NO_VALUE;
     public int displayHeight = Format.NO_VALUE;
     public int displayUnit = DISPLAY_UNIT_PIXELS;
@@ -2325,6 +2332,8 @@ public class MatroskaExtractor implements Extractor {
         formatBuilder
             .setWidth(width)
             .setHeight(height)
+            .setLumaBitdepth(bitsPerChannel)
+            .setChromaBitdepth(bitsPerChannel)
             .setPixelWidthHeightRatio(pixelWidthHeightRatio)
             .setRotationDegrees(rotationDegrees)
             .setProjectionData(projectionData)

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
@@ -94,7 +94,6 @@ public class MatroskaExtractor implements Extractor {
       flag = true,
       value = {FLAG_DISABLE_SEEK_FOR_CUES})
   public @interface Flags {}
-
   /**
    * Flag to disable seeking for cues.
    *
@@ -260,7 +259,6 @@ public class MatroskaExtractor implements Extractor {
    * https://www.matroska.org/technical/codec_specs.html.
    */
   private static final int BLOCK_ADD_ID_TYPE_DVCC = 0x64766343;
-
   /**
    * BlockAddIdType value for Dolby Vision configuration with profile > 7. See also
    * https://www.matroska.org/technical/codec_specs.html.
@@ -292,10 +290,8 @@ public class MatroskaExtractor implements Extractor {
         49, 10, 48, 48, 58, 48, 48, 58, 48, 48, 44, 48, 48, 48, 32, 45, 45, 62, 32, 48, 48, 58, 48,
         48, 58, 48, 48, 44, 48, 48, 48, 10
       };
-
   /** The byte offset of the end timecode in {@link #SUBRIP_PREFIX}. */
   private static final int SUBRIP_PREFIX_END_TIMECODE_OFFSET = 19;
-
   /**
    * The value by which to divide a time in microseconds to convert it to the unit of the last value
    * in a subrip timecode (milliseconds).
@@ -310,7 +306,6 @@ public class MatroskaExtractor implements Extractor {
       Util.getUtf8Bytes(
           "Format: Start, End, "
               + "ReadOrder, Layer, Style, Name, MarginL, MarginR, MarginV, Effect, Text");
-
   /**
    * A template for the prefix that must be added to each SSA sample.
    *
@@ -327,16 +322,13 @@ public class MatroskaExtractor implements Extractor {
         68, 105, 97, 108, 111, 103, 117, 101, 58, 32, 48, 58, 48, 48, 58, 48, 48, 58, 48, 48, 44,
         48, 58, 48, 48, 58, 48, 48, 58, 48, 48, 44
       };
-
   /** The byte offset of the end timecode in {@link #SSA_PREFIX}. */
   private static final int SSA_PREFIX_END_TIMECODE_OFFSET = 21;
-
   /**
    * The value by which to divide a time in microseconds to convert it to the unit of the last value
    * in an SSA timecode (1/100ths of a second).
    */
   private static final long SSA_TIMECODE_LAST_VALUE_SCALING_FACTOR = 10_000;
-
   /** The format of an SSA timecode. */
   private static final String SSA_TIMECODE_FORMAT = "%01d:%02d:%02d:%02d";
 
@@ -359,13 +351,11 @@ public class MatroskaExtractor implements Extractor {
 
   /** The byte offset of the end timecode in {@link #VTT_PREFIX}. */
   private static final int VTT_PREFIX_END_TIMECODE_OFFSET = 25;
-
   /**
    * The value by which to divide a time in microseconds to convert it to the unit of the last value
    * in a VTT timecode (milliseconds).
    */
   private static final long VTT_TIMECODE_LAST_VALUE_SCALING_FACTOR = 1000;
-
   /** The format of a VTT timecode. */
   private static final String VTT_TIMECODE_FORMAT = "%02d:%02d:%02d.%03d";
 
@@ -374,10 +364,8 @@ public class MatroskaExtractor implements Extractor {
 
   /** Format tag indicating a WAVEFORMATEXTENSIBLE structure. */
   private static final int WAVE_FORMAT_EXTENSIBLE = 0xFFFE;
-
   /** Format tag for PCM. */
   private static final int WAVE_FORMAT_PCM = 1;
-
   /** Sub format for PCM. */
   private static final UUID WAVE_SUBFORMAT_PCM = new UUID(0x0100000000001000L, 0x800000AA00389B71L);
 
@@ -1996,7 +1984,6 @@ public class MatroskaExtractor implements Extractor {
 
     private static final int DISPLAY_UNIT_PIXELS = 0;
     private static final int MAX_CHROMATICITY = 50_000; // Defined in CTA-861.3.
-
     /** Default max content light level (CLL) that should be encoded into hdrStaticInfo. */
     private static final int DEFAULT_MAX_CLL = 1000; // nits.
 
@@ -2308,14 +2295,14 @@ public class MatroskaExtractor implements Extractor {
         @Nullable ColorInfo colorInfo = null;
         if (hasColorInfo) {
           @Nullable byte[] hdrStaticInfo = getHdrStaticInfo();
-          colorInfo =
-              new ColorInfo(
-                  colorSpace,
-                  colorRange,
-                  colorTransfer,
-                  hdrStaticInfo,
-                  bitsPerChannel,
-                  bitsPerChannel);
+          colorInfo = new ColorInfo.Builder()
+              .setColorSpace(colorSpace)
+              .setColorRange(colorRange)
+              .setColorTransfer(colorTransfer)
+              .setHdrStaticInfo(hdrStaticInfo)
+              .setLumaBitdepth(bitsPerChannel)
+              .setChromaBitdepth(bitsPerChannel)
+              .build();
         }
         int rotationDegrees = Format.NO_VALUE;
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/AtomParsers.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/AtomParsers.java
@@ -1358,27 +1358,22 @@ import java.util.List;
             .setCodecs(codecs)
             .setWidth(width)
             .setHeight(height)
-            .setLumaBitdepth(bitdepthLuma)
-            .setChromaBitdepth(bitdepthChroma)
             .setPixelWidthHeightRatio(pixelWidthHeightRatio)
             .setRotationDegrees(rotationDegrees)
             .setProjectionData(projectionData)
             .setStereoMode(stereoMode)
             .setInitializationData(initializationData)
-            .setDrmInitData(drmInitData);
-    if (colorSpace != Format.NO_VALUE
-        || colorRange != Format.NO_VALUE
-        || colorTransfer != Format.NO_VALUE
-        || hdrStaticInfo != null) {
-      // Note that if either mdcv or clli are missing, we leave the corresponding HDR static
-      // metadata bytes with value zero. See [Internal ref: b/194535665].
-      formatBuilder.setColorInfo(
-          new ColorInfo(
-              colorSpace,
-              colorRange,
-              colorTransfer,
-              hdrStaticInfo != null ? hdrStaticInfo.array() : null));
-    }
+            .setDrmInitData(drmInitData)
+            // Note that if either mdcv or clli are missing, we leave the corresponding HDR static
+            // metadata bytes with value zero. See [Internal ref: b/194535665].
+            .setColorInfo(
+              new ColorInfo(
+                  colorSpace,
+                  colorRange,
+                  colorTransfer,
+                  hdrStaticInfo != null ? hdrStaticInfo.array() : null,
+                  bitdepthLuma,
+                  bitdepthChroma));
 
     if (esdsData != null) {
       formatBuilder

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/AtomParsers.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/AtomParsers.java
@@ -1224,7 +1224,8 @@ import java.util.List;
         ExtractorUtil.checkContainerInput(mimeType == null, /* message= */ null);
         mimeType = MimeTypes.VIDEO_AV1;
         parent.setPosition(childStartPosition + Atom.HEADER_SIZE);
-        parent.skipBytes(1); ;  // marker(1), version(7)
+        parent.skipBytes(1);
+        ; // marker(1), version(7)
         int byte2 = parent.readUnsignedByte();
         int seqProfile = byte2 >> 5;
         int byte3 = parent.readUnsignedByte();
@@ -1367,13 +1368,13 @@ import java.util.List;
             // Note that if either mdcv or clli are missing, we leave the corresponding HDR static
             // metadata bytes with value zero. See [Internal ref: b/194535665].
             .setColorInfo(
-              new ColorInfo(
-                  colorSpace,
-                  colorRange,
-                  colorTransfer,
-                  hdrStaticInfo != null ? hdrStaticInfo.array() : null,
-                  bitdepthLuma,
-                  bitdepthChroma));
+                new ColorInfo(
+                    colorSpace,
+                    colorRange,
+                    colorTransfer,
+                    hdrStaticInfo != null ? hdrStaticInfo.array() : null,
+                    bitdepthLuma,
+                    bitdepthChroma));
 
     if (esdsData != null) {
       formatBuilder

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/AtomParsers.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/AtomParsers.java
@@ -1225,7 +1225,6 @@ import java.util.List;
         mimeType = MimeTypes.VIDEO_AV1;
         parent.setPosition(childStartPosition + Atom.HEADER_SIZE);
         parent.skipBytes(1);
-        ; // marker(1), version(7)
         int byte2 = parent.readUnsignedByte();
         int seqProfile = byte2 >> 5;
         int byte3 = parent.readUnsignedByte();
@@ -1368,13 +1367,14 @@ import java.util.List;
             // Note that if either mdcv or clli are missing, we leave the corresponding HDR static
             // metadata bytes with value zero. See [Internal ref: b/194535665].
             .setColorInfo(
-                new ColorInfo(
-                    colorSpace,
-                    colorRange,
-                    colorTransfer,
-                    hdrStaticInfo != null ? hdrStaticInfo.array() : null,
-                    bitdepthLuma,
-                    bitdepthChroma));
+                new ColorInfo.Builder()
+                    .setColorSpace(colorSpace)
+                    .setColorRange(colorRange)
+                    .setColorTransfer(colorTransfer)
+                    .setHdrStaticInfo(hdrStaticInfo != null ? hdrStaticInfo.array() : null)
+                    .setLumaBitdepth(bitdepthLuma)
+                    .setChromaBitdepth(bitdepthChroma)
+                    .build());
 
     if (esdsData != null) {
       formatBuilder

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/AtomParsers.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/AtomParsers.java
@@ -1224,21 +1224,19 @@ import java.util.List;
         ExtractorUtil.checkContainerInput(mimeType == null, /* message= */ null);
         mimeType = MimeTypes.VIDEO_AV1;
         parent.setPosition(childStartPosition + Atom.HEADER_SIZE);
-        if (childAtomSize > Atom.HEADER_SIZE) {
-          parent.skipBytes(1); ;  // marker(1), version(7)
-          int byte2 = parent.readUnsignedByte();
-          int seqProfile = byte2 >> 5;
-          int byte3 = parent.readUnsignedByte();
-          boolean highBitdepth = ((byte3 >> 6) & 0b1) != 0;
+        parent.skipBytes(1); ;  // marker(1), version(7)
+        int byte2 = parent.readUnsignedByte();
+        int seqProfile = byte2 >> 5;
+        int byte3 = parent.readUnsignedByte();
+        boolean highBitdepth = ((byte3 >> 6) & 0b1) != 0;
+        // From https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=44
+        if (seqProfile == 2 && highBitdepth) {
           boolean twelveBit = ((byte3 >> 5) & 0b1) != 0;
-          // From https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=44
-          if (seqProfile == 2 && highBitdepth) {
-            bitdepthLuma = twelveBit ? 12 : 10;
-          } else if (seqProfile <= 2) {
-            bitdepthLuma = highBitdepth ? 10 : 8;
-          }
-          bitdepthChroma = bitdepthLuma;
+          bitdepthLuma = twelveBit ? 12 : 10;
+        } else if (seqProfile <= 2) {
+          bitdepthLuma = highBitdepth ? 10 : 8;
         }
+        bitdepthChroma = bitdepthLuma;
       } else if (childAtomType == Atom.TYPE_clli) {
         if (hdrStaticInfo == null) {
           hdrStaticInfo = allocateHdrStaticInfo();

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
@@ -221,13 +221,13 @@ public final class H264Reader implements ElementaryStreamReader {
                   .setWidth(spsData.width)
                   .setHeight(spsData.height)
                   .setColorInfo(
-                      new ColorInfo(
-                          spsData.colorSpace,
-                          spsData.colorRange,
-                          spsData.colorTransfer,
-                          null,
-                          spsData.bitDepthLumaMinus8 + 8,
-                          spsData.bitDepthChromaMinus8 + 8))
+                      new ColorInfo.Builder()
+                          .setColorSpace(spsData.colorSpace)
+                          .setColorRange(spsData.colorRange)
+                          .setColorTransfer(spsData.colorTransfer)
+                          .setLumaBitdepth(spsData.bitDepthLumaMinus8 + 8)
+                          .setChromaBitdepth(spsData.bitDepthChromaMinus8 + 8)
+                          .build())
                   .setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio)
                   .setInitializationData(initializationData)
                   .build());

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
@@ -20,6 +20,7 @@ import static androidx.media3.extractor.ts.TsPayloadReader.FLAG_RANDOM_ACCESS_IN
 import android.util.SparseArray;
 import androidx.annotation.Nullable;
 import androidx.media3.common.C;
+import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Assertions;
@@ -219,8 +220,14 @@ public final class H264Reader implements ElementaryStreamReader {
                   .setCodecs(codecs)
                   .setWidth(spsData.width)
                   .setHeight(spsData.height)
-                  .setLumaBitdepth(spsData.bitDepthLumaMinus8 + 8)
-                  .setChromaBitdepth(spsData.bitDepthChromaMinus8 + 8)
+                  .setColorInfo(
+                      new ColorInfo(
+                          spsData.colorSpace,
+                          spsData.colorRange,
+                          spsData.colorTransfer,
+                          null,
+                          spsData.bitDepthLumaMinus8 + 8,
+                          spsData.bitDepthChromaMinus8 + 8))
                   .setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio)
                   .setInitializationData(initializationData)
                   .build());

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
@@ -219,6 +219,8 @@ public final class H264Reader implements ElementaryStreamReader {
                   .setCodecs(codecs)
                   .setWidth(spsData.width)
                   .setHeight(spsData.height)
+                  .setLumaBitdepth(spsData.bitDepthLumaMinus8 + 8)
+                  .setChromaBitdepth(spsData.bitDepthChromaMinus8 + 8)
                   .setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio)
                   .setInitializationData(initializationData)
                   .build());

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
@@ -264,6 +264,8 @@ public final class H265Reader implements ElementaryStreamReader {
         .setCodecs(codecs)
         .setWidth(spsData.width)
         .setHeight(spsData.height)
+        .setLumaBitdepth(spsData.bitDepthLumaMinus8 + 8)
+        .setChromaBitdepth(spsData.bitDepthChromaMinus8 + 8)
         .setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio)
         .setInitializationData(Collections.singletonList(csdData))
         .build();

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
@@ -17,6 +17,7 @@ package androidx.media3.extractor.ts;
 
 import androidx.annotation.Nullable;
 import androidx.media3.common.C;
+import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Assertions;
@@ -264,8 +265,14 @@ public final class H265Reader implements ElementaryStreamReader {
         .setCodecs(codecs)
         .setWidth(spsData.width)
         .setHeight(spsData.height)
-        .setLumaBitdepth(spsData.bitDepthLumaMinus8 + 8)
-        .setChromaBitdepth(spsData.bitDepthChromaMinus8 + 8)
+        .setColorInfo(
+            new ColorInfo(
+                spsData.colorSpace,
+                spsData.colorRange,
+                spsData.colorTransfer,
+                null,
+                spsData.bitDepthLumaMinus8 + 8,
+                spsData.bitDepthChromaMinus8 + 8))
         .setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio)
         .setInitializationData(Collections.singletonList(csdData))
         .build();

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
@@ -266,13 +266,13 @@ public final class H265Reader implements ElementaryStreamReader {
         .setWidth(spsData.width)
         .setHeight(spsData.height)
         .setColorInfo(
-            new ColorInfo(
-                spsData.colorSpace,
-                spsData.colorRange,
-                spsData.colorTransfer,
-                null,
-                spsData.bitDepthLumaMinus8 + 8,
-                spsData.bitDepthChromaMinus8 + 8))
+            new ColorInfo.Builder()
+                .setColorSpace(spsData.colorSpace)
+                .setColorRange(spsData.colorRange)
+                .setColorTransfer(spsData.colorTransfer)
+                .setLumaBitdepth(spsData.bitDepthLumaMinus8 + 8)
+                .setChromaBitdepth(spsData.bitDepthChromaMinus8 + 8)
+                .build())
         .setPixelWidthHeightRatio(spsData.pixelWidthHeightRatio)
         .setInitializationData(Collections.singletonList(csdData))
         .build();

--- a/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.0.dump
@@ -17,6 +17,11 @@ track 0:
     width = 180
     height = 120
     pixelWidthHeightRatio = 0.5
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf58.42.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
     initializationData:
       data = length 32, hash 1F3D6E87

--- a/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.0.dump
@@ -18,10 +18,8 @@ track 0:
     height = 120
     pixelWidthHeightRatio = 0.5
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf58.42.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
     initializationData:
       data = length 32, hash 1F3D6E87

--- a/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.1.dump
@@ -17,6 +17,11 @@ track 0:
     width = 180
     height = 120
     pixelWidthHeightRatio = 0.5
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf58.42.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
     initializationData:
       data = length 32, hash 1F3D6E87

--- a/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.1.dump
@@ -18,10 +18,8 @@ track 0:
     height = 120
     pixelWidthHeightRatio = 0.5
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf58.42.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
     initializationData:
       data = length 32, hash 1F3D6E87

--- a/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.2.dump
@@ -17,6 +17,11 @@ track 0:
     width = 180
     height = 120
     pixelWidthHeightRatio = 0.5
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf58.42.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
     initializationData:
       data = length 32, hash 1F3D6E87

--- a/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.2.dump
@@ -18,10 +18,8 @@ track 0:
     height = 120
     pixelWidthHeightRatio = 0.5
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf58.42.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
     initializationData:
       data = length 32, hash 1F3D6E87

--- a/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.3.dump
@@ -17,6 +17,11 @@ track 0:
     width = 180
     height = 120
     pixelWidthHeightRatio = 0.5
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf58.42.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
     initializationData:
       data = length 32, hash 1F3D6E87

--- a/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/jpeg/pixel-motion-photo-jfif-segment-shortened.jpg.3.dump
@@ -18,10 +18,8 @@ track 0:
     height = 120
     pixelWidthHeightRatio = 0.5
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf58.42.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
     initializationData:
       data = length 32, hash 1F3D6E87

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.0.dump
@@ -18,10 +18,8 @@ track 0:
     height = 720
     frameRate = 29.970028
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.0.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 29.970028
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.1.dump
@@ -18,10 +18,8 @@ track 0:
     height = 720
     frameRate = 29.970028
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.1.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 29.970028
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.2.dump
@@ -18,10 +18,8 @@ track 0:
     height = 720
     frameRate = 29.970028
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.2.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 29.970028
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.3.dump
@@ -18,10 +18,8 @@ track 0:
     height = 720
     frameRate = 29.970028
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.3.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 29.970028
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.unknown_length.dump
@@ -18,10 +18,8 @@ track 0:
     height = 720
     frameRate = 29.970028
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample.mp4.unknown_length.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 29.970028
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_18byte_nclx_colr.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_18byte_nclx_colr.mp4.0.dump
@@ -21,6 +21,8 @@ track 0:
       colorSpace = 1
       colorRange = 2
       colorTransfer = 3
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=3718109610, modification time=3718109610, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_18byte_nclx_colr.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_18byte_nclx_colr.mp4.1.dump
@@ -21,6 +21,8 @@ track 0:
       colorSpace = 1
       colorRange = 2
       colorTransfer = 3
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=3718109610, modification time=3718109610, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_18byte_nclx_colr.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_18byte_nclx_colr.mp4.2.dump
@@ -21,6 +21,8 @@ track 0:
       colorSpace = 1
       colorRange = 2
       colorTransfer = 3
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=3718109610, modification time=3718109610, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_18byte_nclx_colr.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_18byte_nclx_colr.mp4.3.dump
@@ -21,6 +21,8 @@ track 0:
       colorSpace = 1
       colorRange = 2
       colorTransfer = 3
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=3718109610, modification time=3718109610, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_18byte_nclx_colr.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_18byte_nclx_colr.mp4.unknown_length.dump
@@ -21,6 +21,8 @@ track 0:
       colorSpace = 1
       colorRange = 2
       colorTransfer = 3
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=3718109610, modification time=3718109610, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_android_slow_motion.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_android_slow_motion.mp4.0.dump
@@ -20,6 +20,8 @@ track 0:
     colorInfo:
       colorSpace = 2
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=major_brand, value=mp42, mdta: key=minor_version, value=0, mdta: key=compatible_brands, value=isommp42, mdta: key=com.android.capture.fps, value=240.0, mdta: key=com.android.version, value=10, mdta: key=encoder, value=Lavf58.29.100, Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
     initializationData:
       data = length 22, hash 4CF81805

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_android_slow_motion.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_android_slow_motion.mp4.1.dump
@@ -20,6 +20,8 @@ track 0:
     colorInfo:
       colorSpace = 2
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=major_brand, value=mp42, mdta: key=minor_version, value=0, mdta: key=compatible_brands, value=isommp42, mdta: key=com.android.capture.fps, value=240.0, mdta: key=com.android.version, value=10, mdta: key=encoder, value=Lavf58.29.100, Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
     initializationData:
       data = length 22, hash 4CF81805

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_android_slow_motion.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_android_slow_motion.mp4.2.dump
@@ -20,6 +20,8 @@ track 0:
     colorInfo:
       colorSpace = 2
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=major_brand, value=mp42, mdta: key=minor_version, value=0, mdta: key=compatible_brands, value=isommp42, mdta: key=com.android.capture.fps, value=240.0, mdta: key=com.android.version, value=10, mdta: key=encoder, value=Lavf58.29.100, Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
     initializationData:
       data = length 22, hash 4CF81805

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_android_slow_motion.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_android_slow_motion.mp4.3.dump
@@ -20,6 +20,8 @@ track 0:
     colorInfo:
       colorSpace = 2
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=major_brand, value=mp42, mdta: key=minor_version, value=0, mdta: key=compatible_brands, value=isommp42, mdta: key=com.android.capture.fps, value=240.0, mdta: key=com.android.version, value=10, mdta: key=encoder, value=Lavf58.29.100, Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
     initializationData:
       data = length 22, hash 4CF81805

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_android_slow_motion.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_android_slow_motion.mp4.unknown_length.dump
@@ -20,6 +20,8 @@ track 0:
     colorInfo:
       colorSpace = 2
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=major_brand, value=mp42, mdta: key=minor_version, value=0, mdta: key=compatible_brands, value=isommp42, mdta: key=com.android.capture.fps, value=240.0, mdta: key=com.android.version, value=10, mdta: key=encoder, value=Lavf58.29.100, Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
     initializationData:
       data = length 22, hash 4CF81805

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented.mp4.0.dump
@@ -12,6 +12,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented.mp4.unknown_length.dump
@@ -12,6 +12,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_large_bitrates.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_large_bitrates.mp4.0.dump
@@ -15,6 +15,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_large_bitrates.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_large_bitrates.mp4.1.dump
@@ -15,6 +15,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_large_bitrates.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_large_bitrates.mp4.2.dump
@@ -15,6 +15,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_large_bitrates.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_large_bitrates.mp4.3.dump
@@ -15,6 +15,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_large_bitrates.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_large_bitrates.mp4.unknown_length.dump
@@ -15,6 +15,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_seekable.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_seekable.mp4.0.dump
@@ -15,6 +15,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_seekable.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_seekable.mp4.1.dump
@@ -15,6 +15,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_seekable.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_seekable.mp4.2.dump
@@ -15,6 +15,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_seekable.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_seekable.mp4.3.dump
@@ -15,6 +15,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_seekable.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_seekable.mp4.unknown_length.dump
@@ -15,6 +15,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_sei.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_sei.mp4.0.dump
@@ -12,6 +12,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_sei.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_sei.mp4.unknown_length.dump
@@ -12,6 +12,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.0.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 29.970028
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.0.dump
@@ -18,10 +18,8 @@ track 0:
     height = 720
     frameRate = 29.970028
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.1.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 29.970028
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.1.dump
@@ -18,10 +18,8 @@ track 0:
     height = 720
     frameRate = 29.970028
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.2.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 29.970028
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.2.dump
@@ -18,10 +18,8 @@ track 0:
     height = 720
     frameRate = 29.970028
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.3.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 29.970028
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.3.dump
@@ -18,10 +18,8 @@ track 0:
     height = 720
     frameRate = 29.970028
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.unknown_length.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 29.970028
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_mdat_too_long.mp4.unknown_length.dump
@@ -18,10 +18,8 @@ track 0:
     height = 720
     frameRate = 29.970028
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_partially_fragmented.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_partially_fragmented.mp4.0.dump
@@ -12,6 +12,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_partially_fragmented.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_partially_fragmented.mp4.unknown_length.dump
@@ -12,6 +12,9 @@ track 0:
     codecs = avc1.64001F
     width = 1080
     height = 720
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4746B5D9
       data = length 10, hash 7A0D0F2B

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_color_info.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_color_info.mp4.0.dump
@@ -22,6 +22,8 @@ track 0:
       colorSpace = 6
       colorRange = 2
       colorTransfer = 7
+      lumaBitdepth = 10
+      chromaBitdepth = 10
     metadata = entries=[mdta: key=com.apple.quicktime.location.accuracy.horizontal, value=3.754789, mdta: key=com.apple.quicktime.location.ISO6709, value=+37.7450-122.4301+066.374/, mdta: key=com.apple.quicktime.make, value=Apple, mdta: key=com.apple.quicktime.model, value=iPhone 12 Pro Max, mdta: key=com.apple.quicktime.software, value=14.5.1, mdta: key=com.apple.quicktime.creationdate, value=2021-05-25T09:21:51-0700, Mp4Timestamp: creation time=3704804511, modification time=3704804511, timescale=600]
     initializationData:
       data = length 526, hash 7B3FC433

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_color_info.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_color_info.mp4.1.dump
@@ -22,6 +22,8 @@ track 0:
       colorSpace = 6
       colorRange = 2
       colorTransfer = 7
+      lumaBitdepth = 10
+      chromaBitdepth = 10
     metadata = entries=[mdta: key=com.apple.quicktime.location.accuracy.horizontal, value=3.754789, mdta: key=com.apple.quicktime.location.ISO6709, value=+37.7450-122.4301+066.374/, mdta: key=com.apple.quicktime.make, value=Apple, mdta: key=com.apple.quicktime.model, value=iPhone 12 Pro Max, mdta: key=com.apple.quicktime.software, value=14.5.1, mdta: key=com.apple.quicktime.creationdate, value=2021-05-25T09:21:51-0700, Mp4Timestamp: creation time=3704804511, modification time=3704804511, timescale=600]
     initializationData:
       data = length 526, hash 7B3FC433

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_color_info.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_color_info.mp4.2.dump
@@ -22,6 +22,8 @@ track 0:
       colorSpace = 6
       colorRange = 2
       colorTransfer = 7
+      lumaBitdepth = 10
+      chromaBitdepth = 10
     metadata = entries=[mdta: key=com.apple.quicktime.location.accuracy.horizontal, value=3.754789, mdta: key=com.apple.quicktime.location.ISO6709, value=+37.7450-122.4301+066.374/, mdta: key=com.apple.quicktime.make, value=Apple, mdta: key=com.apple.quicktime.model, value=iPhone 12 Pro Max, mdta: key=com.apple.quicktime.software, value=14.5.1, mdta: key=com.apple.quicktime.creationdate, value=2021-05-25T09:21:51-0700, Mp4Timestamp: creation time=3704804511, modification time=3704804511, timescale=600]
     initializationData:
       data = length 526, hash 7B3FC433

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_color_info.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_color_info.mp4.3.dump
@@ -22,6 +22,8 @@ track 0:
       colorSpace = 6
       colorRange = 2
       colorTransfer = 7
+      lumaBitdepth = 10
+      chromaBitdepth = 10
     metadata = entries=[mdta: key=com.apple.quicktime.location.accuracy.horizontal, value=3.754789, mdta: key=com.apple.quicktime.location.ISO6709, value=+37.7450-122.4301+066.374/, mdta: key=com.apple.quicktime.make, value=Apple, mdta: key=com.apple.quicktime.model, value=iPhone 12 Pro Max, mdta: key=com.apple.quicktime.software, value=14.5.1, mdta: key=com.apple.quicktime.creationdate, value=2021-05-25T09:21:51-0700, Mp4Timestamp: creation time=3704804511, modification time=3704804511, timescale=600]
     initializationData:
       data = length 526, hash 7B3FC433

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_color_info.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_color_info.mp4.unknown_length.dump
@@ -22,6 +22,8 @@ track 0:
       colorSpace = 6
       colorRange = 2
       colorTransfer = 7
+      lumaBitdepth = 10
+      chromaBitdepth = 10
     metadata = entries=[mdta: key=com.apple.quicktime.location.accuracy.horizontal, value=3.754789, mdta: key=com.apple.quicktime.location.ISO6709, value=+37.7450-122.4301+066.374/, mdta: key=com.apple.quicktime.make, value=Apple, mdta: key=com.apple.quicktime.model, value=iPhone 12 Pro Max, mdta: key=com.apple.quicktime.software, value=14.5.1, mdta: key=com.apple.quicktime.creationdate, value=2021-05-25T09:21:51-0700, Mp4Timestamp: creation time=3704804511, modification time=3704804511, timescale=600]
     initializationData:
       data = length 526, hash 7B3FC433

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_colr_mdcv_and_clli.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_colr_mdcv_and_clli.mp4.0.dump
@@ -21,6 +21,8 @@ track 0:
       colorRange = 2
       colorTransfer = 6
       hdrStaticInfo = length 25, hash 423AFC35
+      lumaBitdepth = 10
+      chromaBitdepth = 10
     metadata = entries=[TSSE: description=null: values=[Lavf58.76.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_colr_mdcv_and_clli.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_colr_mdcv_and_clli.mp4.1.dump
@@ -21,6 +21,8 @@ track 0:
       colorRange = 2
       colorTransfer = 6
       hdrStaticInfo = length 25, hash 423AFC35
+      lumaBitdepth = 10
+      chromaBitdepth = 10
     metadata = entries=[TSSE: description=null: values=[Lavf58.76.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_colr_mdcv_and_clli.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_colr_mdcv_and_clli.mp4.2.dump
@@ -21,6 +21,8 @@ track 0:
       colorRange = 2
       colorTransfer = 6
       hdrStaticInfo = length 25, hash 423AFC35
+      lumaBitdepth = 10
+      chromaBitdepth = 10
     metadata = entries=[TSSE: description=null: values=[Lavf58.76.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_colr_mdcv_and_clli.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_colr_mdcv_and_clli.mp4.3.dump
@@ -21,6 +21,8 @@ track 0:
       colorRange = 2
       colorTransfer = 6
       hdrStaticInfo = length 25, hash 423AFC35
+      lumaBitdepth = 10
+      chromaBitdepth = 10
     metadata = entries=[TSSE: description=null: values=[Lavf58.76.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_colr_mdcv_and_clli.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_colr_mdcv_and_clli.mp4.unknown_length.dump
@@ -21,6 +21,8 @@ track 0:
       colorRange = 2
       colorTransfer = 6
       hdrStaticInfo = length 25, hash 423AFC35
+      lumaBitdepth = 10
+      chromaBitdepth = 10
     metadata = entries=[TSSE: description=null: values=[Lavf58.76.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_original_quicktime_specification.mov.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_original_quicktime_specification.mov.0.dump
@@ -21,6 +21,8 @@ track 0:
     colorInfo:
       colorRange = 1
       colorTransfer = 3
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=com.apple.quicktime.live-photo.auto, value=01, mdta: key=com.apple.quicktime.content.identifier, value=A873E9D3-2FBA-440A-B4D1-AEB073BC8E54, mdta: key=com.apple.quicktime.live-photo.vitality-score, value=0.9398496, mdta: key=com.apple.quicktime.live-photo.vitality-scoring-version, value=0000000000000004, mdta: key=com.apple.quicktime.make, value=Apple, mdta: key=com.apple.quicktime.model, value=iPhone SE (3rd generation), mdta: key=com.apple.quicktime.software, value=16.5.1, mdta: key=com.apple.quicktime.creationdate, value=2023-07-05T13:13:32+0800, Mp4Timestamp: creation time=3771378882, modification time=3771378882, timescale=600]
     initializationData:
       data = length 78, hash C57F938D

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_original_quicktime_specification.mov.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_original_quicktime_specification.mov.1.dump
@@ -21,6 +21,8 @@ track 0:
     colorInfo:
       colorRange = 1
       colorTransfer = 3
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=com.apple.quicktime.live-photo.auto, value=01, mdta: key=com.apple.quicktime.content.identifier, value=A873E9D3-2FBA-440A-B4D1-AEB073BC8E54, mdta: key=com.apple.quicktime.live-photo.vitality-score, value=0.9398496, mdta: key=com.apple.quicktime.live-photo.vitality-scoring-version, value=0000000000000004, mdta: key=com.apple.quicktime.make, value=Apple, mdta: key=com.apple.quicktime.model, value=iPhone SE (3rd generation), mdta: key=com.apple.quicktime.software, value=16.5.1, mdta: key=com.apple.quicktime.creationdate, value=2023-07-05T13:13:32+0800, Mp4Timestamp: creation time=3771378882, modification time=3771378882, timescale=600]
     initializationData:
       data = length 78, hash C57F938D

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_original_quicktime_specification.mov.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_original_quicktime_specification.mov.2.dump
@@ -21,6 +21,8 @@ track 0:
     colorInfo:
       colorRange = 1
       colorTransfer = 3
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=com.apple.quicktime.live-photo.auto, value=01, mdta: key=com.apple.quicktime.content.identifier, value=A873E9D3-2FBA-440A-B4D1-AEB073BC8E54, mdta: key=com.apple.quicktime.live-photo.vitality-score, value=0.9398496, mdta: key=com.apple.quicktime.live-photo.vitality-scoring-version, value=0000000000000004, mdta: key=com.apple.quicktime.make, value=Apple, mdta: key=com.apple.quicktime.model, value=iPhone SE (3rd generation), mdta: key=com.apple.quicktime.software, value=16.5.1, mdta: key=com.apple.quicktime.creationdate, value=2023-07-05T13:13:32+0800, Mp4Timestamp: creation time=3771378882, modification time=3771378882, timescale=600]
     initializationData:
       data = length 78, hash C57F938D

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_original_quicktime_specification.mov.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_original_quicktime_specification.mov.3.dump
@@ -21,6 +21,8 @@ track 0:
     colorInfo:
       colorRange = 1
       colorTransfer = 3
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=com.apple.quicktime.live-photo.auto, value=01, mdta: key=com.apple.quicktime.content.identifier, value=A873E9D3-2FBA-440A-B4D1-AEB073BC8E54, mdta: key=com.apple.quicktime.live-photo.vitality-score, value=0.9398496, mdta: key=com.apple.quicktime.live-photo.vitality-scoring-version, value=0000000000000004, mdta: key=com.apple.quicktime.make, value=Apple, mdta: key=com.apple.quicktime.model, value=iPhone SE (3rd generation), mdta: key=com.apple.quicktime.software, value=16.5.1, mdta: key=com.apple.quicktime.creationdate, value=2023-07-05T13:13:32+0800, Mp4Timestamp: creation time=3771378882, modification time=3771378882, timescale=600]
     initializationData:
       data = length 78, hash C57F938D

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_original_quicktime_specification.mov.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_with_original_quicktime_specification.mov.unknown_length.dump
@@ -21,6 +21,8 @@ track 0:
     colorInfo:
       colorRange = 1
       colorTransfer = 3
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=com.apple.quicktime.live-photo.auto, value=01, mdta: key=com.apple.quicktime.content.identifier, value=A873E9D3-2FBA-440A-B4D1-AEB073BC8E54, mdta: key=com.apple.quicktime.live-photo.vitality-score, value=0.9398496, mdta: key=com.apple.quicktime.live-photo.vitality-scoring-version, value=0000000000000004, mdta: key=com.apple.quicktime.make, value=Apple, mdta: key=com.apple.quicktime.model, value=iPhone SE (3rd generation), mdta: key=com.apple.quicktime.software, value=16.5.1, mdta: key=com.apple.quicktime.creationdate, value=2023-07-05T13:13:32+0800, Mp4Timestamp: creation time=3771378882, modification time=3771378882, timescale=600]
     initializationData:
       data = length 78, hash C57F938D

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_dts_audio.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_dts_audio.ts.0.dump
@@ -15,6 +15,11 @@ track 256:
     codecs = avc1.64001E
     width = 640
     height = 426
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_dts_audio.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_dts_audio.ts.0.dump
@@ -16,10 +16,8 @@ track 256:
     width = 640
     height = 426
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_dts_audio.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_dts_audio.ts.unknown_length.dump
@@ -12,6 +12,11 @@ track 256:
     codecs = avc1.64001E
     width = 640
     height = 426
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_dts_audio.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_dts_audio.ts.unknown_length.dump
@@ -13,10 +13,8 @@ track 256:
     width = 640
     height = 426
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.0.dump
@@ -15,6 +15,11 @@ track 256:
     codecs = avc1.64001E
     width = 640
     height = 426
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.0.dump
@@ -16,10 +16,8 @@ track 256:
     width = 640
     height = 426
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.1.dump
@@ -15,6 +15,11 @@ track 256:
     codecs = avc1.64001E
     width = 640
     height = 426
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.1.dump
@@ -16,10 +16,8 @@ track 256:
     width = 640
     height = 426
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.2.dump
@@ -15,6 +15,11 @@ track 256:
     codecs = avc1.64001E
     width = 640
     height = 426
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.2.dump
@@ -16,10 +16,8 @@ track 256:
     width = 640
     height = 426
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.3.dump
@@ -15,6 +15,11 @@ track 256:
     codecs = avc1.64001E
     width = 640
     height = 426
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.3.dump
@@ -16,10 +16,8 @@ track 256:
     width = 640
     height = 426
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.unknown_length.dump
@@ -12,6 +12,11 @@ track 256:
     codecs = avc1.64001E
     width = 640
     height = 426
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_mpeg_audio.ts.unknown_length.dump
@@ -13,10 +13,8 @@ track 256:
     width = 640
     height = 426
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.0.dump
@@ -15,6 +15,11 @@ track 256:
     codecs = avc1.64001E
     width = 640
     height = 426
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.0.dump
@@ -16,10 +16,8 @@ track 256:
     width = 640
     height = 426
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.1.dump
@@ -15,6 +15,11 @@ track 256:
     codecs = avc1.64001E
     width = 640
     height = 426
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.1.dump
@@ -16,10 +16,8 @@ track 256:
     width = 640
     height = 426
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.2.dump
@@ -15,6 +15,11 @@ track 256:
     codecs = avc1.64001E
     width = 640
     height = 426
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.2.dump
@@ -16,10 +16,8 @@ track 256:
     width = 640
     height = 426
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.3.dump
@@ -15,6 +15,11 @@ track 256:
     codecs = avc1.64001E
     width = 640
     height = 426
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.3.dump
@@ -16,10 +16,8 @@ track 256:
     width = 640
     height = 426
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.unknown_length.dump
@@ -12,6 +12,11 @@ track 256:
     codecs = avc1.64001E
     width = 640
     height = 426
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h264_no_access_unit_delimiters.ts.unknown_length.dump
@@ -13,10 +13,8 @@ track 256:
     width = 640
     height = 426
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 29, hash 4C2CAE9C
       data = length 9, hash D971CD89

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.0.dump
@@ -16,10 +16,9 @@ track 256:
     width = 854
     height = 480
     colorInfo:
-      colorSpace = -1
       colorRange = 2
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 83, hash 7F428
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.0.dump
@@ -15,6 +15,11 @@ track 256:
     codecs = hvc1.1.6.L90.90
     width = 854
     height = 480
+    colorInfo:
+      colorSpace = -1
+      colorRange = 2
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 83, hash 7F428
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.1.dump
@@ -16,10 +16,9 @@ track 256:
     width = 854
     height = 480
     colorInfo:
-      colorSpace = -1
       colorRange = 2
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 83, hash 7F428
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.1.dump
@@ -15,6 +15,11 @@ track 256:
     codecs = hvc1.1.6.L90.90
     width = 854
     height = 480
+    colorInfo:
+      colorSpace = -1
+      colorRange = 2
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 83, hash 7F428
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.2.dump
@@ -16,10 +16,9 @@ track 256:
     width = 854
     height = 480
     colorInfo:
-      colorSpace = -1
       colorRange = 2
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 83, hash 7F428
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.2.dump
@@ -15,6 +15,11 @@ track 256:
     codecs = hvc1.1.6.L90.90
     width = 854
     height = 480
+    colorInfo:
+      colorSpace = -1
+      colorRange = 2
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 83, hash 7F428
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.3.dump
@@ -16,10 +16,9 @@ track 256:
     width = 854
     height = 480
     colorInfo:
-      colorSpace = -1
       colorRange = 2
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 83, hash 7F428
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.3.dump
@@ -15,6 +15,11 @@ track 256:
     codecs = hvc1.1.6.L90.90
     width = 854
     height = 480
+    colorInfo:
+      colorSpace = -1
+      colorRange = 2
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 83, hash 7F428
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.unknown_length.dump
@@ -13,10 +13,9 @@ track 256:
     width = 854
     height = 480
     colorInfo:
-      colorSpace = -1
       colorRange = 2
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 83, hash 7F428
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265.ts.unknown_length.dump
@@ -12,6 +12,11 @@ track 256:
     codecs = hvc1.1.6.L90.90
     width = 854
     height = 480
+    colorInfo:
+      colorSpace = -1
+      colorRange = 2
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 83, hash 7F428
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.0.dump
@@ -16,6 +16,11 @@ track 256:
     width = 914
     height = 686
     pixelWidthHeightRatio = 1.0003651
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 146, hash 61554FEF
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.0.dump
@@ -17,10 +17,8 @@ track 256:
     height = 686
     pixelWidthHeightRatio = 1.0003651
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 146, hash 61554FEF
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.1.dump
@@ -16,6 +16,11 @@ track 256:
     width = 914
     height = 686
     pixelWidthHeightRatio = 1.0003651
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 146, hash 61554FEF
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.1.dump
@@ -17,10 +17,8 @@ track 256:
     height = 686
     pixelWidthHeightRatio = 1.0003651
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 146, hash 61554FEF
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.2.dump
@@ -16,6 +16,11 @@ track 256:
     width = 914
     height = 686
     pixelWidthHeightRatio = 1.0003651
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 146, hash 61554FEF
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.2.dump
@@ -17,10 +17,8 @@ track 256:
     height = 686
     pixelWidthHeightRatio = 1.0003651
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 146, hash 61554FEF
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.3.dump
@@ -16,6 +16,11 @@ track 256:
     width = 914
     height = 686
     pixelWidthHeightRatio = 1.0003651
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 146, hash 61554FEF
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.3.dump
@@ -17,10 +17,8 @@ track 256:
     height = 686
     pixelWidthHeightRatio = 1.0003651
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 146, hash 61554FEF
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.unknown_length.dump
@@ -13,6 +13,11 @@ track 256:
     width = 914
     height = 686
     pixelWidthHeightRatio = 1.0003651
+    colorInfo:
+      colorSpace = -1
+      colorRange = -1
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     initializationData:
       data = length 146, hash 61554FEF
   sample 0:

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h265_rps_pred.ts.unknown_length.dump
@@ -14,10 +14,8 @@ track 256:
     height = 686
     pixelWidthHeightRatio = 1.0003651
     colorInfo:
-      colorSpace = -1
-      colorRange = -1
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     initializationData:
       data = length 146, hash 61554FEF
   sample 0:

--- a/libraries/test_data/src/test/assets/muxerdumps/h265_with_metadata_track.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/h265_with_metadata_track.mp4.dump
@@ -69,6 +69,8 @@ track 2:
       colorSpace = 2
       colorRange = 1
       colorTransfer = 3
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=2083344800, modification time=2083344800, timescale=10000]
     initializationData:
       data = length 85, hash 6F3CAA16

--- a/libraries/test_data/src/test/assets/muxerdumps/hdr10-720p.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/hdr10-720p.mp4.dump
@@ -21,6 +21,8 @@ track 0:
       colorSpace = 6
       colorRange = 2
       colorTransfer = 6
+      lumaBitdepth = 10
+      chromaBitdepth = 10
     metadata = entries=[Mp4Timestamp: creation time=2083344800, modification time=2083344800, timescale=10000]
     initializationData:
       data = length 99, hash 99842E5A

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4_with_0_orientation.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4_with_0_orientation.mp4.dump
@@ -18,6 +18,8 @@ track 0:
     height = 10
     colorInfo:
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=2082849800, modification time=2082849800, timescale=10000]
     initializationData:
       data = length 28, hash 410B510

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4_with_180_orientation.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4_with_180_orientation.mp4.dump
@@ -19,6 +19,8 @@ track 0:
     rotationDegrees = 180
     colorInfo:
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=2082849800, modification time=2082849800, timescale=10000]
     initializationData:
       data = length 28, hash 410B510

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4_with_270_orientation.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4_with_270_orientation.mp4.dump
@@ -19,6 +19,8 @@ track 0:
     rotationDegrees = 270
     colorInfo:
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=2082849800, modification time=2082849800, timescale=10000]
     initializationData:
       data = length 28, hash 410B510

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4_with_90_orientation.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4_with_90_orientation.mp4.dump
@@ -19,6 +19,8 @@ track 0:
     rotationDegrees = 90
     colorInfo:
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=2082849800, modification time=2082849800, timescale=10000]
     initializationData:
       data = length 28, hash 410B510

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4_with_different_tracks_offset.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4_with_different_tracks_offset.mp4.dump
@@ -19,6 +19,8 @@ track 0:
     frameRate = 20000.0
     colorInfo:
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=2083344800, modification time=2083344800, timescale=10000]
     initializationData:
       data = length 28, hash 410B510
@@ -44,6 +46,8 @@ track 1:
     frameRate = 10000.0
     colorInfo:
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=2083344800, modification time=2083344800, timescale=10000]
     initializationData:
       data = length 28, hash 410B510

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4_with_float_metadata.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4_with_float_metadata.mp4.dump
@@ -18,6 +18,8 @@ track 0:
     height = 10
     colorInfo:
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=SomeStringKey, value=10.0, Mp4Timestamp: creation time=2082849800, modification time=2082849800, timescale=10000]
     initializationData:
       data = length 28, hash 410B510

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4_with_frame_rate.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4_with_frame_rate.mp4.dump
@@ -18,6 +18,8 @@ track 0:
     height = 10
     colorInfo:
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=com.android.capture.fps, value=120.0, Mp4Timestamp: creation time=2082849800, modification time=2082849800, timescale=10000]
     initializationData:
       data = length 28, hash 410B510

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4_with_location.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4_with_location.mp4.dump
@@ -18,6 +18,8 @@ track 0:
     height = 10
     colorInfo:
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[xyz: latitude=33.0, longitude=-120.0, Mp4Timestamp: creation time=2082849800, modification time=2082849800, timescale=10000]
     initializationData:
       data = length 28, hash 410B510

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4_with_null_location.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4_with_null_location.mp4.dump
@@ -18,6 +18,8 @@ track 0:
     height = 10
     colorInfo:
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=2082849800, modification time=2082849800, timescale=10000]
     initializationData:
       data = length 28, hash 410B510

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4_with_same_tracks_offset.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4_with_same_tracks_offset.mp4.dump
@@ -19,6 +19,8 @@ track 0:
     frameRate = 20000.0
     colorInfo:
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=2083344800, modification time=2083344800, timescale=10000]
     initializationData:
       data = length 28, hash 410B510
@@ -44,6 +46,8 @@ track 1:
     frameRate = 10000.0
     colorInfo:
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=2083344800, modification time=2083344800, timescale=10000]
     initializationData:
       data = length 28, hash 410B510

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4_with_string_metadata.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4_with_string_metadata.mp4.dump
@@ -18,6 +18,8 @@ track 0:
     height = 10
     colorInfo:
       colorRange = 1
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=SomeStringKey, value=Some Random String, Mp4Timestamp: creation time=2082849800, modification time=2082849800, timescale=10000]
     initializationData:
       data = length 28, hash 410B510

--- a/libraries/test_data/src/test/assets/muxerdumps/partial_hdr10-720p.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/partial_hdr10-720p.mp4.dump
@@ -21,6 +21,8 @@ track 0:
       colorSpace = 6
       colorRange = 2
       colorTransfer = 6
+      lumaBitdepth = 10
+      chromaBitdepth = 10
     metadata = entries=[Mp4Timestamp: creation time=2083344800, modification time=2083344800, timescale=10000]
     initializationData:
       data = length 99, hash 99842E5A

--- a/libraries/test_data/src/test/assets/muxerdumps/sample.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/sample.mp4.dump
@@ -17,6 +17,9 @@ track 0:
     width = 1080
     height = 720
     frameRate = 32.113037
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=2083344800, modification time=2083344800, timescale=10000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/muxerdumps/sample_av1.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/sample_av1.mp4.dump
@@ -16,6 +16,9 @@ track 0:
     width = 1080
     height = 720
     frameRate = 31.004547
+    colorInfo:
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[Mp4Timestamp: creation time=2083344800, modification time=2083344800, timescale=10000]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/transformerdumps/mp3/test.mp3/looping_mixedWith_sample_18byte_nclx_colr.mp4.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp3/test.mp3/looping_mixedWith_sample_18byte_nclx_colr.mp4.dump
@@ -18,6 +18,8 @@ format video:
     colorSpace = 1
     colorRange = 2
     colorTransfer = 3
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=3718109610, modification time=3718109610, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/noaudio.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/noaudio.dump
@@ -6,6 +6,11 @@ format video:
   width = 1080
   height = 720
   frameRate = 29.970028
+  colorInfo:
+    colorSpace = -1
+    colorRange = -1
+    colorTransfer = -1
+    hdrStaticInfo = length 0, hash 0
   metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/noaudio.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/noaudio.dump
@@ -7,10 +7,8 @@ format video:
   height = 720
   frameRate = 29.970028
   colorInfo:
-    colorSpace = -1
-    colorRange = -1
-    colorTransfer = -1
-    hdrStaticInfo = length 0, hash 0
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/original.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/original.dump
@@ -18,6 +18,11 @@ format video:
   width = 1080
   height = 720
   frameRate = 29.970028
+  colorInfo:
+    colorSpace = -1
+    colorRange = -1
+    colorTransfer = -1
+    hdrStaticInfo = length 0, hash 0
   metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/original.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/original.dump
@@ -19,10 +19,8 @@ format video:
   height = 720
   frameRate = 29.970028
   colorInfo:
-    colorSpace = -1
-    colorRange = -1
-    colorTransfer = -1
-    hdrStaticInfo = length 0, hash 0
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/original_original_transmux.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/original_original_transmux.dump
@@ -18,6 +18,11 @@ format video:
   width = 1080
   height = 720
   frameRate = 29.970028
+  colorInfo:
+    colorSpace = -1
+    colorRange = -1
+    colorTransfer = -1
+    hdrStaticInfo = length 0, hash 0
   metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/original_original_transmux.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/original_original_transmux.dump
@@ -19,10 +19,8 @@ format video:
   height = 720
   frameRate = 29.970028
   colorInfo:
-    colorSpace = -1
-    colorRange = -1
-    colorTransfer = -1
-    hdrStaticInfo = length 0, hash 0
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/rotated.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/rotated.dump
@@ -20,10 +20,8 @@ format video:
   frameRate = 29.970028
   rotationDegrees = 90
   colorInfo:
-    colorSpace = -1
-    colorRange = -1
-    colorTransfer = -1
-    hdrStaticInfo = length 0, hash 0
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/rotated.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/rotated.dump
@@ -19,6 +19,11 @@ format video:
   height = 720
   frameRate = 29.970028
   rotationDegrees = 90
+  colorInfo:
+    colorSpace = -1
+    colorRange = -1
+    colorTransfer = -1
+    hdrStaticInfo = length 0, hash 0
   metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/silence.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/silence.dump
@@ -13,10 +13,8 @@ format video:
   height = 720
   frameRate = 29.970028
   colorInfo:
-    colorSpace = -1
-    colorRange = -1
-    colorTransfer = -1
-    hdrStaticInfo = length 0, hash 0
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/silence.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/silence.dump
@@ -12,6 +12,11 @@ format video:
   width = 1080
   height = 720
   frameRate = 29.970028
+  colorInfo:
+    colorSpace = -1
+    colorRange = -1
+    colorTransfer = -1
+    hdrStaticInfo = length 0, hash 0
   metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/silence_48000hz.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/silence_48000hz.dump
@@ -13,10 +13,8 @@ format video:
   height = 720
   frameRate = 29.970028
   colorInfo:
-    colorSpace = -1
-    colorRange = -1
-    colorTransfer = -1
-    hdrStaticInfo = length 0, hash 0
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/silence_48000hz.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/silence_48000hz.dump
@@ -12,6 +12,11 @@ format video:
   width = 1080
   height = 720
   frameRate = 29.970028
+  colorInfo:
+    colorSpace = -1
+    colorRange = -1
+    colorTransfer = -1
+    hdrStaticInfo = length 0, hash 0
   metadata = entries=[TSSE: description=null: values=[Lavf56.1.0], xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_capture_fps.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_capture_fps.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 32.113037
+    colorInfo:
+      colorSpace = -1
+      colorRange = 2
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[mdta: key=com.android.capture.fps, value=60.0, xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=10000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_capture_fps.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_capture_fps.dump
@@ -18,10 +18,9 @@ track 0:
     height = 720
     frameRate = 32.113037
     colorInfo:
-      colorSpace = -1
       colorRange = 2
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=com.android.capture.fps, value=60.0, xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=10000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_creation_time.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_creation_time.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 32.113037
+    colorInfo:
+      colorSpace = -1
+      colorRange = 2
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=2000000000, modification time=2000000000, timescale=10000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_creation_time.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_creation_time.dump
@@ -18,10 +18,9 @@ track 0:
     height = 720
     frameRate = 32.113037
     colorInfo:
-      colorSpace = -1
       colorRange = 2
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=2000000000, modification time=2000000000, timescale=10000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_custom_metadata.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_custom_metadata.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 32.113037
+    colorInfo:
+      colorSpace = -1
+      colorRange = 2
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[mdta: key=StringKey, value=StringValue, mdta: key=FloatKey, value=600.0, xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=10000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_custom_metadata.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_custom_metadata.dump
@@ -18,10 +18,9 @@ track 0:
     height = 720
     frameRate = 32.113037
     colorInfo:
-      colorSpace = -1
       colorRange = 2
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[mdta: key=StringKey, value=StringValue, mdta: key=FloatKey, value=600.0, xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=10000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_location_metadata.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_location_metadata.dump
@@ -18,10 +18,9 @@ track 0:
     height = 720
     frameRate = 32.113037
     colorInfo:
-      colorSpace = -1
       colorRange = 2
-      colorTransfer = -1
-      hdrStaticInfo = length 0, hash 0
+      lumaBitdepth = 8
+      chromaBitdepth = 8
     metadata = entries=[xyz: latitude=45.0, longitude=-90.0, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=10000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_location_metadata.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample.mp4/with_location_metadata.dump
@@ -17,6 +17,11 @@ track 0:
     width = 1080
     height = 720
     frameRate = 32.113037
+    colorInfo:
+      colorSpace = -1
+      colorRange = 2
+      colorTransfer = -1
+      hdrStaticInfo = length 0, hash 0
     metadata = entries=[xyz: latitude=45.0, longitude=-90.0, Mp4Timestamp: creation time=3547558895, modification time=3547558895, timescale=10000]
     initializationData:
       data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_18byte_nclx_colr.mp4/looping_mixedWith_test.mp3.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_18byte_nclx_colr.mp4/looping_mixedWith_test.mp3.dump
@@ -18,6 +18,8 @@ format video:
     colorSpace = 1
     colorRange = 2
     colorTransfer = 3
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=3718109610, modification time=3718109610, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_18byte_nclx_colr.mp4/original.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_18byte_nclx_colr.mp4/original.dump
@@ -10,6 +10,8 @@ format video:
     colorSpace = 1
     colorRange = 2
     colorTransfer = 3
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=3718109610, modification time=3718109610, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_18byte_nclx_colr.mp4/silence.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_18byte_nclx_colr.mp4/silence.dump
@@ -16,6 +16,8 @@ format video:
     colorSpace = 1
     colorRange = 2
     colorTransfer = 3
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=3718109610, modification time=3718109610, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_sef_slow_motion.mp4/noaudio.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_sef_slow_motion.mp4/noaudio.dump
@@ -6,6 +6,11 @@ format video:
   width = 320
   height = 240
   frameRate = 29.523811
+  colorInfo:
+    colorSpace = -1
+    colorRange = -1
+    colorTransfer = -1
+    hdrStaticInfo = length 0, hash 0
   metadata = entries=[mdta: key=com.android.version, value=10, mdta: key=com.android.video.temporal_layers_count, value=4, mdta: key=com.android.capture.fps, value=240.0, SlowMotion: segments=[Segment: startTimeMs=88, endTimeMs=879, speedDivisor=2, Segment: startTimeMs=1255, endTimeMs=1970, speedDivisor=8], smta: captureFrameRate=240.0, svcTemporalLayerCount=4, Mp4Timestamp: creation time=3686904890, modification time=3686904890, timescale=1000]
   initializationData:
     data = length 33, hash D3FB879D

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_sef_slow_motion.mp4/noaudio.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_sef_slow_motion.mp4/noaudio.dump
@@ -7,10 +7,8 @@ format video:
   height = 240
   frameRate = 29.523811
   colorInfo:
-    colorSpace = -1
-    colorRange = -1
-    colorTransfer = -1
-    hdrStaticInfo = length 0, hash 0
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[mdta: key=com.android.version, value=10, mdta: key=com.android.video.temporal_layers_count, value=4, mdta: key=com.android.capture.fps, value=240.0, SlowMotion: segments=[Segment: startTimeMs=88, endTimeMs=879, speedDivisor=2, Segment: startTimeMs=1255, endTimeMs=1970, speedDivisor=8], smta: captureFrameRate=240.0, svcTemporalLayerCount=4, Mp4Timestamp: creation time=3686904890, modification time=3686904890, timescale=1000]
   initializationData:
     data = length 33, hash D3FB879D

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_twos_pcm.mp4/original.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_twos_pcm.mp4/original.dump
@@ -13,6 +13,9 @@ format video:
   width = 1080
   height = 720
   frameRate = 29.970028
+  colorInfo:
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_twos_pcm.mp4/silence.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_twos_pcm.mp4/silence.dump
@@ -12,6 +12,9 @@ format video:
   width = 1080
   height = 720
   frameRate = 29.970028
+  colorInfo:
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[xyz: latitude=40.68, longitude=-74.5, Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 29, hash 4746B5D9

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_with_increasing_timestamps_320w_240h.mp4/clipped.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_with_increasing_timestamps_320w_240h.mp4/clipped.dump
@@ -23,6 +23,8 @@ format video:
     colorSpace = 2
     colorRange = 1
     colorTransfer = 3
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[TSSE: description=null: values=[Lavf58.76.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 31, hash 4B108214

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_with_increasing_timestamps_320w_240h.mp4/clipped_clipped_transmux.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sample_with_increasing_timestamps_320w_240h.mp4/clipped_clipped_transmux.dump
@@ -23,6 +23,8 @@ format video:
     colorSpace = 2
     colorRange = 1
     colorTransfer = 3
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[TSSE: description=null: values=[Lavf58.76.100], Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 31, hash 4B108214

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/highPitch_silenceHighPitch.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/highPitch_silenceHighPitch.dump
@@ -16,6 +16,8 @@ format video:
   colorInfo:
     colorSpace = 1
     colorRange = 2
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 34, hash 8D738018

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/mixed_sample_rf64.wav.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/mixed_sample_rf64.wav.dump
@@ -16,6 +16,8 @@ format video:
   colorInfo:
     colorSpace = 1
     colorRange = 2
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 34, hash 8D738018

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/original.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/original.dump
@@ -16,6 +16,8 @@ format video:
   colorInfo:
     colorSpace = 1
     colorRange = 2
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 34, hash 8D738018

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/original_silence.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/original_silence.dump
@@ -16,6 +16,8 @@ format video:
   colorInfo:
     colorSpace = 1
     colorRange = 2
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 34, hash 8D738018

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/sequence_repeated3Times.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/sequence_repeated3Times.dump
@@ -16,6 +16,8 @@ format video:
   colorInfo:
     colorSpace = 1
     colorRange = 2
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 34, hash 8D738018

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/sequence_repeated3Times_mixed_loopingAudiosowt-with-video.mov.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/sequence_repeated3Times_mixed_loopingAudiosowt-with-video.mov.dump
@@ -16,6 +16,8 @@ format video:
   colorInfo:
     colorSpace = 1
     colorRange = 2
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 34, hash 8D738018

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silence.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silence.dump
@@ -15,6 +15,8 @@ format video:
   colorInfo:
     colorSpace = 1
     colorRange = 2
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 34, hash 8D738018

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silenceHighPitch_highPitch.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silenceHighPitch_highPitch.dump
@@ -15,6 +15,8 @@ format video:
   colorInfo:
     colorSpace = 1
     colorRange = 2
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 34, hash 8D738018

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silenceHighPitch_silence.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silenceHighPitch_silence.dump
@@ -15,6 +15,8 @@ format video:
   colorInfo:
     colorSpace = 1
     colorRange = 2
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 34, hash 8D738018

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silenceHighPitch_silenceHighPitch.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silenceHighPitch_silenceHighPitch.dump
@@ -15,6 +15,8 @@ format video:
   colorInfo:
     colorSpace = 1
     colorRange = 2
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 34, hash 8D738018

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silence_original.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silence_original.dump
@@ -15,6 +15,8 @@ format video:
   colorInfo:
     colorSpace = 1
     colorRange = 2
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 34, hash 8D738018

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silence_silence.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silence_silence.dump
@@ -15,6 +15,8 @@ format video:
   colorInfo:
     colorSpace = 1
     colorRange = 2
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 34, hash 8D738018

--- a/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silence_silenceHighPitch.dump
+++ b/libraries/test_data/src/test/assets/transformerdumps/mp4/sowt-with-video.mov/silence_silenceHighPitch.dump
@@ -15,6 +15,8 @@ format video:
   colorInfo:
     colorSpace = 1
     colorRange = 2
+    lumaBitdepth = 8
+    chromaBitdepth = 8
   metadata = entries=[Mp4Timestamp: creation time=0, modification time=0, timescale=1000]
   initializationData:
     data = length 34, hash 8D738018

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/DumpableFormat.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/DumpableFormat.java
@@ -74,6 +74,8 @@ public final class DumpableFormat implements Dumper.Dumpable {
       if (colorInfo.hdrStaticInfo != null) {
         dumper.add("hdrStaticInfo", colorInfo.hdrStaticInfo);
       }
+      addIfNonDefault(dumper, "lumaBitdepth", colorInfo, DEFAULT_COLOR_INFO, c -> c.lumaBitdepth);
+      addIfNonDefault(dumper, "chromaBitdepth", colorInfo, DEFAULT_COLOR_INFO, c -> c.chromaBitdepth);
       dumper.endBlock();
     }
     addIfNonDefault(dumper, "channelCount", format, DEFAULT_FORMAT, format -> format.channelCount);

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/VideoSampleExporter.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/VideoSampleExporter.java
@@ -97,7 +97,7 @@ import org.checkerframework.dataflow.qual.Pure;
     finalFramePresentationTimeUs = C.TIME_UNSET;
 
     ColorInfo decoderInputColor;
-    if (firstInputFormat.colorInfo == null || !firstInputFormat.colorInfo.isValid()) {
+    if (firstInputFormat.colorInfo == null || !firstInputFormat.colorInfo.isColorValid()) {
       Log.d(TAG, "colorInfo is null or invalid. Defaulting to SDR_BT709_LIMITED.");
       decoderInputColor = ColorInfo.SDR_BT709_LIMITED;
     } else {

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/VideoSampleExporter.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/VideoSampleExporter.java
@@ -97,7 +97,7 @@ import org.checkerframework.dataflow.qual.Pure;
     finalFramePresentationTimeUs = C.TIME_UNSET;
 
     ColorInfo decoderInputColor;
-    if (firstInputFormat.colorInfo == null || !firstInputFormat.colorInfo.isColorValid()) {
+    if (firstInputFormat.colorInfo == null || !firstInputFormat.colorInfo.isDataSpaceValid()) {
       Log.d(TAG, "colorInfo is null or invalid. Defaulting to SDR_BT709_LIMITED.");
       decoderInputColor = ColorInfo.SDR_BT709_LIMITED;
     } else {


### PR DESCRIPTION
**Issue**
Videos may be encoded with different bit depths (even between luma and chroma), not just the traditional 8 bpp.

Currently the Format class carries Color metadata, but not bit depths. The capability to decode wide bit depth videos is down to the codec profile support from the device but not always the video profile is associated with a unique bit depth (for ex. not for H266 where Main 10 is for both 8 and 10 bpp). Besides working out the bitdepth from the codec specific profile strings would be cumbersome.

We think it would be useful for e.g. renderers, transformers etc to know the video bit depth. We had this issue internally while working on use cases such as 8bpp base and 10bpp LCEVC enhanced output, but we think it could very well benefit other scenarios.

**Proposed solution**
Add luma and chroma bit depths to the Format class, set them from the various parsers (see changes).
