### PR TITLE
Fix forward and rewind button texts cut off with material theme applied

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -116,6 +116,9 @@
     *   Fix issue where forward and rewind buttons are not visible when used
         with Material Design in a BottomSheetDialogFragment
         ([#511](https://github.com/androidx/media/issues/511)).
+    *   Fix issue where the numbers in the fast forward button of the
+        `PlayerControlView` were misaligned
+        ([#547](https://github.com/androidx/media/issues/547)).
 *   Downloads:
 *   OkHttp Extension:
 *   Cronet Extension:

--- a/libraries/ui/src/main/res/values/styles.xml
+++ b/libraries/ui/src/main/res/values/styles.xml
@@ -50,6 +50,8 @@
   <style name="ExoStyledControls.Button.Center.FfwdWithAmount">
     <item name="android:foreground">@drawable/exo_styled_controls_fastforward</item>
     <item name="android:gravity">center|bottom</item>
+    <item name="android:paddingRight">0dp</item>
+    <item name="android:paddingLeft">0dp</item>
     <item name="android:paddingBottom">@dimen/exo_icon_padding_bottom</item>
     <item name="android:textStyle">bold</item>
     <item name="android:textSize">@dimen/exo_icon_text_size</item>
@@ -62,6 +64,8 @@
   <style name="ExoStyledControls.Button.Center.RewWithAmount">
     <item name="android:foreground">@drawable/exo_styled_controls_rewind</item>
     <item name="android:gravity">center|bottom</item>
+    <item name="android:paddingRight">0dp</item>
+    <item name="android:paddingLeft">0dp</item>
     <item name="android:paddingBottom">@dimen/exo_icon_padding_bottom</item>
     <item name="android:textStyle">bold</item>
     <item name="android:textSize">@dimen/exo_icon_text_size</item>


### PR DESCRIPTION
This style change does not affect the `Theme.AppCompat.NoActionBar` theme applied to the demo app.

You may test this patch by applying the `Theme.Material3.Dark` as parent theme to `PlayerTheme` inside `demos/main/src/main/res/values/styles.xml`. The default 15 second forward text should not be cut off any longer.

Tested on api levels 34 and 26.
 
Fixes #547