### PR TITLE
RFC SQLiteDatabase -> SupportSQLiteDatabase

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -51,6 +51,7 @@ project.ext {
     androidxMultidexVersion = '2.0.1'
     androidxRecyclerViewVersion = '1.3.0'
     androidxMaterialVersion = '1.8.0'
+    androidxSqliteVersion = '2.3.1'
     androidxTestCoreVersion = '1.5.0'
     androidxTestEspressoVersion = '3.5.1'
     androidxTestJUnitVersion = '1.1.5'

--- a/libraries/common/build.gradle
+++ b/libraries/common/build.gradle
@@ -65,7 +65,6 @@ dependencies {
     }
     api 'androidx.annotation:annotation-experimental:' + androidxAnnotationExperimentalVersion
     implementation 'androidx.annotation:annotation:' + androidxAnnotationVersion
-    implementation 'androidx.sqlite:sqlite:' + androidxSqliteVersion
     compileOnly 'com.google.code.findbugs:jsr305:' + jsr305Version
     compileOnly 'com.google.errorprone:error_prone_annotations:' + errorProneVersion
     compileOnly 'org.checkerframework:checker-qual:' + checkerframeworkVersion

--- a/libraries/common/build.gradle
+++ b/libraries/common/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     }
     api 'androidx.annotation:annotation-experimental:' + androidxAnnotationExperimentalVersion
     implementation 'androidx.annotation:annotation:' + androidxAnnotationVersion
