### PR TITLE
GL: Fix non-standard call to glEnableVertexAttribArray

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/GlProgram.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/GlProgram.java
@@ -303,7 +303,7 @@ public final class GlProgram {
       GLES20.glBindBuffer(GLES20.GL_ARRAY_BUFFER, /* buffer= */ 0);
       GLES20.glVertexAttribPointer(
           location, size, GLES20.GL_FLOAT, /* normalized= */ false, /* stride= */ 0, buffer);
-      GLES20.glEnableVertexAttribArray(index);
+      GLES20.glEnableVertexAttribArray(location);
       GlUtil.checkGlError();
     }
   }


### PR DESCRIPTION
When setting up vertex arrays, glEnableVertexAttribArray should use the location parameter instead of the externally passed index parameter, to be consistent with the above glVertexAttribPointer.