### PR TITLE
Fix support link in `ExoPlayerImpl#verifyApplicationThread()`

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
@@ -2845,8 +2845,8 @@ import java.util.concurrent.TimeoutException;
               "Player is accessed on the wrong thread.\n"
                   + "Current thread: '%s'\n"
                   + "Expected thread: '%s'\n"
-                  + "See https://developer.android.com/guide/topics/media/issues/"
-                  + "player-accessed-on-wrong-thread",
+                  + "See https://developer.android.com/media/media3/exoplayer/troubleshooting"
+                  + "#what-do-player-is-accessed-on-the-wrong-thread-errors-mean",
               Thread.currentThread().getName(), getApplicationLooper().getThread().getName());
       if (throwsWhenUsingWrongThread) {
         throw new IllegalStateException(message);


### PR DESCRIPTION
`ExoPlayerImpl#verifyApplicationThread()` throws an `IllegalStateException` and log a message if the player is accessed from the wrong thread. The message contains a link to the documentation to help developers understand the issue. However, the link is no longer valid. This PR updates it to point to the right location.