### PR TITLE
feat: show video track selectors on PlayerControlView

### DIFF
--- a/libraries/ui/src/main/res/drawable/exo_ic_videotrack.xml
+++ b/libraries/ui/src/main/res/drawable/exo_ic_videotrack.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24">
+  <path
+    android:fillColor="#FFFFFF"
+    android:pathData="M4,6L2,6v14c0,1.1 0.9,2 2,2h14v-2L4,20L4,6zM20,2L8,2c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM12,14.5v-9l6,4.5 -6,4.5z" />
+</vector>

--- a/libraries/ui/src/main/res/values/drawables.xml
+++ b/libraries/ui/src/main/res/values/drawables.xml
@@ -59,5 +59,6 @@
   <drawable name="exo_styled_controls_settings">@drawable/exo_ic_settings</drawable>
   <drawable name="exo_styled_controls_check">@drawable/exo_ic_check</drawable>
   <drawable name="exo_styled_controls_audiotrack">@drawable/exo_ic_audiotrack</drawable>
+  <drawable name="exo_styled_controls_videotrack">@drawable/exo_ic_videotrack</drawable>
   <drawable name="exo_styled_controls_speed">@drawable/exo_ic_speed</drawable>
 </resources>

--- a/libraries/ui/src/main/res/values/ids.xml
+++ b/libraries/ui/src/main/res/values/ids.xml
@@ -45,6 +45,7 @@
   <item name="exo_fullscreen" type="id"/>
   <item name="exo_playback_speed" type="id"/>
   <item name="exo_audio_track" type="id"/>
+  <item name="exo_video_track" type="id"/>
   <item name="exo_settings" type="id"/>
   <item name="exo_controls_background" type="id"/>
   <item name="exo_basic_controls" type="id"/>


### PR DESCRIPTION
This PR adds functionality on PlayerControlView to display an extra setting on SettingsPopup (Window) where user is able to select another VideoTrackSelection similar to AudioTrackSelection.

![image](https://github.com/androidx/media/assets/50703441/c471ecd6-ce49-4a93-a80a-d5a2d826c1f7)


![image](https://github.com/androidx/media/assets/50703441/74d98252-ab1d-44d8-af2e-65a12b935fcf)
