### PR TITLE
Apply ClearKey DRM invalid URL workaround for Android 13 and newer

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -53,6 +53,9 @@
 *   Text:
 *   Metadata:
 *   DRM:
+    *   Extend workaround for spurious ClearKey `https://default.url` license
+        URL to API 33+ (previously the workaround only applied on API 33
+        exactly) ([#837](https://github.com/androidx/media/pull/837)).
 *   Effect:
 *   Muxers:
 *   IMA extension:

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
@@ -246,7 +246,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
   private static String adjustLicenseServerUrl(String licenseServerUrl) {
     if (MOCK_LA_URL.equals(licenseServerUrl)) {
       return "";
-    } else if (Util.SDK_INT == 33 && "https://default.url".equals(licenseServerUrl)) {
+    } else if (Util.SDK_INT >= 33 && "https://default.url".equals(licenseServerUrl)) {
       // Work around b/247808112
       return "";
     } else {


### PR DESCRIPTION
At least some Android 14 devices still have the same invalid URL issue when using ClearKey DRM, so might as well apply the check to newer versions of Android as well. We have seen this in the wild on Samsung S23 series devices at least.

Original fix: https://github.com/androidx/media/commit/715c948004eeabb6f7e2d45b8b8856ee4a015391