### PR TITLE
Fix AudioCapabilities regression

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -22,6 +22,7 @@
 *   Audio:
     *   Fix DTS Express audio buffer underflow issue
         ([#650](https://github.com/androidx/media/pull/650)).
+    * Fix bug where the capabilties check for E-AC3-JOC throws an `IllegalArgumentException` ([#677](https://github.com/androidx/media/issues/677)).
 *   Video:
 *   Text:
     *   Remove `ExoplayerCuesDecoder`. Text tracks with `sampleMimeType =

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -406,11 +406,15 @@ public final class AudioCapabilities {
       // TODO(internal b/234351617): Query supported channel masks directly once it's supported,
       // see also b/25994457.
       for (int channelCount = DEFAULT_MAX_CHANNEL_COUNT; channelCount > 0; channelCount--) {
+        int channelConfig = Util.getAudioTrackChannelConfig(channelCount);
+        if (channelConfig == AudioFormat.CHANNEL_INVALID) {
+          continue;
+        }
         AudioFormat audioFormat =
             new AudioFormat.Builder()
                 .setEncoding(encoding)
                 .setSampleRate(sampleRate)
-                .setChannelMask(Util.getAudioTrackChannelConfig(channelCount))
+                .setChannelMask(channelConfig)
                 .build();
         if (AudioTrack.isDirectPlaybackSupported(audioFormat, DEFAULT_AUDIO_ATTRIBUTES)) {
           return channelCount;


### PR DESCRIPTION
Since DEFAULT_MAX_CHANNEL_COUNT was increased from 8 to 10, getMaxSupportedChannelCountForPassthrough always throws if its loop enters its second iteration (channelCount of 9). This is due to Util.getAudioTrackChannelConfig returning CHANNEL_INVALID when passed a channelCount of 9, and setting CHANNEL_INVALID as the AudioFormat's channel mask throws an exception.

This change skips each iteration where CHANNEL_INVALID is returned.

Fixes issue #677