### PR TITLE
Fix playback of AAC in TS files

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -44,6 +44,9 @@
         `ColorInfo.colorSpace`, `ColorInfo.colorTransfer`, and
         `ColorInfo.colorRange` values
         ([#692](https://github.com/androidx/media/pull/692)).
+    *   Fix playback of AAC in TS files when channel config is `0` by reading
+        Program Config Element (PCE)
+        ([#722](https://github.com/androidx/media/pull/722)).
 *   Audio:
 *   Video:
     *   Add workaround for a device issue on Galaxy Tab S7 FE, Chromecast with

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/AdtsReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/AdtsReader.java
@@ -608,8 +608,11 @@ public final class AdtsReader implements ElementaryStreamReader {
         pceBuffer.setPosition(3 /* PCE tag */);
         pceBuffer.readBits(newConfig, oldConfig.length, numPceBits);
 
-        pendingOutputFormat = pendingOutputFormat.buildUpon()
-            .setInitializationData(Collections.singletonList(newConfig)).build();
+        pendingOutputFormat =
+            pendingOutputFormat
+                .buildUpon()
+                .setInitializationData(Collections.singletonList(newConfig))
+                .build();
 
         // Submit PCE-appended output format.
         currentOutput.format(pendingOutputFormat);

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/ts/AdtsReaderTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/ts/AdtsReaderTest.java
@@ -65,8 +65,7 @@ public class AdtsReaderTest {
       TestUtil.createByteArray(0xff, 0xf1, 0x50, 0x00, 0x02, 0x1f, 0xfc);
 
   private static final byte[] AAC_PCE_ADTS_CONTENT =
-      TestUtil.createByteArray(
-          0xa0, 0x99, 0x01, 0x20, 0x00, 0x21, 0x19, 0x00, 0x00);
+      TestUtil.createByteArray(0xa0, 0x99, 0x01, 0x20, 0x00, 0x21, 0x19, 0x00, 0x00);
 
   private static final byte[] AAC_PCE_TEST_DATA =
       Bytes.concat(AAC_PCE_ADTS_HEADER, AAC_PCE_ADTS_CONTENT);
@@ -202,16 +201,17 @@ public class AdtsReaderTest {
   @Test
   public void aacPceData() throws ParserException {
     data = new ParsableByteArray(AAC_PCE_TEST_DATA);
+
     feed();
+
     assertSampleCounts(0, 1);
     adtsOutput.assertSample(0, AAC_PCE_ADTS_CONTENT, 0, C.BUFFER_FLAG_KEY_FRAME, null);
   }
 
   @Test(expected = IllegalStateException.class)
   public void aacPceDataFail() throws ParserException {
-    data = new ParsableByteArray(AAC_PCE_TEST_DATA);
+    data = new ParsableByteArray(Arrays.copyOf(AAC_PCE_TEST_DATA, AAC_PCE_TEST_DATA.length));
     byte[] bytes = data.getData();
-
     // Remove PCE tag (first 3 bits of content).
     bytes[AAC_PCE_ADTS_HEADER.length] &= 0x1f;
     // Replace with CPE tag.

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/ts/AdtsReaderTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/ts/AdtsReaderTest.java
@@ -17,6 +17,7 @@ package androidx.media3.extractor.ts;
 
 import static androidx.media3.extractor.ts.TsPayloadReader.FLAG_DATA_ALIGNMENT_INDICATOR;
 import static java.lang.Math.min;
+import static org.junit.Assert.assertThrows;
 
 import androidx.media3.common.C;
 import androidx.media3.common.ParserException;
@@ -208,7 +209,7 @@ public class AdtsReaderTest {
     adtsOutput.assertSample(0, AAC_PCE_ADTS_CONTENT, 0, C.BUFFER_FLAG_KEY_FRAME, null);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void aacPceDataFail() throws ParserException {
     data = new ParsableByteArray(Arrays.copyOf(AAC_PCE_TEST_DATA, AAC_PCE_TEST_DATA.length));
     byte[] bytes = data.getData();
@@ -218,7 +219,7 @@ public class AdtsReaderTest {
     bytes[AAC_PCE_ADTS_HEADER.length] |= 0x20;
 
     // Should throw as FakeTrackOutput expects a format before sampleMetadata.
-    feed();
+    assertThrows(IllegalStateException.class, this::feed);
   }
 
   private void feedLimited(int limit) throws ParserException {

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/ts/AdtsReaderTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/ts/AdtsReaderTest.java
@@ -210,6 +210,22 @@ public class AdtsReaderTest {
   }
 
   @Test
+  public void aacPceDataSplit() throws ParserException {
+    byte[] first = Arrays.copyOf(AAC_PCE_TEST_DATA, AAC_PCE_ADTS_HEADER.length + 1);
+    byte[] second =
+        Arrays.copyOfRange(
+            AAC_PCE_TEST_DATA, AAC_PCE_ADTS_HEADER.length + 1, AAC_PCE_TEST_DATA.length);
+
+    data = new ParsableByteArray(first);
+    feed();
+    data = new ParsableByteArray(second);
+    feed();
+
+    assertSampleCounts(0, 1);
+    adtsOutput.assertSample(0, AAC_PCE_ADTS_CONTENT, 0, C.BUFFER_FLAG_KEY_FRAME, null);
+  }
+
+  @Test
   public void aacPceDataFail() throws ParserException {
     data = new ParsableByteArray(Arrays.copyOf(AAC_PCE_TEST_DATA, AAC_PCE_TEST_DATA.length));
     byte[] bytes = data.getData();

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/ts/AdtsReaderTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/ts/AdtsReaderTest.java
@@ -61,6 +61,16 @@ public class AdtsReaderTest {
   private static final byte[] TEST_DATA =
       Bytes.concat(ID3_DATA_1, ID3_DATA_2, ADTS_HEADER, ADTS_CONTENT);
 
+  private static final byte[] AAC_PCE_ADTS_HEADER =
+      TestUtil.createByteArray(0xff, 0xf1, 0x50, 0x00, 0x02, 0x1f, 0xfc);
+
+  private static final byte[] AAC_PCE_ADTS_CONTENT =
+      TestUtil.createByteArray(
+          0xa0, 0x99, 0x01, 0x20, 0x00, 0x21, 0x19, 0x00, 0x00);
+
+  private static final byte[] AAC_PCE_TEST_DATA =
+      Bytes.concat(AAC_PCE_ADTS_HEADER, AAC_PCE_ADTS_CONTENT);
+
   private static final long ADTS_SAMPLE_DURATION = 23219L;
 
   private FakeTrackOutput adtsOutput;
@@ -187,6 +197,28 @@ public class AdtsReaderTest {
     feed();
     assertSampleCounts(0, 1);
     adtsOutput.assertSample(0, ADTS_CONTENT, 0, C.BUFFER_FLAG_KEY_FRAME, null);
+  }
+
+  @Test
+  public void aacPceData() throws ParserException {
+    data = new ParsableByteArray(AAC_PCE_TEST_DATA);
+    feed();
+    assertSampleCounts(0, 1);
+    adtsOutput.assertSample(0, AAC_PCE_ADTS_CONTENT, 0, C.BUFFER_FLAG_KEY_FRAME, null);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void aacPceDataFail() throws ParserException {
+    data = new ParsableByteArray(AAC_PCE_TEST_DATA);
+    byte[] bytes = data.getData();
+
+    // Remove PCE tag (first 3 bits of content).
+    bytes[AAC_PCE_ADTS_HEADER.length] &= 0x1f;
+    // Replace with CPE tag.
+    bytes[AAC_PCE_ADTS_HEADER.length] |= 0x20;
+
+    // Should throw as FakeTrackOutput expects a format before sampleMetadata.
+    feed();
   }
 
   private void feedLimited(int limit) throws ParserException {


### PR DESCRIPTION
When the channel config is 0 in the ADTS header, delay the submission of the format to the output until a Program Config Element (PCE) is found and appended to the format's initialization data.

This reproduces the initialization data payload that is submitted by the same AAC stream when inside other containers such as MP4 or MKV.

Fixes issue #695