### PR TITLE
DASH UrlTemplate parses template if it contains more than one time ea…

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -24,6 +24,8 @@
 *   Cronet Extension:
 *   RTMP Extension:
 *   HLS Extension:
+*   DASH Extension:
+    *   Allow multiple of the same DASH identifier in segment template url.
 *   Smooth Streaming Extension:
 *   RTSP Extension:
 *   Decoder Extensions (FFmpeg, VP9, AV1, etc.):

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/UrlTemplate.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/UrlTemplate.java
@@ -17,6 +17,7 @@ package androidx.media3.exoplayer.dash.manifest;
 
 import androidx.media3.common.util.UnstableApi;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -39,9 +40,9 @@ public final class UrlTemplate {
   private static final int BANDWIDTH_ID = 3;
   private static final int TIME_ID = 4;
 
-  private final ArrayList<String> urlPieces;
-  private final ArrayList<Integer> identifiers;
-  private final ArrayList<String> identifierFormatTags;
+  private final List<String> urlPieces;
+  private final List<Integer> identifiers;
+  private final List<String> identifierFormatTags;
   private final int identifierCount;
 
   /**
@@ -52,9 +53,9 @@ public final class UrlTemplate {
    * @throws IllegalArgumentException If the template string is malformed.
    */
   public static UrlTemplate compile(String template) {
-    ArrayList<String> urlPieces = new ArrayList<>();
-    ArrayList<Integer> identifiers = new ArrayList<>();
-    ArrayList<String> identifierFormatTags = new ArrayList<>();
+    List<String> urlPieces = new ArrayList<>();
+    List<Integer> identifiers = new ArrayList<>();
+    List<String> identifierFormatTags = new ArrayList<>();
 
     int identifierCount = parseTemplate(template, urlPieces, identifiers, identifierFormatTags);
     return new UrlTemplate(urlPieces, identifiers, identifierFormatTags, identifierCount);
@@ -62,9 +63,9 @@ public final class UrlTemplate {
 
   /** Internal constructor. Use {@link #compile(String)} to build instances of this class. */
   private UrlTemplate(
-      ArrayList<String> urlPieces,
-      ArrayList<Integer> identifiers,
-      ArrayList<String> identifierFormatTags,
+      List<String> urlPieces,
+      List<Integer> identifiers,
+      List<String> identifierFormatTags,
       int identifierCount) {
     this.urlPieces = urlPieces;
     this.identifiers = identifiers;
@@ -118,9 +119,9 @@ public final class UrlTemplate {
    */
   private static int parseTemplate(
       String template,
-      ArrayList<String> urlPieces,
-      ArrayList<Integer> identifiers,
-      ArrayList<String> identifierFormatTags) {
+      List<String> urlPieces,
+      List<Integer> identifiers,
+      List<String> identifierFormatTags) {
     urlPieces.add("");
     int templateIndex = 0;
     int identifierCount = 0;
@@ -139,7 +140,7 @@ public final class UrlTemplate {
         urlPieces.set(identifierCount, urlPieces.get(identifierCount) + "$");
         templateIndex += 2;
       } else {
-        identifierFormatTags.add(null);
+        identifierFormatTags.add("");
         int secondIndex = template.indexOf("$", templateIndex + 1);
         String identifier = template.substring(templateIndex + 1, secondIndex);
         if (identifier.equals(REPRESENTATION)) {

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/UrlTemplate.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/UrlTemplate.java
@@ -51,11 +51,16 @@ public final class UrlTemplate {
    * @throws IllegalArgumentException If the template string is malformed.
    */
   public static UrlTemplate compile(String template) {
-    // These arrays are sizes assuming each of the four possible identifiers will be present at
-    // most once in the template, which seems like a reasonable assumption.
-    String[] urlPieces = new String[5];
-    int[] identifiers = new int[4];
-    String[] identifierFormatTags = new String[4];
+    // We can have more than once each identifier in the template so we need
+    // to count the total number of identifiers present in the template
+    int identifiersCount = 0;
+    String[] identifiersNames = { REPRESENTATION, NUMBER, BANDWIDTH, TIME };
+    for(String identifierName : identifiersNames){
+      identifiersCount += template.split("\\$" + identifierName + "\\$").length - 1;
+    }
+    String[] urlPieces = new String[identifiersCount+1];
+    int[] identifiers = new int[identifiersCount];
+    String[] identifierFormatTags = new String[identifiersCount];
     int identifierCount = parseTemplate(template, urlPieces, identifiers, identifierFormatTags);
     return new UrlTemplate(urlPieces, identifiers, identifierFormatTags, identifierCount);
   }

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/UrlTemplate.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/UrlTemplate.java
@@ -100,10 +100,11 @@ public final class UrlTemplate {
   /**
    * Parses {@code template}, placing the decomposed components into the provided lists.
    *
-   * <p>If the return value is N, {@code urlPieces} will contain (N+1) strings that must be
-   * interleaved with N arguments in order to construct a url. The N identifiers that correspond to
-   * the required arguments, together with the tags that define their required formatting, are
-   * returned in {@code identifiers} and {@code identifierFormatTags} respectively.
+   * <p>If the number of identifiers in the {@code template} is N, {@code urlPieces} will contain
+   * (N+1) strings that must be interleaved with those N arguments in order to construct a url. The
+   * N identifiers that correspond to the required arguments, together with the tags that define
+   * their required formatting, are returned in {@code identifiers} and {@code identifierFormatTags}
+   * respectively.
    *
    * @param template The template to parse.
    * @param urlPieces A holder for pieces of url parsed from the template.
@@ -122,7 +123,8 @@ public final class UrlTemplate {
       int dollarIndex = template.indexOf("$", templateIndex);
       if (dollarIndex == -1) {
         urlPieces.set(
-            identifiers.size(), urlPieces.get(identifiers.size()) + template.substring(templateIndex));
+            identifiers.size(),
+            urlPieces.get(identifiers.size()) + template.substring(templateIndex));
         templateIndex = template.length();
       } else if (dollarIndex != templateIndex) {
         urlPieces.set(

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/UrlTemplate.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/UrlTemplate.java
@@ -16,7 +16,6 @@
 package androidx.media3.exoplayer.dash.manifest;
 
 import androidx.media3.common.util.UnstableApi;
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Locale;
 
@@ -63,7 +62,10 @@ public final class UrlTemplate {
 
   /** Internal constructor. Use {@link #compile(String)} to build instances of this class. */
   private UrlTemplate(
-      ArrayList<String> urlPieces, ArrayList<Integer> identifiers, ArrayList<String> identifierFormatTags, int identifierCount) {
+      ArrayList<String> urlPieces,
+      ArrayList<Integer> identifiers,
+      ArrayList<String> identifierFormatTags,
+      int identifierCount) {
     this.urlPieces = urlPieces;
     this.identifiers = identifiers;
     this.identifierFormatTags = identifierFormatTags;
@@ -115,17 +117,23 @@ public final class UrlTemplate {
    * @throws IllegalArgumentException If the template string is malformed.
    */
   private static int parseTemplate(
-      String template, ArrayList<String> urlPieces, ArrayList<Integer> identifiers, ArrayList<String> identifierFormatTags) {
+      String template,
+      ArrayList<String> urlPieces,
+      ArrayList<Integer> identifiers,
+      ArrayList<String> identifierFormatTags) {
     urlPieces.add("");
     int templateIndex = 0;
     int identifierCount = 0;
     while (templateIndex < template.length()) {
       int dollarIndex = template.indexOf("$", templateIndex);
       if (dollarIndex == -1) {
-        urlPieces.set(identifierCount, urlPieces.get(identifierCount) + template.substring(templateIndex));
+        urlPieces.set(
+            identifierCount, urlPieces.get(identifierCount) + template.substring(templateIndex));
         templateIndex = template.length();
       } else if (dollarIndex != templateIndex) {
-        urlPieces.set(identifierCount, urlPieces.get(identifierCount) + template.substring(templateIndex, dollarIndex));
+        urlPieces.set(
+            identifierCount,
+            urlPieces.get(identifierCount) + template.substring(templateIndex, dollarIndex));
         templateIndex = dollarIndex;
       } else if (template.startsWith(ESCAPED_DOLLAR, templateIndex)) {
         urlPieces.set(identifierCount, urlPieces.get(identifierCount) + "$");

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/UrlTemplate.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/UrlTemplate.java
@@ -16,6 +16,7 @@
 package androidx.media3.exoplayer.dash.manifest;
 
 import androidx.media3.common.util.UnstableApi;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Locale;
 
@@ -39,9 +40,9 @@ public final class UrlTemplate {
   private static final int BANDWIDTH_ID = 3;
   private static final int TIME_ID = 4;
 
-  private final String[] urlPieces;
-  private final Integer[] identifiers;
-  private final String[] identifierFormatTags;
+  private final ArrayList<String> urlPieces;
+  private final ArrayList<Integer> identifiers;
+  private final ArrayList<String> identifierFormatTags;
   private final int identifierCount;
 
   /**
@@ -63,9 +64,9 @@ public final class UrlTemplate {
   /** Internal constructor. Use {@link #compile(String)} to build instances of this class. */
   private UrlTemplate(
       ArrayList<String> urlPieces, ArrayList<Integer> identifiers, ArrayList<String> identifierFormatTags, int identifierCount) {
-    this.urlPieces = urlPieces.toArray(new String[0]);
-    this.identifiers = identifiers.toArray(new Integer[0]);
-    this.identifierFormatTags = identifierFormatTags.toArray(new String[0]);
+    this.urlPieces = urlPieces;
+    this.identifiers = identifiers;
+    this.identifierFormatTags = identifierFormatTags;
     this.identifierCount = identifierCount;
   }
 
@@ -83,18 +84,18 @@ public final class UrlTemplate {
   public String buildUri(String representationId, long segmentNumber, int bandwidth, long time) {
     StringBuilder builder = new StringBuilder();
     for (int i = 0; i < identifierCount; i++) {
-      builder.append(urlPieces[i]);
-      if (identifiers[i] == REPRESENTATION_ID) {
+      builder.append(urlPieces.get(i));
+      if (identifiers.get(i) == REPRESENTATION_ID) {
         builder.append(representationId);
-      } else if (identifiers[i] == NUMBER_ID) {
-        builder.append(String.format(Locale.US, identifierFormatTags[i], segmentNumber));
-      } else if (identifiers[i] == BANDWIDTH_ID) {
-        builder.append(String.format(Locale.US, identifierFormatTags[i], bandwidth));
-      } else if (identifiers[i] == TIME_ID) {
-        builder.append(String.format(Locale.US, identifierFormatTags[i], time));
+      } else if (identifiers.get(i) == NUMBER_ID) {
+        builder.append(String.format(Locale.US, identifierFormatTags.get(i), segmentNumber));
+      } else if (identifiers.get(i) == BANDWIDTH_ID) {
+        builder.append(String.format(Locale.US, identifierFormatTags.get(i), bandwidth));
+      } else if (identifiers.get(i) == TIME_ID) {
+        builder.append(String.format(Locale.US, identifierFormatTags.get(i), time));
       }
     }
-    builder.append(urlPieces[identifierCount]);
+    builder.append(urlPieces.get(identifierCount));
     return builder.toString();
   }
 

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/UrlTemplate.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/UrlTemplate.java
@@ -17,6 +17,8 @@ package androidx.media3.exoplayer.dash.manifest;
 
 import androidx.media3.common.util.UnstableApi;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * A template from which URLs can be built.
@@ -56,7 +58,10 @@ public final class UrlTemplate {
     int identifiersCount = 0;
     String[] identifiersNames = { REPRESENTATION, NUMBER, BANDWIDTH, TIME };
     for(String identifierName : identifiersNames){
-      identifiersCount += template.split("\\$" + identifierName + "\\$").length - 1;
+      Pattern pattern = Pattern.compile("(\\$" + identifierName + "\\$|" + ESCAPED_DOLLAR + "\\$" + identifierName + "\\$" + ESCAPED_DOLLAR +")");
+      Matcher matcher = pattern.matcher(template);
+      while(matcher.find())
+        identifiersCount++;
     }
     String[] urlPieces = new String[identifiersCount+1];
     int[] identifiers = new int[identifiersCount];

--- a/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/manifest/UrlTemplateTest.java
+++ b/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/manifest/UrlTemplateTest.java
@@ -72,16 +72,18 @@ public class UrlTemplateTest {
   }
 
   @Test
-  public void fullWithMultipleOccurrences(){
-    String template = "$Bandwidth$_a1_$RepresentationID$_b1_$Time$_c1_$Number$_$Bandwidth$_a2_$RepresentationID$_b2_$Time$_c2_$Number$";
+  public void fullWithMultipleOccurrences() {
+    String template =
+        "$Bandwidth$_a1_$RepresentationID$_b1_$Time$_c1_$Number$_$Bandwidth$_a2_$RepresentationID$_b2_$Time$_c2_$Number$";
     UrlTemplate urlTemplate = UrlTemplate.compile(template);
     String url = urlTemplate.buildUri("abc1", 10, 650000, 5000);
     assertThat(url).isEqualTo("650000_a1_abc1_b1_5000_c1_10_650000_a2_abc1_b2_5000_c2_10");
   }
 
   @Test
-  public void fullWithMultipleOccurrencesAndDollarEscaping(){
-    String template = "$$$Bandwidth$$$_a1$$_$RepresentationID$_b1_$Time$_c1_$Number$$$_$$$Bandwidth$$$_a2$$_$RepresentationID$_b2_$Time$_c2_$Number$$$";
+  public void fullWithMultipleOccurrencesAndDollarEscaping() {
+    String template =
+        "$$$Bandwidth$$$_a1$$_$RepresentationID$_b1_$Time$_c1_$Number$$$_$$$Bandwidth$$$_a2$$_$RepresentationID$_b2_$Time$_c2_$Number$$$";
     UrlTemplate urlTemplate = UrlTemplate.compile(template);
     String url = urlTemplate.buildUri("abc1", 10, 650000, 5000);
     assertThat(url).isEqualTo("$650000$_a1$_abc1_b1_5000_c1_10$_$650000$_a2$_abc1_b2_5000_c2_10$");

--- a/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/manifest/UrlTemplateTest.java
+++ b/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/manifest/UrlTemplateTest.java
@@ -70,4 +70,20 @@ public class UrlTemplateTest {
       // Expected.
     }
   }
+
+  @Test
+  public void fullWithMultipleOccurrences(){
+    String template = "$Bandwidth$_a1_$RepresentationID$_b1_$Time$_c1_$Number$_$Bandwidth$_a2_$RepresentationID$_b2_$Time$_c2_$Number$";
+    UrlTemplate urlTemplate = UrlTemplate.compile(template);
+    String url = urlTemplate.buildUri("abc1", 10, 650000, 5000);
+    assertThat(url).isEqualTo("650000_a1_abc1_b1_5000_c1_10_650000_a2_abc1_b2_5000_c2_10");
+  }
+
+  @Test
+  public void fullWithMultipleOccurrencesAndDollarEscaping(){
+    String template = "$$$Bandwidth$$$_a1$$_$RepresentationID$_b1_$Time$_c1_$Number$$$_$$$Bandwidth$$$_a2$$_$RepresentationID$_b2_$Time$_c2_$Number$$$";
+    UrlTemplate urlTemplate = UrlTemplate.compile(template);
+    String url = urlTemplate.buildUri("abc1", 10, 650000, 5000);
+    assertThat(url).isEqualTo("$650000$_a1$_abc1_b1_5000_c1_10$_$650000$_a2$_abc1_b2_5000_c2_10$");
+  }
 }


### PR DESCRIPTION
With DASH, it's possible to have multiple times each DASH identifier in a template (for example by using a proxy, see [Chaos streaming proxy](https://github.com/Eyevinn/chaos-stream-proxy)).
This commit allows to compile templates containing more than 4 identifiers (it was not possible before)