### PR TITLE
Player view to show post-processed resolution instead of the input one

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/DebugTextViewHelper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/DebugTextViewHelper.java
@@ -22,6 +22,7 @@ import androidx.annotation.Nullable;
 import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
 import androidx.media3.common.Player;
+import androidx.media3.common.VideoSize;
 import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.DecoderCounters;
@@ -127,6 +128,7 @@ public class DebugTextViewHelper {
   @UnstableApi
   protected String getVideoString() {
     Format format = player.getVideoFormat();
+    VideoSize videoSize = player.getVideoSize();
     DecoderCounters decoderCounters = player.getVideoDecoderCounters();
     if (format == null || decoderCounters == null) {
       return "";
@@ -136,11 +138,11 @@ public class DebugTextViewHelper {
         + "(id:"
         + format.id
         + " r:"
-        + format.width
+        + videoSize.width
         + "x"
-        + format.height
+        + videoSize.height
         + getColorInfoString(format.colorInfo)
-        + getPixelAspectRatioString(format.pixelWidthHeightRatio)
+        + getPixelAspectRatioString(videoSize.pixelWidthHeightRatio)
         + getDecoderCountersBufferCountString(decoderCounters)
         + " vfpo: "
         + getVideoFrameProcessingOffsetAverageString(


### PR DESCRIPTION
_Problem_
If a video effect is applied to the video, or an "enhancement" such as LCEVC, is applied, the on screen player view debug text still shows the "input" resolution and pixel aspect ratio and not the one after post-processing. This can be easily reproduced with effects such as `Crop` or `ScaleAndRotateTransformation` which change the output resolution.

_Root cause_
The resolution and pixel aspect ratio shown are taken from the input Format object, which is a property of the stream and not of the video decoding and post processing applied.

_Proposed solution_
Take with, height and pixel aspect ratio from the player's VideoSize, which does get updated in case of post-processing.
