### PR TITLE
Fix HLS DTS Express bit-rate unknown issue.

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -15,7 +15,6 @@
  */
 package androidx.media3.exoplayer.mediacodec;
 
-import static androidx.media3.common.Format.NO_VALUE;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.Assertions.checkStateNotNull;
@@ -80,7 +79,6 @@ import androidx.media3.exoplayer.source.MediaSource;
 import androidx.media3.exoplayer.source.SampleStream;
 import androidx.media3.exoplayer.source.SampleStream.ReadDataResult;
 import androidx.media3.exoplayer.source.SampleStream.ReadFlags;
-import androidx.media3.extractor.DtsUtil;
 import androidx.media3.extractor.OpusUtil;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -2402,20 +2402,6 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
                       .setEncoderDelay(numberPreSkipSamples)
                       .build();
             }
-            // For HLS-fMP4 and HLS-TS, the bit-rate of the DTS Express stream is not in the
-            // manifest file. The bit-rate has no value at the point of AudioTrack Initialisation.
-            // This will lead to a computed direct passthrough playback buffer size of 2250000
-            // bytes. Some TVs (E.g. Xiaomi A Pro and Q2) do not support such a big buffer for
-            // direct passthrough playback. It will crash at the point of AudioTrack Initialisation.
-            // Here we set the unknown bit-rate to a known peak bit-rate for DTS Express streams.
-            if (Objects.equals(outputFormat.sampleMimeType, MimeTypes.AUDIO_DTS_EXPRESS)
-                && (outputFormat.bitrate == NO_VALUE)) {
-              outputFormat =
-                  checkNotNull(outputFormat)
-                      .buildUpon()
-                      .setPeakBitrate(DtsUtil.DTS_EXPRESS_MAX_RATE_BITS_PER_SECOND)
-                      .build();
-            }
             onOutputFormatChanged(outputFormat, /* mediaFormat= */ null);
             waitingForFirstSampleInFormat = false;
           }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
@@ -143,6 +143,9 @@ public final class DtsUtil {
   /** Maximum rate for a DTS-HD audio stream, in bytes per second. */
   public static final int DTS_HD_MAX_RATE_BYTES_PER_SECOND = 18000 * 1000 / 8;
 
+  /** Maximum bit-rate for a DTS Express audio stream, in bits per second. */
+  public static final int DTS_EXPRESS_MAX_RATE_BITS_PER_SECOND = 768000;
+
   /**
    * DTS Core Syncword (in different Endianness). See ETSI TS 102 114 V1.6.1 (2019-08), Section 5.3.
    */


### PR DESCRIPTION
 For HLS-fMP4 and HLS-TS, the bit-rate of the DTS Express stream is not in the manifest file. The bit-rate has no value at the point of AudioTrack Initialisation. This will lead to a computed direct passthrough playback buffer size of 2250000 bytes. Some TVs (E.g. Xiaomi A Pro and Q2) do not support such a big buffer for direct passthrough playback. It will crash at the point of AudioTrack Initialization. Here we set the unknown bit-rate to a known peak bit-rate for DTS Express streams so that a smaller buffer size will be computed based on it.
      