### PR TITLE
Ignore rowLock and columnLock values as specified by ANSI/CTA-708-E S…

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -93,6 +93,10 @@
         that contained Binder objects` error when using
         `DefaultExtractorsFactory.setTextTrackTranscodingEnabled`
         ([#836](https://github.com/androidx/media/issues/836)).
+    *   CEA-708: Ignore `rowLock` value. The CEA-708-E S-2023 spec states that
+        `rowLock` and `columnLock` should both be assumed to be true, regardless
+        of the values present in the stream (`columnLock` support is not
+        implemented, so it's effectively assumed to always be false).
 *   Metadata:
     *   Fix bug where `MediaMetadata` was only populated from Vorbis comments
         with upper-case keys

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/cea/Cea708Parser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/cea/Cea708Parser.java
@@ -784,7 +784,8 @@ public final class Cea708Parser implements SubtitleParser {
     captionChannelPacketData.skipBits(2); // null padding
     boolean visible = captionChannelPacketData.readBit();
 
-    // ANSI/CTA-708-E S-2023 spec (Section 8.4.7) indicates that rowLock and columnLock should be ignored and assumed to be lock
+    // ANSI/CTA-708-E S-2023 spec (Section 8.4.7) indicates that rowLock and columnLock should be
+    // ignored and assumed to be lock
     captionChannelPacketData.skipBits(2);
     boolean rowLock = true;
     boolean columnLock = true;

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/cea/Cea708Parser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/cea/Cea708Parser.java
@@ -785,7 +785,7 @@ public final class Cea708Parser implements SubtitleParser {
     boolean visible = captionChannelPacketData.readBit();
 
     // ANSI/CTA-708-E S-2023 spec (Section 8.4.7) indicates that rowLock and columnLock should be ignored and assumed to be lock
-    captionChannelPacketData.readBits(2);
+    captionChannelPacketData.skipBits(2);
     boolean rowLock = true;
     boolean columnLock = true;
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/cea/Cea708Parser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/cea/Cea708Parser.java
@@ -783,8 +783,12 @@ public final class Cea708Parser implements SubtitleParser {
     // first byte
     captionChannelPacketData.skipBits(2); // null padding
     boolean visible = captionChannelPacketData.readBit();
-    boolean rowLock = captionChannelPacketData.readBit();
-    boolean columnLock = captionChannelPacketData.readBit();
+
+    // ANSI/CTA-708-E S-2023 spec (Section 8.4.7) indicates that rowLock and columnLock should be ignored and assumed to be lock
+    captionChannelPacketData.readBits(2);
+    boolean rowLock = true;
+    boolean columnLock = true;
+
     int priority = captionChannelPacketData.readBits(3);
     // second byte
     boolean relativePositioning = captionChannelPacketData.readBit();

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/text/cea/Cea708ParserTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/text/cea/Cea708ParserTest.java
@@ -139,20 +139,13 @@ public class Cea708ParserTest {
                     Bytes.concat(
                         windowDefinition,
                         setCurrentWindow,
-                        "row1\r\nrow2\r\nrow3\r\nrow4".getBytes(Charsets.US_ASCII)))));
-    byte[] garbagePrefix = TestUtil.buildTestData(subtitleData.length * 2);
-    byte[] garbageSuffix = TestUtil.buildTestData(10);
-    byte[] subtitleDataWithGarbagePrefixAndSuffix =
-        Bytes.concat(garbagePrefix, subtitleData, garbageSuffix);
+                        "row1\r\nrow2\r\nrow3\r\nrow4".getBytes(Charsets.UTF_8)))));
 
     List<CuesWithTiming> result = new ArrayList<>();
-    cea708Parser.parse(
-        subtitleDataWithGarbagePrefixAndSuffix,
-        garbagePrefix.length,
-        subtitleData.length,
-        SubtitleParser.OutputOptions.allCues(),
-        result::add);
+    cea708Parser.parse(subtitleData, SubtitleParser.OutputOptions.allCues(), result::add);
 
+    // Row count is 1 (which means 2 rows should be kept). Row lock is disabled in the media,
+    // but this is ignored and the result is still truncated to only the last two rows.
     assertThat(Iterables.getOnlyElement(Iterables.getOnlyElement(result).cues).text.toString())
         .isEqualTo("row3\nrow4");
   }

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/text/cea/Cea708ParserTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/text/cea/Cea708ParserTest.java
@@ -42,6 +42,7 @@ public class Cea708ParserTest {
   private static final byte CHANNEL_PACKET_DATA = 0x6;
   private static final byte CHANNEL_PACKET_END = 0x2;
 
+
   @Test
   public void singleServiceAndWindowDefinition() throws Exception {
     Cea708Parser cea708Parser =
@@ -113,6 +114,47 @@ public class Cea708ParserTest {
 
     assertThat(Iterables.getOnlyElement(Iterables.getOnlyElement(result).cues).text.toString())
         .isEqualTo("test subtitle");
+  }
+
+  @Test
+  public void singleServiceAndWindowDefinition_ignoreRowLock() throws Exception {
+    Cea708Parser cea708Parser =
+        new Cea708Parser(
+            /* accessibilityChannel= */ Format.NO_VALUE, /* initializationData= */ null);
+    byte[] windowDefinition =
+        TestUtil.createByteArray(
+            0x98, // DF0 command (define window 0)
+            0b0010_0000, // visible=true, row lock and column lock disabled, priority=0
+            0xF0 | 50, // relative positioning, anchor vertical
+            50, // anchor horizontal
+            1, // anchor point = 0, row count = 10
+            30, // column count = 30
+            0b0000_1001); // window style = 1, pen style = 1
+    byte[] setCurrentWindow = TestUtil.createByteArray(0x80); // CW0 (set current window to 0)
+    byte[] subtitleData =
+        encodePacketIntoBytePairs(
+            createPacket(
+                /* sequenceNumber= */ 0,
+                createServiceBlock(
+                    Bytes.concat(
+                        windowDefinition,
+                        setCurrentWindow,
+                        "row1\r\nrow2\r\nrow3\r\nrow4".getBytes(Charsets.US_ASCII)))));
+    byte[] garbagePrefix = TestUtil.buildTestData(subtitleData.length * 2);
+    byte[] garbageSuffix = TestUtil.buildTestData(10);
+    byte[] subtitleDataWithGarbagePrefixAndSuffix =
+        Bytes.concat(garbagePrefix, subtitleData, garbageSuffix);
+
+    List<CuesWithTiming> result = new ArrayList<>();
+    cea708Parser.parse(
+        subtitleDataWithGarbagePrefixAndSuffix,
+        garbagePrefix.length,
+        subtitleData.length,
+        SubtitleParser.OutputOptions.allCues(),
+        result::add);
+
+    assertThat(Iterables.getOnlyElement(Iterables.getOnlyElement(result).cues).text.toString())
+        .isEqualTo("row3\nrow4");
   }
 
   /** See section 4.4.1 of the CEA-708-B spec. */

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/text/cea/Cea708ParserTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/text/cea/Cea708ParserTest.java
@@ -127,7 +127,7 @@ public class Cea708ParserTest {
             0b0010_0000, // visible=true, row lock and column lock disabled, priority=0
             0xF0 | 50, // relative positioning, anchor vertical
             50, // anchor horizontal
-            1, // anchor point = 0, row count = 10
+            1, // anchor point = 0, row count = 1
             30, // column count = 30
             0b0000_1001); // window style = 1, pen style = 1
     byte[] setCurrentWindow = TestUtil.createByteArray(0x80); // CW0 (set current window to 0)


### PR DESCRIPTION
ANSI CTA-708-E S-2023 specification indicates that row and column lock values should be ignored in DefineWindow command and decoders should assume rows and columns are locked.

8.4.7 Window Row and Column Locking
Prior to CEA-708-D, parameters row lock (rl) and column lock (cl) in the DefineWindow (DFx) command were used for control of window row and column locking, providing alternatives in growing and shrinking caption windows. This standard specifies a single method for window growing and shrinking, and in Section 8.10.5.2 these parameters are reserved. Future versions of this standard may allow use of these parameters, but decoders compliant with the present version of CEA-708 shall ignore the values, and assume rows and columns are locked. Future versions of this standard may allow the optional decoder implementation of windows with unlocked rows and columns, and may use these syntax elements.

The change is to make Cea708Parser follow the specification.