### PR TITLE
Format passed to audioSink.configure is missing information.

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DecoderAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DecoderAudioRenderer.java
@@ -447,6 +447,12 @@ public abstract class DecoderAudioRenderer<
               .buildUpon()
               .setEncoderDelay(encoderDelay)
               .setEncoderPadding(encoderPadding)
+              .setMetadata(inputFormat.metadata)
+              .setId(inputFormat.id)
+              .setLabel(inputFormat.label)
+              .setLanguage(inputFormat.language)
+              .setSelectionFlags(inputFormat.selectionFlags)
+              .setRoleFlags(inputFormat.roleFlags)
               .build();
       audioSink.configure(outputFormat, /* specifiedBufferSize= */ 0, /* outputChannels= */ null);
       audioTrackNeedsConfigure = false;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
@@ -562,6 +562,12 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
               .setPcmEncoding(pcmEncoding)
               .setEncoderDelay(format.encoderDelay)
               .setEncoderPadding(format.encoderPadding)
+              .setMetadata(format.metadata)
+              .setId(format.id)
+              .setLabel(format.label)
+              .setLanguage(format.language)
+              .setSelectionFlags(format.selectionFlags)
+              .setRoleFlags(format.roleFlags)
               .setChannelCount(mediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT))
               .setSampleRate(mediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE))
               .build();


### PR DESCRIPTION
AudioSink might require the identifying data and metadata to be able to take decisions.