+    implementation 'androidx.sqlite:sqlite:' + androidxSqliteVersion
     compileOnly 'com.google.code.findbugs:jsr305:' + jsr305Version
     compileOnly 'com.google.errorprone:error_prone_annotations:' + errorProneVersion
     compileOnly 'org.checkerframework:checker-qual:' + checkerframeworkVersion

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -2854,27 +2854,27 @@ public final class Util {
   /** Returns whether the table exists in the database. */
   @UnstableApi
   public static boolean tableExists(SupportSQLiteDatabase database, String tableName) {
-    long count = queryNumEntries(
-            database, "sqlite_master", "tbl_name = ?", new String[] {tableName});
+    long count =
+        queryNumEntries(database, "sqlite_master", "tbl_name = ?", new String[] {tableName});
     return count > 0;
-
   }
 
   /**
-   * copied from the android framework {@link android.database.DatabaseUtils#queryNumEntries(SQLiteDatabase, String, String)}
+   * copied from the android framework {@link
+   * android.database.DatabaseUtils#queryNumEntries(SQLiteDatabase, String, String)}
    */
-  public static long queryNumEntries(SupportSQLiteDatabase db, String table, String selection,
-      String[] selectionArgs) {
+  public static long queryNumEntries(
+      SupportSQLiteDatabase db, String table, String selection, String[] selectionArgs) {
     String s = (!android.text.TextUtils.isEmpty(selection)) ? " where " + selection : "";
-    return longForQuery(db, "select count(*) from " + table + s,
-        selectionArgs);
+    return longForQuery(db, "select count(*) from " + table + s, selectionArgs);
   }
 
   /**
-   * Utility method to run the query on the db and return the value in the
-   * first column of the first row.
-   * <p>
-   * copied from {@link android.database.DatabaseUtils#longForQuery(SQLiteDatabase, String, String[])}
+   * Utility method to run the query on the db and return the value in the first column of the first
+   * row.
+   *
+   * <p>copied from {@link android.database.DatabaseUtils#longForQuery(SQLiteDatabase, String,
+   * String[])}
    */
   public static long longForQuery(SupportSQLiteDatabase db, String query, String[] selectionArgs) {
     SupportSQLiteStatement prog = db.compileStatement(query);
@@ -2885,9 +2885,7 @@ public final class Util {
     }
   }
 
-  /**
-   * copied from {@link android.database.DatabaseUtils#longForQuery(SQLiteStatement, String[])}
-   */
+  /** copied from {@link android.database.DatabaseUtils#longForQuery(SQLiteStatement, String[])} */
   public static long longForQuery(SupportSQLiteStatement prog, String[] selectionArgs) {
     bindAllArgsAsStrings(prog, selectionArgs);
     return prog.simpleQueryForLong();
@@ -2896,7 +2894,8 @@ public final class Util {
   /**
    * Equivalent to {@link android.database.sqlite.SQLiteStatement#bindAllArgsAsStrings(String[])}
    */
-  public static void bindAllArgsAsStrings(SupportSQLiteStatement prog, @Nullable String[] bindArgs) {
+  public static void bindAllArgsAsStrings(
+      SupportSQLiteStatement prog, @Nullable String[] bindArgs) {
     if (bindArgs != null) {
       for (int i = bindArgs.length; i != 0; i--) {
         prog.bindString(i, bindArgs[i - 1]);

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -47,8 +47,6 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Configuration;
 import android.content.res.Resources;
-import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteStatement;
 import android.graphics.Point;
 import android.graphics.drawable.Drawable;
 import android.hardware.display.DisplayManager;
@@ -85,8 +83,6 @@ import androidx.media3.common.ParserException;
 import androidx.media3.common.PlaybackException;
 import androidx.media3.common.Player;
 import androidx.media3.common.Player.Commands;
-import androidx.sqlite.db.SupportSQLiteDatabase;
-import androidx.sqlite.db.SupportSQLiteStatement;
 import com.google.common.base.Ascii;
 import com.google.common.base.Charsets;
 import com.google.common.util.concurrent.AsyncFunction;
@@ -2849,58 +2845,6 @@ public final class Util {
       removedItems.addFirst(items.remove(fromIndex + i));
     }
     items.addAll(min(newFromIndex, items.size()), removedItems);
-  }
-
-  /** Returns whether the table exists in the database. */
-  @UnstableApi
-  public static boolean tableExists(SupportSQLiteDatabase database, String tableName) {
-    long count =
-        queryNumEntries(database, "sqlite_master", "tbl_name = ?", new String[] {tableName});
-    return count > 0;
-  }
-
-  /**
-   * copied from the android framework {@link
-   * android.database.DatabaseUtils#queryNumEntries(SQLiteDatabase, String, String)}
-   */
-  public static long queryNumEntries(
-      SupportSQLiteDatabase db, String table, String selection, String[] selectionArgs) {
-    String s = (!android.text.TextUtils.isEmpty(selection)) ? " where " + selection : "";
-    return longForQuery(db, "select count(*) from " + table + s, selectionArgs);
-  }
-
-  /**
-   * Utility method to run the query on the db and return the value in the first column of the first
-   * row.
-   *
-   * <p>copied from {@link android.database.DatabaseUtils#longForQuery(SQLiteDatabase, String,
-   * String[])}
-   */
-  public static long longForQuery(SupportSQLiteDatabase db, String query, String[] selectionArgs) {
-    SupportSQLiteStatement prog = db.compileStatement(query);
-    try {
-      return longForQuery(prog, selectionArgs);
-    } finally {
-      androidx.media3.common.util.Util.closeQuietly(prog);
-    }
-  }
-
-  /** copied from {@link android.database.DatabaseUtils#longForQuery(SQLiteStatement, String[])} */
-  public static long longForQuery(SupportSQLiteStatement prog, String[] selectionArgs) {
-    bindAllArgsAsStrings(prog, selectionArgs);
-    return prog.simpleQueryForLong();
-  }
-
-  /**
-   * Equivalent to {@link android.database.sqlite.SQLiteStatement#bindAllArgsAsStrings(String[])}
-   */
-  public static void bindAllArgsAsStrings(
-      SupportSQLiteStatement prog, @Nullable String[] bindArgs) {
-    if (bindArgs != null) {
-      for (int i = bindArgs.length; i != 0; i--) {
-        prog.bindString(i, bindArgs[i - 1]);
-      }
-    }
   }
 
   /**

--- a/libraries/common/src/test/java/androidx/media3/common/util/UtilTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/util/UtilTest.java
@@ -40,6 +40,7 @@ import android.os.HandlerThread;
 import android.os.Looper;
 import android.util.SparseLongArray;
 import androidx.media3.common.C;
+import androidx.media3.database.DatabaseUtil;
 import androidx.media3.test.utils.TestUtil;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 import androidx.test.core.app.ApplicationProvider;
@@ -1161,13 +1162,13 @@ public class UtilTest {
     SupportSQLiteDatabase database = getInMemoryDatabase(ApplicationProvider.getApplicationContext());
     database.execSQL("CREATE TABLE TestTable (ID INTEGER NOT NULL)");
 
-    assertThat(Util.tableExists(database, "TestTable")).isTrue();
+    assertThat(DatabaseUtil.tableExists(database, "TestTable")).isTrue();
   }
 
   @Test
   public void tableExists_withNonExistingTable() {
     SupportSQLiteDatabase database = getInMemoryDatabase(ApplicationProvider.getApplicationContext());
-    assertThat(Util.tableExists(database, "table")).isFalse();
+    assertThat(DatabaseUtil.tableExists(database, "table")).isFalse();
   }
 
   @Test

--- a/libraries/common/src/test/java/androidx/media3/common/util/UtilTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/util/UtilTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import android.database.sqlite.SQLiteDatabase;
+import android.content.Context;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.net.Uri;
 import android.os.Handler;
@@ -41,6 +41,8 @@ import android.os.Looper;
 import android.util.SparseLongArray;
 import androidx.media3.common.C;
 import androidx.media3.test.utils.TestUtil;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.Futures;
@@ -1156,7 +1158,7 @@ public class UtilTest {
 
   @Test
   public void tableExists_withExistingTable() {
-    SQLiteDatabase database = getInMemorySQLiteOpenHelper().getWritableDatabase();
+    SupportSQLiteDatabase database = getInMemoryDatabase(ApplicationProvider.getApplicationContext());
     database.execSQL("CREATE TABLE TestTable (ID INTEGER NOT NULL)");
 
     assertThat(Util.tableExists(database, "TestTable")).isTrue();
@@ -1164,8 +1166,7 @@ public class UtilTest {
 
   @Test
   public void tableExists_withNonExistingTable() {
-    SQLiteDatabase database = getInMemorySQLiteOpenHelper().getReadableDatabase();
-
+    SupportSQLiteDatabase database = getInMemoryDatabase(ApplicationProvider.getApplicationContext());
     assertThat(Util.tableExists(database, "table")).isFalse();
   }
 
@@ -1468,15 +1469,8 @@ public class UtilTest {
   }
 
   /** Returns a {@link SQLiteOpenHelper} that provides an in-memory database. */
-  private static SQLiteOpenHelper getInMemorySQLiteOpenHelper() {
-    return new SQLiteOpenHelper(
-        /* context= */ null, /* name= */ null, /* factory= */ null, /* version= */ 1) {
-      @Override
-      public void onCreate(SQLiteDatabase db) {}
-
-      @Override
-      public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {}
-    };
+  private static SupportSQLiteDatabase getInMemoryDatabase(Context context) {
+    return TestUtil.getInMemoryDatabaseProvider(context).getWritableDatabase();
   }
 
   /** Generates an array of random bytes with the specified length. */

--- a/libraries/database/build.gradle
+++ b/libraries/database/build.gradle
@@ -32,6 +32,8 @@ android {
 dependencies {
     implementation project(modulePrefix + 'lib-common')
     implementation 'androidx.annotation:annotation:' + androidxAnnotationVersion
+    api 'androidx.sqlite:sqlite:' + androidxSqliteVersion
+    implementation 'androidx.sqlite:sqlite-framework:' + androidxSqliteVersion
     compileOnly 'org.jetbrains.kotlin:kotlin-annotations-jvm:' + kotlinAnnotationsVersion
     testImplementation 'androidx.test:core:' + androidxTestCoreVersion
     testImplementation 'androidx.test.ext:junit:' + androidxTestJUnitVersion

--- a/libraries/database/src/main/java/androidx/media3/database/DatabaseProvider.java
+++ b/libraries/database/src/main/java/androidx/media3/database/DatabaseProvider.java
@@ -18,6 +18,7 @@ package androidx.media3.database;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import androidx.media3.common.util.UnstableApi;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 
 /**
  * Provides {@link SQLiteDatabase} instances to media library components, which may read and write
@@ -39,7 +40,7 @@ public interface DatabaseProvider {
    * @throws SQLiteException If the database cannot be opened for writing.
    * @return A read/write database object.
    */
-  SQLiteDatabase getWritableDatabase();
+  SupportSQLiteDatabase getWritableDatabase();
 
   /**
    * Creates and/or opens a database. This will be the same object returned by {@link
@@ -54,5 +55,5 @@ public interface DatabaseProvider {
    * @throws SQLiteException If the database cannot be opened.
    * @return A database object valid until {@link #getWritableDatabase()} is called.
    */
-  SQLiteDatabase getReadableDatabase();
+  SupportSQLiteDatabase getReadableDatabase();
 }

--- a/libraries/database/src/main/java/androidx/media3/database/DatabaseUtil.java
+++ b/libraries/database/src/main/java/androidx/media3/database/DatabaseUtil.java
@@ -1,0 +1,65 @@
+package androidx.media3.database;
+
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteStatement;
+import androidx.annotation.Nullable;
+import androidx.media3.common.util.UnstableApi;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteStatement;
+
+public class DatabaseUtil {
+
+  private DatabaseUtil() {}
+
+  /** Returns whether the table exists in the database. */
+  @UnstableApi
+  public static boolean tableExists(SupportSQLiteDatabase database, String tableName) {
+    long count =
+        queryNumEntries(database, "sqlite_master", "tbl_name = ?", new String[] {tableName});
+    return count > 0;
+  }
+
+  /**
+   * copied from the android framework {@link
+   * android.database.DatabaseUtils#queryNumEntries(SQLiteDatabase, String, String)}
+   */
+  public static long queryNumEntries(
+      SupportSQLiteDatabase db, String table, String selection, String[] selectionArgs) {
+    String s = (!android.text.TextUtils.isEmpty(selection)) ? " where " + selection : "";
+    return longForQuery(db, "select count(*) from " + table + s, selectionArgs);
+  }
+
+  /**
+   * Utility method to run the query on the db and return the value in the first column of the first
+   * row.
+   *
+   * <p>copied from {@link android.database.DatabaseUtils#longForQuery(SQLiteDatabase, String,
+   * String[])}
+   */
+  public static long longForQuery(SupportSQLiteDatabase db, String query, String[] selectionArgs) {
+    SupportSQLiteStatement prog = db.compileStatement(query);
+    try {
+      return longForQuery(prog, selectionArgs);
+    } finally {
+      androidx.media3.common.util.Util.closeQuietly(prog);
+    }
+  }
+
+  /** copied from {@link android.database.DatabaseUtils#longForQuery(SQLiteStatement, String[])} */
+  public static long longForQuery(SupportSQLiteStatement prog, String[] selectionArgs) {
+    bindAllArgsAsStrings(prog, selectionArgs);
+    return prog.simpleQueryForLong();
+  }
+
+  /**
+   * Equivalent to {@link android.database.sqlite.SQLiteStatement#bindAllArgsAsStrings(String[])}
+   */
+  public static void bindAllArgsAsStrings(
+      SupportSQLiteStatement prog, @Nullable String[] bindArgs) {
+    if (bindArgs != null) {
+      for (int i = bindArgs.length; i != 0; i--) {
+        prog.bindString(i, bindArgs[i - 1]);
+      }
+    }
+  }
+}

--- a/libraries/database/src/main/java/androidx/media3/database/DefaultDatabaseProvider.java
+++ b/libraries/database/src/main/java/androidx/media3/database/DefaultDatabaseProvider.java
@@ -1,45 +1,51 @@
-/*
- * Copyright (C) 2018 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package androidx.media3.database;
 
+import android.content.Context;
 import android.database.sqlite.SQLiteOpenHelper;
-import androidx.media3.common.util.UnstableApi;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 import androidx.sqlite.db.SupportSQLiteOpenHelper;
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 
-/** A {@link DatabaseProvider} that provides instances obtained from a {@link SQLiteOpenHelper}. */
-@UnstableApi
-public final class DefaultDatabaseProvider implements DatabaseProvider {
+/**
+ * @deprecated Use {@link SupportDatabaseProvider} instead.
+ */
+@Deprecated
+public class DefaultDatabaseProvider extends SupportSQLiteOpenHelper.Callback
+    implements DatabaseProvider {
 
-  private final SupportSQLiteOpenHelper sqliteOpenHelper;
+  private final SupportSQLiteOpenHelper helper;
 
-  /**
-   * A {@link DatabaseProvider} that provides instances obtained from a {@link SQLiteOpenHelper}.
-   */
-  public DefaultDatabaseProvider(SupportSQLiteOpenHelper sqliteOpenHelper) {
-    this.sqliteOpenHelper = sqliteOpenHelper;
+  private SupportSQLiteOpenHelper createHelper(Context context, SQLiteOpenHelper openHelper) {
+    SupportSQLiteOpenHelper.Configuration cfg =
+        SupportSQLiteOpenHelper.Configuration.builder(context)
+            .name(openHelper.getDatabaseName())
+            .callback(this)
+            .build();
+    return new FrameworkSQLiteOpenHelperFactory().create(cfg);
+  }
+
+  public DefaultDatabaseProvider(Context context, SQLiteOpenHelper openHelper) {
+    super();
+    this.helper = createHelper(context, openHelper);
   }
 
   @Override
   public SupportSQLiteDatabase getWritableDatabase() {
-    return sqliteOpenHelper.getWritableDatabase();
+    return helper.getWritableDatabase();
+  }
+
+  @Override
+  public void onCreate(SupportSQLiteDatabase supportSQLiteDatabase) {
+    // Features create their own tables.
+  }
+
+  @Override
+  public void onUpgrade(SupportSQLiteDatabase supportSQLiteDatabase, int i, int i1) {
+    // Features handle their own upgrades.
   }
 
   @Override
   public SupportSQLiteDatabase getReadableDatabase() {
-    return sqliteOpenHelper.getReadableDatabase();
+    return helper.getReadableDatabase();
   }
 }

--- a/libraries/database/src/main/java/androidx/media3/database/DefaultDatabaseProvider.java
+++ b/libraries/database/src/main/java/androidx/media3/database/DefaultDatabaseProvider.java
@@ -15,30 +15,33 @@
  */
 package androidx.media3.database;
 
-import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import androidx.media3.common.util.UnstableApi;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
 
-/** A {@link DatabaseProvider} that provides instances obtained from a {@link SQLiteOpenHelper}. */
+/**
+ * A {@link DatabaseProvider} that provides instances obtained from a {@link SQLiteOpenHelper}.
+ */
 @UnstableApi
 public final class DefaultDatabaseProvider implements DatabaseProvider {
 
-  private final SQLiteOpenHelper sqliteOpenHelper;
+  private final SupportSQLiteOpenHelper sqliteOpenHelper;
 
   /**
    * @param sqliteOpenHelper An {@link SQLiteOpenHelper} from which to obtain database instances.
    */
-  public DefaultDatabaseProvider(SQLiteOpenHelper sqliteOpenHelper) {
+  public DefaultDatabaseProvider(SupportSQLiteOpenHelper sqliteOpenHelper) {
     this.sqliteOpenHelper = sqliteOpenHelper;
   }
 
   @Override
-  public SQLiteDatabase getWritableDatabase() {
+  public SupportSQLiteDatabase getWritableDatabase() {
     return sqliteOpenHelper.getWritableDatabase();
   }
 
   @Override
-  public SQLiteDatabase getReadableDatabase() {
+  public SupportSQLiteDatabase getReadableDatabase() {
     return sqliteOpenHelper.getReadableDatabase();
   }
 }

--- a/libraries/database/src/main/java/androidx/media3/database/DefaultDatabaseProvider.java
+++ b/libraries/database/src/main/java/androidx/media3/database/DefaultDatabaseProvider.java
@@ -6,6 +6,21 @@ import androidx.sqlite.db.SupportSQLiteDatabase;
 import androidx.sqlite.db.SupportSQLiteOpenHelper;
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * @deprecated Use {@link SupportDatabaseProvider} instead.
  */

--- a/libraries/database/src/main/java/androidx/media3/database/DefaultDatabaseProvider.java
+++ b/libraries/database/src/main/java/androidx/media3/database/DefaultDatabaseProvider.java
@@ -28,9 +28,7 @@ public final class DefaultDatabaseProvider implements DatabaseProvider {
 
   private final SupportSQLiteOpenHelper sqliteOpenHelper;
 
-  /**
-   * @param sqliteOpenHelper An {@link SQLiteOpenHelper} from which to obtain database instances.
-   */
+  /** A {@link DatabaseProvider} that provides instances obtained from a {@link SQLiteOpenHelper}. */
   public DefaultDatabaseProvider(SupportSQLiteOpenHelper sqliteOpenHelper) {
     this.sqliteOpenHelper = sqliteOpenHelper;
   }

--- a/libraries/database/src/main/java/androidx/media3/database/DefaultDatabaseProvider.java
+++ b/libraries/database/src/main/java/androidx/media3/database/DefaultDatabaseProvider.java
@@ -20,15 +20,15 @@ import androidx.media3.common.util.UnstableApi;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 import androidx.sqlite.db.SupportSQLiteOpenHelper;
 
-/**
- * A {@link DatabaseProvider} that provides instances obtained from a {@link SQLiteOpenHelper}.
- */
+/** A {@link DatabaseProvider} that provides instances obtained from a {@link SQLiteOpenHelper}. */
 @UnstableApi
 public final class DefaultDatabaseProvider implements DatabaseProvider {
 
   private final SupportSQLiteOpenHelper sqliteOpenHelper;
 
-  /** A {@link DatabaseProvider} that provides instances obtained from a {@link SQLiteOpenHelper}. */
+  /**
+   * A {@link DatabaseProvider} that provides instances obtained from a {@link SQLiteOpenHelper}.
+   */
   public DefaultDatabaseProvider(SupportSQLiteOpenHelper sqliteOpenHelper) {
     this.sqliteOpenHelper = sqliteOpenHelper;
   }

--- a/libraries/database/src/main/java/androidx/media3/database/DefaultDatabaseProvider.java
+++ b/libraries/database/src/main/java/androidx/media3/database/DefaultDatabaseProvider.java
@@ -13,6 +13,7 @@ import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 public class DefaultDatabaseProvider extends SupportSQLiteOpenHelper.Callback
     implements DatabaseProvider {
 
+  private static final int VERSION = 1;
   private final SupportSQLiteOpenHelper helper;
 
   private SupportSQLiteOpenHelper createHelper(Context context, SQLiteOpenHelper openHelper) {
@@ -25,7 +26,7 @@ public class DefaultDatabaseProvider extends SupportSQLiteOpenHelper.Callback
   }
 
   public DefaultDatabaseProvider(Context context, SQLiteOpenHelper openHelper) {
-    super();
+    super(VERSION);
     this.helper = createHelper(context, openHelper);
   }
 

--- a/libraries/database/src/main/java/androidx/media3/database/StandaloneDatabaseProvider.java
+++ b/libraries/database/src/main/java/androidx/media3/database/StandaloneDatabaseProvider.java
@@ -89,7 +89,7 @@ public class StandaloneDatabaseProvider extends SupportSQLiteOpenHelper.Callback
   }
 
   @VisibleForTesting
-  public void tearDown() {
+  public void close() {
     this.openHelper.close();
   }
 

--- a/libraries/database/src/main/java/androidx/media3/database/StandaloneDatabaseProvider.java
+++ b/libraries/database/src/main/java/androidx/media3/database/StandaloneDatabaseProvider.java
@@ -34,7 +34,7 @@ import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
  *
  * <p>Suitable for use by applications that do not already have their own database, or that would
  * prefer to keep tables used by media library components isolated in their own database. Other
- * applications should prefer to use {@link DefaultDatabaseProvider} with their own {@link
+ * applications should prefer to use {@link SupportDatabaseProvider} with their own {@link
  * SQLiteOpenHelper}.
  */
 // TODO: Make this class final when ExoDatabaseProvider is removed.

--- a/libraries/database/src/main/java/androidx/media3/database/StandaloneDatabaseProvider.java
+++ b/libraries/database/src/main/java/androidx/media3/database/StandaloneDatabaseProvider.java
@@ -18,10 +18,16 @@ package androidx.media3.database;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.SQLException;
-import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.UnstableApi;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
+import androidx.sqlite.db.SupportSQLiteQuery;
+import androidx.sqlite.db.SupportSQLiteQueryBuilder;
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 
 /**
  * An {@link SQLiteOpenHelper} that provides instances of a standalone database.
@@ -33,13 +39,16 @@ import androidx.media3.common.util.UnstableApi;
  */
 // TODO: Make this class final when ExoDatabaseProvider is removed.
 @UnstableApi
-public class StandaloneDatabaseProvider extends SQLiteOpenHelper implements DatabaseProvider {
+public class StandaloneDatabaseProvider extends SupportSQLiteOpenHelper.Callback implements
+    DatabaseProvider {
 
   /** The file name used for the standalone database. */
   public static final String DATABASE_NAME = "exoplayer_internal.db";
 
   private static final int VERSION = 1;
   private static final String TAG = "SADatabaseProvider";
+
+  public final SupportSQLiteOpenHelper openHelper;
 
   /**
    * Provides instances of the database located by passing {@link #DATABASE_NAME} to {@link
@@ -48,21 +57,44 @@ public class StandaloneDatabaseProvider extends SQLiteOpenHelper implements Data
    * @param context Any context.
    */
   public StandaloneDatabaseProvider(Context context) {
-    super(context.getApplicationContext(), DATABASE_NAME, /* factory= */ null, VERSION);
+    this(context, DATABASE_NAME);
+  }
+
+  public StandaloneDatabaseProvider(Context context, @Nullable String name) {
+    super(VERSION);
+    SupportSQLiteOpenHelper.Configuration configuration = SupportSQLiteOpenHelper.Configuration.builder(
+        context).name(name).callback(this).build();
+    FrameworkSQLiteOpenHelperFactory factory = new FrameworkSQLiteOpenHelperFactory();
+    this.openHelper = factory.create(configuration);
   }
 
   @Override
-  public void onCreate(SQLiteDatabase db) {
+  public SupportSQLiteDatabase getWritableDatabase() {
+    return this.openHelper.getWritableDatabase();
+  }
+
+  @Override
+  public SupportSQLiteDatabase getReadableDatabase() {
+    return this.openHelper.getReadableDatabase();
+  }
+
+  @Override
+  public void onCreate(SupportSQLiteDatabase supportSQLiteDatabase) {
     // Features create their own tables.
   }
 
   @Override
-  public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+  public void onUpgrade(SupportSQLiteDatabase supportSQLiteDatabase, int i, int i1) {
     // Features handle their own upgrades.
   }
 
+  @VisibleForTesting
+  public void tearDown() {
+    this.openHelper.close();
+  }
+
   @Override
-  public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+  public void onDowngrade(SupportSQLiteDatabase db, int oldVersion, int newVersion) {
     wipeDatabase(db);
   }
 
@@ -70,17 +102,11 @@ public class StandaloneDatabaseProvider extends SQLiteOpenHelper implements Data
    * Makes a best effort to wipe the existing database. The wipe may be incomplete if the database
    * contains foreign key constraints.
    */
-  private static void wipeDatabase(SQLiteDatabase db) {
+  private static void wipeDatabase(SupportSQLiteDatabase db) {
     String[] columns = {"type", "name"};
-    try (Cursor cursor =
-        db.query(
-            "sqlite_master",
-            columns,
-            /* selection= */ null,
-            /* selectionArgs= */ null,
-            /* groupBy= */ null,
-            /* having= */ null,
-            /* orderBy= */ null)) {
+    SupportSQLiteQuery query = SupportSQLiteQueryBuilder.builder("sqlite_master").columns(columns)
+        .create();
+    try (Cursor cursor = db.query(query)) {
       while (cursor.moveToNext()) {
         String type = cursor.getString(0);
         String name = cursor.getString(1);

--- a/libraries/database/src/main/java/androidx/media3/database/SupportDatabaseProvider.java
+++ b/libraries/database/src/main/java/androidx/media3/database/SupportDatabaseProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.database;
+
+import android.database.sqlite.SQLiteOpenHelper;
+import androidx.media3.common.util.UnstableApi;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
+
+/**
+ * A {@link DatabaseProvider} that provides instances obtained from a {@link
+ * SupportSQLiteOpenHelper}.
+ */
+@UnstableApi
+public final class SupportDatabaseProvider implements DatabaseProvider {
+
+  private final SupportSQLiteOpenHelper sqliteOpenHelper;
+
+  /**
+   * A {@link DatabaseProvider} that provides instances obtained from a {@link SQLiteOpenHelper}.
+   */
+  public SupportDatabaseProvider(SupportSQLiteOpenHelper sqliteOpenHelper) {
+    this.sqliteOpenHelper = sqliteOpenHelper;
+  }
+
+  @Override
+  public SupportSQLiteDatabase getWritableDatabase() {
+    return sqliteOpenHelper.getWritableDatabase();
+  }
+
+  @Override
+  public SupportSQLiteDatabase getReadableDatabase() {
+    return sqliteOpenHelper.getReadableDatabase();
+  }
+}

--- a/libraries/database/src/main/java/androidx/media3/database/VersionTable.java
+++ b/libraries/database/src/main/java/androidx/media3/database/VersionTable.java
@@ -23,7 +23,6 @@ import android.database.sqlite.SQLiteDatabase;
 import androidx.annotation.IntDef;
 import androidx.media3.common.MediaLibraryInfo;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 import androidx.sqlite.db.SupportSQLiteQuery;
 import java.lang.annotation.Documented;
@@ -42,7 +41,7 @@ public final class VersionTable {
     MediaLibraryInfo.registerModule("media3.database");
   }
 
-  /** Returned by {@link #getVersion(SQLiteDatabase, int, String)} if the version is unset. */
+  /** Returned by {@link {@link VersionTable#getVersion(SupportSQLiteDatabase, int, String)} if the version is unset. */
   public static final int VERSION_UNSET = -1;
 
   /** Version of tables used for offline functionality. */
@@ -103,9 +102,8 @@ public final class VersionTable {
    * @param version The version.
    * @throws DatabaseIOException If an error occurs executing the SQL.
    */
-  public static void setVersion(SupportSQLiteDatabase writableDatabase, @Feature int feature,
-      String instanceUid,
-      int version)
+  public static void setVersion(
+      SupportSQLiteDatabase writableDatabase, @Feature int feature, String instanceUid, int version)
       throws DatabaseIOException {
     try {
       writableDatabase.execSQL(SQL_CREATE_TABLE_IF_NOT_EXISTS);
@@ -113,8 +111,7 @@ public final class VersionTable {
       values.put(COLUMN_FEATURE, feature);
       values.put(COLUMN_INSTANCE_UID, instanceUid);
       values.put(COLUMN_VERSION, version);
-      writableDatabase.insert(TABLE_NAME, SQLiteDatabase.CONFLICT_REPLACE,
-          values);
+      writableDatabase.insert(TABLE_NAME, SQLiteDatabase.CONFLICT_REPLACE, values);
     } catch (SQLException e) {
       throw new DatabaseIOException(e);
     }
@@ -132,7 +129,7 @@ public final class VersionTable {
       SupportSQLiteDatabase writableDatabase, @Feature int feature, String instanceUid)
       throws DatabaseIOException {
     try {
-      if (!Util.tableExists(writableDatabase, TABLE_NAME)) {
+      if (!DatabaseUtil.tableExists(writableDatabase, TABLE_NAME)) {
         return;
       }
       writableDatabase.delete(
@@ -154,18 +151,20 @@ public final class VersionTable {
    * @return The version, or {@link #VERSION_UNSET} if no version is set.
    * @throws DatabaseIOException If an error occurs executing the SQL.
    */
-  public static int getVersion(SupportSQLiteDatabase database, @Feature int feature,
-      String instanceUid)
+  public static int getVersion(
+      SupportSQLiteDatabase database, @Feature int feature, String instanceUid)
       throws DatabaseIOException {
     try {
-      if (!Util.tableExists(database, TABLE_NAME)) {
+      if (!DatabaseUtil.tableExists(database, TABLE_NAME)) {
         return VERSION_UNSET;
       }
-      SupportSQLiteQuery query = androidx.sqlite.db.SupportSQLiteQueryBuilder.builder(TABLE_NAME)
-          .columns(new String[]{COLUMN_VERSION})
-          .selection(WHERE_FEATURE_AND_INSTANCE_UID_EQUALS,
-              featureAndInstanceUidArguments(feature, instanceUid))
-          .create();
+      SupportSQLiteQuery query =
+          androidx.sqlite.db.SupportSQLiteQueryBuilder.builder(TABLE_NAME)
+              .columns(new String[] {COLUMN_VERSION})
+              .selection(
+                  WHERE_FEATURE_AND_INSTANCE_UID_EQUALS,
+                  featureAndInstanceUidArguments(feature, instanceUid))
+              .create();
       try (android.database.Cursor cursor = database.query(query)) {
         if (cursor.getCount() == 0) {
           return VERSION_UNSET;
@@ -179,6 +178,6 @@ public final class VersionTable {
   }
 
   private static String[] featureAndInstanceUidArguments(int feature, String instance) {
-    return new String[]{Integer.toString(feature), instance};
+    return new String[] {Integer.toString(feature), instance};
   }
 }

--- a/libraries/database/src/main/java/androidx/media3/database/VersionTable.java
+++ b/libraries/database/src/main/java/androidx/media3/database/VersionTable.java
@@ -42,9 +42,7 @@ public final class VersionTable {
     MediaLibraryInfo.registerModule("media3.database");
   }
 
-  /**
-   * Returned by {@link #getVersion(SupportSQLiteDatabase, int, String)} if the version is unset.
-   */
+  /** Returned by {@link #getVersion(SQLiteDatabase, int, String)} if the version is unset. */
   public static final int VERSION_UNSET = -1;
 
   /** Version of tables used for offline functionality. */

--- a/libraries/database/src/main/java/androidx/media3/database/VersionTable.java
+++ b/libraries/database/src/main/java/androidx/media3/database/VersionTable.java
@@ -159,7 +159,7 @@ public final class VersionTable {
       throws DatabaseIOException {
     try {
       if (!Util.tableExists(database, TABLE_NAME)) {
-        return -1;
+        return VERSION_UNSET;
       }
       SupportSQLiteQuery query = androidx.sqlite.db.SupportSQLiteQueryBuilder.builder(TABLE_NAME)
           .columns(new String[]{COLUMN_VERSION})
@@ -168,7 +168,7 @@ public final class VersionTable {
           .create();
       try (android.database.Cursor cursor = database.query(query)) {
         if (cursor.getCount() == 0) {
-          return -1;
+          return VERSION_UNSET;
         }
         cursor.moveToNext();
         return cursor.getInt(/* COLUMN_VERSION index */ 0);

--- a/libraries/database/src/test/java/androidx/media3/database/VersionTableTest.java
+++ b/libraries/database/src/test/java/androidx/media3/database/VersionTableTest.java
@@ -17,14 +17,17 @@ package androidx.media3.database;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import android.database.sqlite.SQLiteDatabase;
 import androidx.media3.test.utils.TestUtil;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-/** Unit tests for {@link VersionTable}. */
+/**
+ * Unit tests for {@link VersionTable}.
+ */
 @RunWith(AndroidJUnit4.class)
 public class VersionTableTest {
 
@@ -34,11 +37,12 @@ public class VersionTableTest {
   private static final String INSTANCE_2 = "2";
 
   private DatabaseProvider databaseProvider;
-  private SQLiteDatabase database;
+  private SupportSQLiteDatabase database;
 
   @Before
   public void setUp() {
-    databaseProvider = TestUtil.getInMemoryDatabaseProvider();
+    databaseProvider = TestUtil.getInMemoryDatabaseProvider(
+        ApplicationProvider.getApplicationContext() );
     database = databaseProvider.getWritableDatabase();
   }
 

--- a/libraries/database/src/test/java/androidx/media3/database/VersionTableTest.java
+++ b/libraries/database/src/test/java/androidx/media3/database/VersionTableTest.java
@@ -25,9 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-/**
- * Unit tests for {@link VersionTable}.
- */
+/** Unit tests for {@link VersionTable}. */
 @RunWith(AndroidJUnit4.class)
 public class VersionTableTest {
 

--- a/libraries/datasource/build.gradle
+++ b/libraries/datasource/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     implementation project(modulePrefix + 'lib-database')
     implementation 'androidx.annotation:annotation:' + androidxAnnotationVersion
     implementation 'androidx.exifinterface:exifinterface:' + androidxExifInterfaceVersion
-    implementation 'androidx.sqlite:sqlite:' + androidxSqliteVersion
     compileOnly 'com.google.code.findbugs:jsr305:' + jsr305Version
     compileOnly 'com.google.errorprone:error_prone_annotations:' + errorProneVersion
     compileOnly 'org.checkerframework:checker-qual:' + checkerframeworkVersion

--- a/libraries/datasource/build.gradle
+++ b/libraries/datasource/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation project(modulePrefix + 'lib-database')
     implementation 'androidx.annotation:annotation:' + androidxAnnotationVersion
     implementation 'androidx.exifinterface:exifinterface:' + androidxExifInterfaceVersion
+    implementation 'androidx.sqlite:sqlite:' + androidxSqliteVersion
     compileOnly 'com.google.code.findbugs:jsr305:' + jsr305Version
     compileOnly 'com.google.errorprone:error_prone_annotations:' + errorProneVersion
     compileOnly 'org.checkerframework:checker-qual:' + checkerframeworkVersion

--- a/libraries/datasource/src/main/java/androidx/media3/datasource/cache/CacheFileMetadataIndex.java
+++ b/libraries/datasource/src/main/java/androidx/media3/datasource/cache/CacheFileMetadataIndex.java
@@ -170,8 +170,8 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
    *
    * <p>This method may be slow and shouldn't normally be called on the main thread.
    *
-   * @param name               The name of the file.
-   * @param length             The file length.
+   * @param name The name of the file.
+   * @param length The file length.
    * @param lastTouchTimestamp The file last touch timestamp.
    * @throws DatabaseIOException If an error occurs setting the metadata.
    */

--- a/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CacheDataSourceContractTest.java
+++ b/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CacheDataSourceContractTest.java
@@ -85,7 +85,7 @@ public class CacheDataSourceContractTest extends DataSourceContractTest {
     File tempFolder =
         Util.createTempDirectory(ApplicationProvider.getApplicationContext(), "ExoPlayerTest");
     SimpleCache cache =
-        new SimpleCache(tempFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider());
+        new SimpleCache(tempFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext()));
     upstreamDataSource = new FakeDataSource(fakeDataSet);
     return new CacheDataSource(cache, upstreamDataSource);
   }

--- a/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CacheDataSourceTest.java
+++ b/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CacheDataSourceTest.java
@@ -84,7 +84,7 @@ public final class CacheDataSourceTest {
     tempFolder =
         Util.createTempDirectory(ApplicationProvider.getApplicationContext(), "ExoPlayerTest");
     cache =
-        new SimpleCache(tempFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider());
+        new SimpleCache(tempFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext()));
     upstreamDataSource = new FakeDataSource();
   }
 

--- a/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CacheDataSourceTest2.java
+++ b/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CacheDataSourceTest2.java
@@ -155,7 +155,7 @@ public final class CacheDataSourceTest2 {
         new SimpleCache(
             new File(cacheDir, EXO_CACHE_DIR),
             new NoOpCacheEvictor(),
-            TestUtil.getInMemoryDatabaseProvider());
+            TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext()));
     emptyCache(cache);
 
     // Source and cipher

--- a/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CacheFileMetadataIndexTest.java
+++ b/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CacheFileMetadataIndexTest.java
@@ -26,9 +26,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-/**
- * Tests {@link CacheFileMetadataIndex}.
- */
+/** Tests {@link CacheFileMetadataIndex}. */
 @RunWith(AndroidJUnit4.class)
 public class CacheFileMetadataIndexTest {
 

--- a/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CacheFileMetadataIndexTest.java
+++ b/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CacheFileMetadataIndexTest.java
@@ -19,13 +19,16 @@ import static com.google.common.truth.Truth.assertThat;
 
 import androidx.media3.database.DatabaseIOException;
 import androidx.media3.test.utils.TestUtil;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.util.HashSet;
 import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-/** Tests {@link CacheFileMetadataIndex}. */
+/**
+ * Tests {@link CacheFileMetadataIndex}.
+ */
 @RunWith(AndroidJUnit4.class)
 public class CacheFileMetadataIndexTest {
 
@@ -128,7 +131,8 @@ public class CacheFileMetadataIndexTest {
 
   private static CacheFileMetadataIndex newInitializedIndex() throws DatabaseIOException {
     CacheFileMetadataIndex index =
-        new CacheFileMetadataIndex(TestUtil.getInMemoryDatabaseProvider());
+        new CacheFileMetadataIndex(
+            TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext()));
     index.initialize(/* uid= */ 1234);
     return index;
   }

--- a/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CacheWriterTest.java
+++ b/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CacheWriterTest.java
@@ -52,7 +52,7 @@ public final class CacheWriterTest {
     tempFolder =
         Util.createTempDirectory(ApplicationProvider.getApplicationContext(), "ExoPlayerTest");
     cache =
-        new SimpleCache(tempFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider());
+        new SimpleCache(tempFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider((ApplicationProvider.getApplicationContext())));
   }
 
   @After

--- a/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CachedContentIndexTest.java
+++ b/libraries/datasource/src/test/java/androidx/media3/datasource/cache/CachedContentIndexTest.java
@@ -462,7 +462,7 @@ public class CachedContentIndexTest {
   }
 
   private CachedContentIndex newInstance() {
-    return new CachedContentIndex(TestUtil.getInMemoryDatabaseProvider());
+    return new CachedContentIndex(TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext()));
   }
 
   private CachedContentIndex newLegacyInstance() {

--- a/libraries/datasource/src/test/java/androidx/media3/datasource/cache/SimpleCacheSpanTest.java
+++ b/libraries/datasource/src/test/java/androidx/media3/datasource/cache/SimpleCacheSpanTest.java
@@ -44,7 +44,7 @@ public class SimpleCacheSpanTest {
   public void setUp() throws Exception {
     cacheDir =
         Util.createTempDirectory(ApplicationProvider.getApplicationContext(), "ExoPlayerTest");
-    index = new CachedContentIndex(TestUtil.getInMemoryDatabaseProvider());
+    index = new CachedContentIndex(TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext()));
   }
 
   @After

--- a/libraries/datasource/src/test/java/androidx/media3/datasource/cache/SimpleCacheTest.java
+++ b/libraries/datasource/src/test/java/androidx/media3/datasource/cache/SimpleCacheTest.java
@@ -61,7 +61,7 @@ public class SimpleCacheTest {
 
   @Before
   public void createDatabaseProvider() {
-    databaseProvider = TestUtil.getInMemoryDatabaseProvider();
+    databaseProvider = TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext());
   }
 
   @After
@@ -591,7 +591,9 @@ public class SimpleCacheTest {
   @Test
   public void exceptionDuringIndexStore_doesNotPreventEviction() throws Exception {
     CachedContentIndex contentIndex =
-        Mockito.spy(new CachedContentIndex(TestUtil.getInMemoryDatabaseProvider()));
+        Mockito.spy(new CachedContentIndex(TestUtil.getInMemoryDatabaseProvider(
+            ApplicationProvider.getApplicationContext()
+        )));
     SimpleCache simpleCache =
         new SimpleCache(
             cacheDir, new LeastRecentlyUsedCacheEvictor(20), contentIndex, /* fileIndex= */ null);

--- a/libraries/exoplayer/build.gradle
+++ b/libraries/exoplayer/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     api project(modulePrefix + 'lib-database')
     implementation 'androidx.annotation:annotation:' + androidxAnnotationVersion
     implementation 'androidx.core:core:' + androidxCoreVersion
+    implementation 'androidx.sqlite:sqlite:' + androidxSqliteVersion
     compileOnly 'com.google.code.findbugs:jsr305:' + jsr305Version
     compileOnly 'org.checkerframework:checker-qual:' + checkerframeworkVersion
     compileOnly 'org.jetbrains.kotlin:kotlin-annotations-jvm:' + kotlinAnnotationsVersion

--- a/libraries/exoplayer/build.gradle
+++ b/libraries/exoplayer/build.gradle
@@ -51,7 +51,6 @@ dependencies {
     api project(modulePrefix + 'lib-database')
     implementation 'androidx.annotation:annotation:' + androidxAnnotationVersion
     implementation 'androidx.core:core:' + androidxCoreVersion
-    implementation 'androidx.sqlite:sqlite:' + androidxSqliteVersion
     compileOnly 'com.google.code.findbugs:jsr305:' + jsr305Version
     compileOnly 'org.checkerframework:checker-qual:' + checkerframeworkVersion
     compileOnly 'org.jetbrains.kotlin:kotlin-annotations-jvm:' + kotlinAnnotationsVersion

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DefaultDownloadIndex.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DefaultDownloadIndex.java
@@ -43,9 +43,7 @@ import androidx.sqlite.db.SupportSQLiteQueryBuilder;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * A {@link DownloadIndex} that uses SQLite to persist {@link Download Downloads}.
- */
+/** A {@link DownloadIndex} that uses SQLite to persist {@link Download Downloads}. */
 @UnstableApi
 public final class DefaultDownloadIndex implements WritableDownloadIndex {
 
@@ -175,8 +173,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
    * by a {@link DatabaseProvider}.
    *
    * @param databaseProvider Provides the SQLite database in which downloads are persisted.
-   * @param name             The name of the index. This name is incorporated into the names of the SQLite
-   *                         tables in which downloads are persisted.
+   * @param name The name of the index. This name is incorporated into the names of the SQLite tables in which downloads are persisted.
    */
   public DefaultDownloadIndex(DatabaseProvider databaseProvider, String name) {
     this.name = name;
@@ -354,7 +351,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
     }
 
     String[] columnsV2 =
-        new String[]{
+        new String[] {
             "id",
             "title",
             "uri",
@@ -380,9 +377,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
     }
   }
 
-  /**
-   * Infers the MIME type from a v2 table row.
-   */
+  /** Infers the MIME type from a v2 table row. */
   private static String inferMimeType(@Nullable String downloadType) {
     if ("dash".equals(downloadType)) {
       return MimeTypes.APPLICATION_MPD;
@@ -450,8 +445,8 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
     byte[] keySetId = cursor.getBlob(COLUMN_INDEX_KEY_SET_ID);
     DownloadRequest request =
         new DownloadRequest.Builder(
-            /* id= */ checkNotNull(cursor.getString(COLUMN_INDEX_ID)),
-            /* uri= */ Uri.parse(checkNotNull(cursor.getString(COLUMN_INDEX_URI))))
+              /* id= */ checkNotNull(cursor.getString(COLUMN_INDEX_ID)),
+              /* uri= */ Uri.parse(checkNotNull(cursor.getString(COLUMN_INDEX_URI))))
             .setMimeType(cursor.getString(COLUMN_INDEX_MIME_TYPE))
             .setStreamKeys(decodeStreamKeys(cursor.getString(COLUMN_INDEX_STREAM_KEYS)))
             .setKeySetId(keySetId.length > 0 ? keySetId : null)
@@ -480,9 +475,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
         downloadProgress);
   }
 
-  /**
-   * Read a {@link Download} from a table row of version 2.
-   */
+  /** Read a {@link Download} from a table row of version 2. */
   private static Download getDownloadForCurrentRowV2(Cursor cursor) {
     /*
      * Version 2 schema
@@ -504,8 +497,8 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
      */
     DownloadRequest request =
         new DownloadRequest.Builder(
-            /* id= */ checkNotNull(cursor.getString(0)),
-            /* uri= */ Uri.parse(checkNotNull(cursor.getString(2))))
+              /* id= */ checkNotNull(cursor.getString(0)),
+              /* uri= */ Uri.parse(checkNotNull(cursor.getString(2))))
             .setMimeType(inferMimeType(cursor.getString(1)))
             .setStreamKeys(decodeStreamKeys(cursor.getString(3)))
             .setCustomCacheKey(cursor.getString(4))

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DefaultDownloadIndex.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DefaultDownloadIndex.java
@@ -34,6 +34,7 @@ import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
 import androidx.media3.database.DatabaseIOException;
 import androidx.media3.database.DatabaseProvider;
+import androidx.media3.database.DatabaseUtil;
 import androidx.media3.database.VersionTable;
 import androidx.media3.exoplayer.offline.Download.FailureReason;
 import androidx.media3.exoplayer.offline.Download.State;
@@ -358,7 +359,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
 
   private List<Download> loadDownloadsFromVersion2(SupportSQLiteDatabase database) {
     List<Download> downloads = new ArrayList<>();
-    if (!Util.tableExists(database, tableName)) {
+    if (!DatabaseUtil.tableExists(database, tableName)) {
       return downloads;
     }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DefaultDownloadIndex.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DefaultDownloadIndex.java
@@ -90,22 +90,22 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
       getStateQuery(Download.STATE_COMPLETED, Download.STATE_FAILED);
 
   private static final String[] COLUMNS =
-      new String[]{
-          COLUMN_ID,
-          COLUMN_MIME_TYPE,
-          COLUMN_URI,
-          COLUMN_STREAM_KEYS,
-          COLUMN_CUSTOM_CACHE_KEY,
-          COLUMN_DATA,
-          COLUMN_STATE,
-          COLUMN_START_TIME_MS,
-          COLUMN_UPDATE_TIME_MS,
-          COLUMN_CONTENT_LENGTH,
-          COLUMN_STOP_REASON,
-          COLUMN_FAILURE_REASON,
-          COLUMN_PERCENT_DOWNLOADED,
-          COLUMN_BYTES_DOWNLOADED,
-          COLUMN_KEY_SET_ID
+      new String[] {
+        COLUMN_ID,
+        COLUMN_MIME_TYPE,
+        COLUMN_URI,
+        COLUMN_STREAM_KEYS,
+        COLUMN_CUSTOM_CACHE_KEY,
+        COLUMN_DATA,
+        COLUMN_STATE,
+        COLUMN_START_TIME_MS,
+        COLUMN_UPDATE_TIME_MS,
+        COLUMN_CONTENT_LENGTH,
+        COLUMN_STOP_REASON,
+        COLUMN_FAILURE_REASON,
+        COLUMN_PERCENT_DOWNLOADED,
+        COLUMN_BYTES_DOWNLOADED,
+        COLUMN_KEY_SET_ID
       };
 
   private static final String TABLE_SCHEMA =
@@ -173,7 +173,8 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
    * by a {@link DatabaseProvider}.
    *
    * @param databaseProvider Provides the SQLite database in which downloads are persisted.
-   * @param name The name of the index. This name is incorporated into the names of the SQLite tables in which downloads are persisted.
+   * @param name The name of the index. This name is incorporated into the names of the SQLite
+   *     tables in which downloads are persisted.
    */
   public DefaultDownloadIndex(DatabaseProvider databaseProvider, String name) {
     this.name = name;
@@ -186,7 +187,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
   @Nullable
   public Download getDownload(String id) throws DatabaseIOException {
     ensureInitialized();
-    try (Cursor cursor = getCursor(WHERE_ID_EQUALS, new String[]{id})) {
+    try (Cursor cursor = getCursor(WHERE_ID_EQUALS, new String[] {id})) {
       if (cursor.getCount() == 0) {
         return null;
       }
@@ -219,7 +220,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
   public void removeDownload(String id) throws DatabaseIOException {
     ensureInitialized();
     try {
-      databaseProvider.getWritableDatabase().delete(tableName, WHERE_ID_EQUALS, new String[]{id});
+      databaseProvider.getWritableDatabase().delete(tableName, WHERE_ID_EQUALS, new String[] {id});
     } catch (SQLiteException e) {
       throw new DatabaseIOException(e);
     }
@@ -232,8 +233,12 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
       ContentValues values = new ContentValues();
       values.put(COLUMN_STATE, Download.STATE_QUEUED);
       SupportSQLiteDatabase writableDatabase = databaseProvider.getWritableDatabase();
-      writableDatabase.update(tableName, SQLiteDatabase.CONFLICT_REPLACE, values,
-          WHERE_STATE_IS_DOWNLOADING, /* whereArgs= */ null);
+      writableDatabase.update(
+          tableName,
+          SQLiteDatabase.CONFLICT_REPLACE,
+          values,
+          WHERE_STATE_IS_DOWNLOADING,
+          /* whereArgs= */ null);
     } catch (SQLException e) {
       throw new DatabaseIOException(e);
     }
@@ -249,8 +254,12 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
       // case we're moving downloads from STATE_FAILED to STATE_REMOVING.
       values.put(COLUMN_FAILURE_REASON, Download.FAILURE_REASON_NONE);
       SupportSQLiteDatabase writableDatabase = databaseProvider.getWritableDatabase();
-      writableDatabase.update(tableName, SQLiteDatabase.CONFLICT_REPLACE, values, /* whereClause= */
-          null, /* whereArgs= */ null);
+      writableDatabase.update(
+          tableName,
+          SQLiteDatabase.CONFLICT_REPLACE,
+          values,
+          /* whereClause= */ null,
+          /* whereArgs= */ null);
     } catch (SQLException e) {
       throw new DatabaseIOException(e);
     }
@@ -263,8 +272,12 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
       ContentValues values = new ContentValues();
       values.put(COLUMN_STOP_REASON, stopReason);
       SupportSQLiteDatabase writableDatabase = databaseProvider.getWritableDatabase();
-      writableDatabase.update(tableName, SQLiteDatabase.CONFLICT_REPLACE, values,
-          WHERE_STATE_IS_TERMINAL, /* whereArgs= */ null);
+      writableDatabase.update(
+          tableName,
+          SQLiteDatabase.CONFLICT_REPLACE,
+          values,
+          WHERE_STATE_IS_TERMINAL,
+          /* whereArgs= */ null);
     } catch (SQLException e) {
       throw new DatabaseIOException(e);
     }
@@ -282,7 +295,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
           SQLiteDatabase.CONFLICT_REPLACE,
           values,
           WHERE_STATE_IS_TERMINAL + " AND " + WHERE_ID_EQUALS,
-          new String[]{id});
+          new String[] {id});
     } catch (SQLException e) {
       throw new DatabaseIOException(e);
     }
@@ -295,8 +308,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
       }
       try {
         SupportSQLiteDatabase readableDatabase = databaseProvider.getReadableDatabase();
-        int version = VersionTable.getVersion(readableDatabase,
-            VersionTable.FEATURE_OFFLINE, name);
+        int version = VersionTable.getVersion(readableDatabase, VersionTable.FEATURE_OFFLINE, name);
         if (version != TABLE_VERSION) {
           SupportSQLiteDatabase writableDatabase = databaseProvider.getWritableDatabase();
           writableDatabase.beginTransactionNonExclusive();
@@ -352,23 +364,23 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
 
     String[] columnsV2 =
         new String[] {
-            "id",
-            "title",
-            "uri",
-            "stream_keys",
-            "custom_cache_key",
-            "data",
-            "state",
-            "start_time_ms",
-            "update_time_ms",
-            "content_length",
-            "stop_reason",
-            "failure_reason",
-            "percent_downloaded",
-            "bytes_downloaded"
+          "id",
+          "title",
+          "uri",
+          "stream_keys",
+          "custom_cache_key",
+          "data",
+          "state",
+          "start_time_ms",
+          "update_time_ms",
+          "content_length",
+          "stop_reason",
+          "failure_reason",
+          "percent_downloaded",
+          "bytes_downloaded"
         };
-    SupportSQLiteQuery query = SupportSQLiteQueryBuilder.builder(tableName).columns(columnsV2)
-        .create();
+    SupportSQLiteQuery query =
+        SupportSQLiteQueryBuilder.builder(tableName).columns(columnsV2).create();
     try (Cursor cursor = database.query(query)) {
       while (cursor.moveToNext()) {
         downloads.add(getDownloadForCurrentRowV2(cursor));
@@ -394,13 +406,13 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
       throws DatabaseIOException {
     try {
       String sortOrder = COLUMN_START_TIME_MS + " ASC";
-      SupportSQLiteQuery query = SupportSQLiteQueryBuilder.builder(tableName).columns(COLUMNS)
-          .selection(
-              selection, selectionArgs
-          ).orderBy(sortOrder).create();
-      return databaseProvider
-          .getReadableDatabase()
-          .query(query);
+      SupportSQLiteQuery query =
+          SupportSQLiteQueryBuilder.builder(tableName)
+              .columns(COLUMNS)
+              .selection(selection, selectionArgs)
+              .orderBy(sortOrder)
+              .create();
+      return databaseProvider.getReadableDatabase().query(query);
     } catch (SQLiteException e) {
       throw new DatabaseIOException(e);
     }
@@ -445,8 +457,8 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
     byte[] keySetId = cursor.getBlob(COLUMN_INDEX_KEY_SET_ID);
     DownloadRequest request =
         new DownloadRequest.Builder(
-              /* id= */ checkNotNull(cursor.getString(COLUMN_INDEX_ID)),
-              /* uri= */ Uri.parse(checkNotNull(cursor.getString(COLUMN_INDEX_URI))))
+                /* id= */ checkNotNull(cursor.getString(COLUMN_INDEX_ID)),
+                /* uri= */ Uri.parse(checkNotNull(cursor.getString(COLUMN_INDEX_URI))))
             .setMimeType(cursor.getString(COLUMN_INDEX_MIME_TYPE))
             .setStreamKeys(decodeStreamKeys(cursor.getString(COLUMN_INDEX_STREAM_KEYS)))
             .setKeySetId(keySetId.length > 0 ? keySetId : null)
@@ -497,8 +509,8 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
      */
     DownloadRequest request =
         new DownloadRequest.Builder(
-              /* id= */ checkNotNull(cursor.getString(0)),
-              /* uri= */ Uri.parse(checkNotNull(cursor.getString(2))))
+                /* id= */ checkNotNull(cursor.getString(0)),
+                /* uri= */ Uri.parse(checkNotNull(cursor.getString(2))))
             .setMimeType(inferMimeType(cursor.getString(1)))
             .setStreamKeys(decodeStreamKeys(cursor.getString(3)))
             .setCustomCacheKey(cursor.getString(4))

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/offline/DefaultDownloadIndexTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/offline/DefaultDownloadIndexTest.java
@@ -63,7 +63,7 @@ public class DefaultDownloadIndexTest {
 
   @After
   public void tearDown() {
-    databaseProvider.tearDown();
+    databaseProvider.close();
   }
 
   @Test

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/offline/DefaultDownloadIndexTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/offline/DefaultDownloadIndexTest.java
@@ -23,7 +23,6 @@ import static androidx.media3.exoplayer.offline.Download.STOP_REASON_NONE;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
-import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 import androidx.annotation.Nullable;
 import androidx.media3.common.MimeTypes;
@@ -33,6 +32,7 @@ import androidx.media3.database.StandaloneDatabaseProvider;
 import androidx.media3.database.VersionTable;
 import androidx.media3.test.utils.DownloadBuilder;
 import androidx.media3.test.utils.TestUtil;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.collect.ImmutableList;
@@ -46,7 +46,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-/** Unit tests for {@link DefaultDownloadIndex}. */
+/**
+ * Unit tests for {@link DefaultDownloadIndex}.
+ */
 @RunWith(AndroidJUnit4.class)
 public class DefaultDownloadIndexTest {
 
@@ -63,7 +65,7 @@ public class DefaultDownloadIndexTest {
 
   @After
   public void tearDown() {
-    databaseProvider.close();
+    databaseProvider.tearDown();
   }
 
   @Test
@@ -104,8 +106,8 @@ public class DefaultDownloadIndexTest {
             .setStreamKeys(
                 new StreamKey(/* periodIndex= */ 0, /* groupIndex= */ 1, /* streamIndex= */ 2),
                 new StreamKey(/* periodIndex= */ 3, /* groupIndex= */ 4, /* streamIndex= */ 5))
-            .setCustomMetadata(new byte[] {0, 1, 2, 3, 7, 8, 9, 10})
-            .setKeySetId(new byte[] {0, 1, 2, 3})
+            .setCustomMetadata(new byte[]{0, 1, 2, 3, 7, 8, 9, 10})
+            .setKeySetId(new byte[]{0, 1, 2, 3})
             .build();
     downloadIndex.putDownload(download);
     Download readDownload = downloadIndex.getDownload(id);
@@ -189,13 +191,15 @@ public class DefaultDownloadIndexTest {
 
   @Test
   public void putDownload_setsVersion() throws DatabaseIOException {
-    SQLiteDatabase readableDatabase = databaseProvider.getReadableDatabase();
-    assertThat(VersionTable.getVersion(readableDatabase, VersionTable.FEATURE_OFFLINE, EMPTY_NAME))
+    SupportSQLiteDatabase readableDatabase = databaseProvider.getReadableDatabase();
+    assertThat(
+        VersionTable.getVersion(readableDatabase, VersionTable.FEATURE_OFFLINE, EMPTY_NAME))
         .isEqualTo(VersionTable.VERSION_UNSET);
 
     downloadIndex.putDownload(new DownloadBuilder("id1").build());
 
-    assertThat(VersionTable.getVersion(readableDatabase, VersionTable.FEATURE_OFFLINE, EMPTY_NAME))
+    assertThat(
+        VersionTable.getVersion(readableDatabase, VersionTable.FEATURE_OFFLINE, EMPTY_NAME))
         .isEqualTo(DefaultDownloadIndex.TABLE_VERSION);
   }
 
@@ -207,7 +211,7 @@ public class DefaultDownloadIndexTest {
     assertThat(cursor.getCount()).isEqualTo(1);
     cursor.close();
 
-    SQLiteDatabase writableDatabase = databaseProvider.getWritableDatabase();
+    SupportSQLiteDatabase writableDatabase = databaseProvider.getWritableDatabase();
     VersionTable.setVersion(
         writableDatabase, VersionTable.FEATURE_OFFLINE, EMPTY_NAME, Integer.MAX_VALUE);
 
@@ -391,7 +395,7 @@ public class DefaultDownloadIndexTest {
             .setMimeType(mimeType)
             .setStreamKeys(streamKeys)
             .setCustomCacheKey(customCacheKey)
-            .setData(new byte[] {0, 1, 2, 3})
+            .setData(new byte[]{0, 1, 2, 3})
             .build();
     return new Download(
         downloadRequest,

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/offline/DefaultDownloadIndexTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/offline/DefaultDownloadIndexTest.java
@@ -46,9 +46,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-/**
- * Unit tests for {@link DefaultDownloadIndex}.
- */
+/** Unit tests for {@link DefaultDownloadIndex}. */
 @RunWith(AndroidJUnit4.class)
 public class DefaultDownloadIndexTest {
 
@@ -106,8 +104,8 @@ public class DefaultDownloadIndexTest {
             .setStreamKeys(
                 new StreamKey(/* periodIndex= */ 0, /* groupIndex= */ 1, /* streamIndex= */ 2),
                 new StreamKey(/* periodIndex= */ 3, /* groupIndex= */ 4, /* streamIndex= */ 5))
-            .setCustomMetadata(new byte[]{0, 1, 2, 3, 7, 8, 9, 10})
-            .setKeySetId(new byte[]{0, 1, 2, 3})
+            .setCustomMetadata(new byte[] {0, 1, 2, 3, 7, 8, 9, 10})
+            .setKeySetId(new byte[] {0, 1, 2, 3})
             .build();
     downloadIndex.putDownload(download);
     Download readDownload = downloadIndex.getDownload(id);
@@ -395,7 +393,7 @@ public class DefaultDownloadIndexTest {
             .setMimeType(mimeType)
             .setStreamKeys(streamKeys)
             .setCustomCacheKey(customCacheKey)
-            .setData(new byte[]{0, 1, 2, 3})
+            .setData(new byte[] {0, 1, 2, 3})
             .build();
     return new Download(
         downloadRequest,

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/offline/DownloadManagerTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/offline/DownloadManagerTest.java
@@ -756,7 +756,7 @@ public class DownloadManagerTest {
             downloadManager =
                 new DownloadManager(
                     ApplicationProvider.getApplicationContext(),
-                    new DefaultDownloadIndex(TestUtil.getInMemoryDatabaseProvider()),
+                    new DefaultDownloadIndex(TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext())),
                     new FakeDownloaderFactory());
             downloadManager.setMaxParallelDownloads(maxParallelDownloads);
             downloadManager.setMinRetryCount(MIN_RETRY_COUNT);

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/offline/ProgressiveDownloaderTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/offline/ProgressiveDownloaderTest.java
@@ -58,7 +58,7 @@ public class ProgressiveDownloaderTest {
     assertThat(testDir.delete()).isTrue();
     assertThat(testDir.mkdirs()).isTrue();
 
-    DatabaseProvider databaseProvider = TestUtil.getInMemoryDatabaseProvider();
+    DatabaseProvider databaseProvider = TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext());
     downloadCache = new SimpleCache(testDir, new NoOpCacheEvictor(), databaseProvider);
   }
 

--- a/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/offline/DashDownloaderTest.java
+++ b/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/offline/DashDownloaderTest.java
@@ -72,7 +72,7 @@ public class DashDownloaderTest {
     tempFolder =
         Util.createTempDirectory(ApplicationProvider.getApplicationContext(), "ExoPlayerTest");
     cache =
-        new SimpleCache(tempFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider());
+        new SimpleCache(tempFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext()));
     progressListener = new ProgressListener();
   }
 

--- a/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/offline/DownloadManagerDashTest.java
+++ b/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/offline/DownloadManagerDashTest.java
@@ -83,7 +83,7 @@ public class DownloadManagerDashTest {
     cacheFolder.mkdir();
     cache =
         new SimpleCache(
-            cacheFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider());
+            cacheFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext()));
     MockitoAnnotations.initMocks(this);
     fakeDataSet =
         new FakeDataSet()
@@ -98,7 +98,7 @@ public class DownloadManagerDashTest {
 
     fakeStreamKey1 = new StreamKey(0, 0, 0);
     fakeStreamKey2 = new StreamKey(0, 1, 0);
-    downloadIndex = new DefaultDownloadIndex(TestUtil.getInMemoryDatabaseProvider());
+    downloadIndex = new DefaultDownloadIndex(TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext()));
     createDownloadManager();
   }
 

--- a/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/offline/DownloadServiceDashTest.java
+++ b/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/offline/DownloadServiceDashTest.java
@@ -80,7 +80,7 @@ public class DownloadServiceDashTest {
     context = ApplicationProvider.getApplicationContext();
     tempFolder = Util.createTempDirectory(context, "ExoPlayerTest");
     cache =
-        new SimpleCache(tempFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider());
+        new SimpleCache(tempFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext()));
 
     Runnable pauseAction =
         () -> {
@@ -113,7 +113,7 @@ public class DownloadServiceDashTest {
     testThread.runTestOnMainThread(
         () -> {
           DefaultDownloadIndex downloadIndex =
-              new DefaultDownloadIndex(TestUtil.getInMemoryDatabaseProvider());
+              new DefaultDownloadIndex(TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext()));
           DefaultDownloaderFactory downloaderFactory =
               new DefaultDownloaderFactory(
                   new CacheDataSource.Factory()

--- a/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/offline/HlsDownloaderTest.java
+++ b/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/offline/HlsDownloaderTest.java
@@ -79,7 +79,7 @@ public class HlsDownloaderTest {
     tempFolder =
         Util.createTempDirectory(ApplicationProvider.getApplicationContext(), "ExoPlayerTest");
     cache =
-        new SimpleCache(tempFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider());
+        new SimpleCache(tempFolder, new NoOpCacheEvictor(), TestUtil.getInMemoryDatabaseProvider(ApplicationProvider.getApplicationContext()));
     progressListener = new ProgressListener();
     fakeDataSet =
         new FakeDataSet()

--- a/libraries/test_utils/build.gradle
+++ b/libraries/test_utils/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     compileOnly 'org.checkerframework:checker-qual:' + checkerframeworkVersion
     compileOnly 'org.jetbrains.kotlin:kotlin-annotations-jvm:' + kotlinAnnotationsVersion
     implementation 'androidx.annotation:annotation:' + androidxAnnotationVersion
+    implementation 'androidx.sqlite:sqlite:' + androidxSqliteVersion
     implementation 'com.squareup.okhttp3:mockwebserver:' + okhttpVersion
     implementation project(modulePrefix + 'lib-exoplayer')
     testImplementation 'androidx.test.espresso:espresso-core:' + androidxTestEspressoVersion

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestUtil.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestUtil.java
@@ -18,8 +18,6 @@ package androidx.media3.test.utils;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
-import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteOpenHelper;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
@@ -32,7 +30,7 @@ import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
 import androidx.media3.database.DatabaseProvider;
-import androidx.media3.database.DefaultDatabaseProvider;
+import androidx.media3.database.StandaloneDatabaseProvider;
 import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DataSourceUtil;
 import androidx.media3.datasource.DataSpec;
@@ -214,20 +212,8 @@ public class TestUtil {
   }
 
   /** Returns a {@link DatabaseProvider} that provides an in-memory database. */
-  public static DatabaseProvider getInMemoryDatabaseProvider() {
-    return new DefaultDatabaseProvider(
-        new SQLiteOpenHelper(
-            /* context= */ null, /* name= */ null, /* factory= */ null, /* version= */ 1) {
-          @Override
-          public void onCreate(SQLiteDatabase db) {
-            // Do nothing.
-          }
-
-          @Override
-          public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-            // Do nothing.
-          }
-        });
+  public static DatabaseProvider getInMemoryDatabaseProvider(Context context) {
+    return new StandaloneDatabaseProvider(context, null);
   }
 
   /**


### PR DESCRIPTION
Would like feedback on approach before polishing. A few questions:

- I assume we are not okay with with common dep on sqlite library. I will make a DatabaseUtil in database lib and hopefully can remove that dependency?
- Is the StandaloneDatabaseProvider relying on androidx.sqlite:sqlite-framework an okay approach?
- Any advice for more tests to write / how to test migration scenarios?

Thanks
