### PR TITLE
Fixes issue #9347 - jump to live on seek to 0

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -33,6 +33,9 @@
     *   Fix issue that OPUS and VORBIS channel layouts are wrong for 3, 5, 6, 7
         and 8 channels
         ([#8396](https://github.com/google/ExoPlayer/issues/8396)).
+    *   Fix issue where track selections after seek to zero in a live stream
+        incorrectly let the stream start at its default position
+        ([#9347](https://github.com/google/ExoPlayer/issues/9347)).
 *   Transformer:
     *   Add support for flattening H.265/HEVC SEF slow motion videos.
     *   Increase transmuxing speed, especially for 'remove video' edits.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/MaskingMediaPeriod.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/MaskingMediaPeriod.java
@@ -183,8 +183,8 @@ public final class MaskingMediaPeriod implements MediaPeriod, MediaPeriod.Callba
       long positionUs) {
     if (preparePositionOverrideUs != C.TIME_UNSET && positionUs == preparePositionUs) {
       positionUs = preparePositionOverrideUs;
-      preparePositionOverrideUs = C.TIME_UNSET;
     }
+    preparePositionOverrideUs = C.TIME_UNSET;
     return castNonNull(mediaPeriod)
         .selectTracks(selections, mayRetainStreamFlags, streams, streamResetFlags, positionUs);
   }


### PR DESCRIPTION
Using 0 as the unset prepare position is the root cause of a number of issues, as outliine in the ExoPlayer issue https://github.com/google/ExoPlayer/issues/7975

The premise of this fix is that once the prepare override is used (the initial call to `selectTracks()`) it is never needed again, so simply invalidate it after use.