### PR TITLE
Main

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Jan 30 08:51:00 MST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libraries/common/src/main/java/androidx/media3/common/Label.java
+++ b/libraries/common/src/main/java/androidx/media3/common/Label.java
@@ -1,0 +1,82 @@
+package androidx.media3.common;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.common.util.Util;
+
+/** A Label, as defined by ISO 23009-1, 2019 edition, 5.3.7.2. */
+@UnstableApi
+public class Label implements Parcelable {
+  /** The Label identifier, if one exists. */
+  @Nullable public final String id;
+
+  /** Declares the language code(s) for this Label. */
+  @Nullable public final String lang;
+
+  /** The value for this Label. */
+  public final String value;
+
+  /**
+   * @param id The id.
+   * @param lang The lang code.
+   * @param value The value.
+   */
+  public Label(@Nullable String id, @Nullable String lang, String value) {
+    this.id = id;
+    this.lang = lang;
+    this.value = value;
+  }
+
+  /* package */ Label(Parcel in) {
+    id = in.readString();
+    lang = in.readString();
+    value = in.readString();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Label label = (Label) o;
+    return Util.areEqual(id, label.id)
+        && Util.areEqual(lang, label.lang)
+        && Util.areEqual(value, label.value);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = value.hashCode();
+    result = 31 * result + (id != null ? id.hashCode() : 0);
+    result = 31 * result + (lang != null ? lang.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(@NonNull Parcel dest, int flags) {
+    dest.writeString(id);
+    dest.writeString(lang);
+    dest.writeString(value);
+  }
+
+  public static final Parcelable.Creator<Label> CREATOR =
+      new Parcelable.Creator<Label>() {
+
+        @Override
+        public Label createFromParcel(Parcel in) {
+          return new Label(in);
+        }
+
+        @Override
+        public Label[] newArray(int size) {
+          return new Label[size];
+        }
+      };
+}

--- a/libraries/common/src/main/java/androidx/media3/common/Label.java
+++ b/libraries/common/src/main/java/androidx/media3/common/Label.java
@@ -7,7 +7,7 @@ import androidx.annotation.Nullable;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
 
-/** A Label, as defined by ISO 23009-1, 2019 edition, 5.3.7.2. */
+/** A Label, as defined by ISO 23009-1, 4th edition, 5.3.7.2. */
 @UnstableApi
 public class Label implements Parcelable {
   /** The Label identifier, if one exists. */

--- a/libraries/common/src/test/java/androidx/media3/common/FormatTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/FormatTest.java
@@ -83,9 +83,11 @@ public final class FormatTest {
             .setChromaBitdepth(11)
             .build();
 
+    List<Label> labels = new ArrayList<>();
+    labels.add(new Label("id", "en", "label"));
     return new Format.Builder()
         .setId("id")
-        .setLabel("label")
+        .setLabels(labels)
         .setLanguage("language")
         .setSelectionFlags(C.SELECTION_FLAG_DEFAULT)
         .setRoleFlags(C.ROLE_FLAG_MAIN)

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DecoderAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DecoderAudioRenderer.java
@@ -450,7 +450,7 @@ public abstract class DecoderAudioRenderer<
               .setEncoderPadding(encoderPadding)
               .setMetadata(inputFormat.metadata)
               .setId(inputFormat.id)
-              .setLabel(inputFormat.label)
+              .setLabels(inputFormat.labels)
               .setLanguage(inputFormat.language)
               .setSelectionFlags(inputFormat.selectionFlags)
               .setRoleFlags(inputFormat.roleFlags)

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
@@ -551,7 +551,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
               .setEncoderPadding(format.encoderPadding)
               .setMetadata(format.metadata)
               .setId(format.id)
-              .setLabel(format.label)
+              .setLabels(format.labels)
               .setLanguage(format.language)
               .setSelectionFlags(format.selectionFlags)
               .setRoleFlags(format.roleFlags)

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/DefaultMediaSourceFactory.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/DefaultMediaSourceFactory.java
@@ -26,6 +26,7 @@ import androidx.annotation.Nullable;
 import androidx.media3.common.AdViewProvider;
 import androidx.media3.common.C;
 import androidx.media3.common.Format;
+import androidx.media3.common.Label;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Assertions;
@@ -58,6 +59,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -513,13 +515,21 @@ public final class DefaultMediaSourceFactory implements MediaSourceFactory {
       mediaSources[0] = mediaSource;
       for (int i = 0; i < subtitleConfigurations.size(); i++) {
         if (parseSubtitlesDuringExtraction) {
+          List<Label> labels = new ArrayList<>();
+          String label = subtitleConfigurations.get(i).label;
+          if (label != null) {
+            labels.add(new Label(null, null, label));
+          } else {
+            labels = null;
+          }
+
           Format format =
               new Format.Builder()
                   .setSampleMimeType(subtitleConfigurations.get(i).mimeType)
                   .setLanguage(subtitleConfigurations.get(i).language)
                   .setSelectionFlags(subtitleConfigurations.get(i).selectionFlags)
                   .setRoleFlags(subtitleConfigurations.get(i).roleFlags)
-                  .setLabel(subtitleConfigurations.get(i).label)
+                  .setLabels(labels)
                   .setId(subtitleConfigurations.get(i).id)
                   .build();
           ExtractorsFactory extractorsFactory =

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/SingleSampleMediaSource.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/SingleSampleMediaSource.java
@@ -21,6 +21,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import android.net.Uri;
 import androidx.annotation.Nullable;
 import androidx.media3.common.Format;
+import androidx.media3.common.Label;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.Timeline;
@@ -33,6 +34,8 @@ import androidx.media3.exoplayer.upstream.DefaultLoadErrorHandlingPolicy;
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Loads data at a given {@link Uri} as a single sample belonging to a single {@link MediaPeriod}.
@@ -170,13 +173,20 @@ public final class SingleSampleMediaSource extends BaseMediaSource {
             .setSubtitleConfigurations(ImmutableList.of(subtitleConfiguration))
             .setTag(tag)
             .build();
+    List<Label> labels = new ArrayList<>();
+    String label = subtitleConfiguration.label;
+    if (label != null) {
+      labels.add(new Label(null, null, label));
+    } else {
+      labels = null;
+    }
     this.format =
         new Format.Builder()
             .setSampleMimeType(firstNonNull(subtitleConfiguration.mimeType, MimeTypes.TEXT_UNKNOWN))
             .setLanguage(subtitleConfiguration.language)
             .setSelectionFlags(subtitleConfiguration.selectionFlags)
             .setRoleFlags(subtitleConfiguration.roleFlags)
-            .setLabel(subtitleConfiguration.label)
+            .setLabels(labels)
             .setId(subtitleConfiguration.id != null ? subtitleConfiguration.id : trackId)
             .build();
     this.dataSpec =

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/mediaparser/OutputConsumerAdapterV30.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/mediaparser/OutputConsumerAdapterV30.java
@@ -517,7 +517,7 @@ public final class OutputConsumerAdapterV30 implements MediaParser.OutputConsume
             .setLanguage(muxedCaptionFormat.language)
             .setRoleFlags(muxedCaptionFormat.roleFlags)
             .setSelectionFlags(muxedCaptionFormat.selectionFlags)
-            .setLabel(muxedCaptionFormat.label)
+            .setLabels(muxedCaptionFormat.labels)
             .setMetadata(muxedCaptionFormat.metadata);
         break;
       }

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/source/SampleQueueTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/source/SampleQueueTest.java
@@ -2058,7 +2058,7 @@ public final class SampleQueueTest {
   }
 
   private static Format copyWithLabel(Format format, String label) {
-    return format.buildUpon().setLabel(label).build();
+    return format.buildUpon().setLabels(label).build();
   }
 
   private static final class MockDrmSessionManager implements DrmSessionManager {

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/HlsMediaPeriod.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/HlsMediaPeriod.java
@@ -21,6 +21,7 @@ import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.media3.common.DrmInitData;
 import androidx.media3.common.Format;
+import androidx.media3.common.Label;
 import androidx.media3.common.Metadata;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.StreamKey;
@@ -845,7 +846,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     @Nullable String sampleMimeType = MimeTypes.getMediaMimeType(codecs);
     return new Format.Builder()
         .setId(variantFormat.id)
-        .setLabel(variantFormat.label)
+        .setLabels(variantFormat.labels)
         .setContainerMimeType(variantFormat.containerMimeType)
         .setSampleMimeType(sampleMimeType)
         .setCodecs(codecs)
@@ -868,7 +869,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     int selectionFlags = 0;
     int roleFlags = 0;
     @Nullable String language = null;
-    @Nullable String label = null;
+    @Nullable List<Label> labels = null;
     if (mediaTagFormat != null) {
       codecs = mediaTagFormat.codecs;
       metadata = mediaTagFormat.metadata;
@@ -876,7 +877,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
       selectionFlags = mediaTagFormat.selectionFlags;
       roleFlags = mediaTagFormat.roleFlags;
       language = mediaTagFormat.language;
-      label = mediaTagFormat.label;
+      labels = mediaTagFormat.labels;
     } else {
       codecs = Util.getCodecsOfType(variantFormat.codecs, C.TRACK_TYPE_AUDIO);
       metadata = variantFormat.metadata;
@@ -885,7 +886,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
         selectionFlags = variantFormat.selectionFlags;
         roleFlags = variantFormat.roleFlags;
         language = variantFormat.language;
-        label = variantFormat.label;
+        labels = variantFormat.labels;
       }
     }
     @Nullable String sampleMimeType = MimeTypes.getMediaMimeType(codecs);
@@ -893,7 +894,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     int peakBitrate = isPrimaryTrackInVariant ? variantFormat.peakBitrate : Format.NO_VALUE;
     return new Format.Builder()
         .setId(variantFormat.id)
-        .setLabel(label)
+        .setLabels(labels)
         .setContainerMimeType(variantFormat.containerMimeType)
         .setSampleMimeType(sampleMimeType)
         .setCodecs(codecs)

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/HlsSampleStreamWrapper.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/HlsSampleStreamWrapper.java
@@ -1563,7 +1563,7 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
         sampleFormat
             .buildUpon()
             .setId(playlistFormat.id)
-            .setLabel(playlistFormat.label)
+            .setLabels(playlistFormat.labels)
             .setLanguage(playlistFormat.language)
             .setSelectionFlags(playlistFormat.selectionFlags)
             .setRoleFlags(playlistFormat.roleFlags)

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsPlaylistParser.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsPlaylistParser.java
@@ -27,6 +27,7 @@ import androidx.media3.common.C;
 import androidx.media3.common.DrmInitData;
 import androidx.media3.common.DrmInitData.SchemeData;
 import androidx.media3.common.Format;
+import androidx.media3.common.Label;
 import androidx.media3.common.Metadata;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.ParserException;
@@ -471,10 +472,12 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
       line = mediaTags.get(i);
       String groupId = parseStringAttr(line, REGEX_GROUP_ID, variableDefinitions);
       String name = parseStringAttr(line, REGEX_NAME, variableDefinitions);
+      List<Label> labels = new ArrayList<>();
+      labels.add(new Label(null, null, name));
       Format.Builder formatBuilder =
           new Format.Builder()
               .setId(groupId + ":" + name)
-              .setLabel(name)
+              .setLabels(labels)
               .setContainerMimeType(MimeTypes.APPLICATION_M3U8)
               .setSelectionFlags(parseSelectionFlags(line))
               .setRoleFlags(parseRoleFlags(line, variableDefinitions))

--- a/libraries/exoplayer_smoothstreaming/src/main/java/androidx/media3/exoplayer/smoothstreaming/manifest/SsManifestParser.java
+++ b/libraries/exoplayer_smoothstreaming/src/main/java/androidx/media3/exoplayer/smoothstreaming/manifest/SsManifestParser.java
@@ -24,6 +24,7 @@ import androidx.media3.common.C;
 import androidx.media3.common.DrmInitData;
 import androidx.media3.common.DrmInitData.SchemeData;
 import androidx.media3.common.Format;
+import androidx.media3.common.Label;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.ParserException;
 import androidx.media3.common.util.Assertions;
@@ -740,10 +741,17 @@ public class SsManifestParser implements ParsingLoadable.Parser<SsManifest> {
         formatBuilder.setContainerMimeType(MimeTypes.APPLICATION_MP4);
       }
 
+      List<Label> labels = new ArrayList<>();
+      String label = (String) getNormalizedAttribute(KEY_NAME);
+      if (label != null) {
+        labels.add(new Label(null, null, label));
+      } else {
+        labels = null;
+      }
       format =
           formatBuilder
               .setId(parser.getAttributeValue(null, KEY_INDEX))
-              .setLabel((String) getNormalizedAttribute(KEY_NAME))
+              .setLabels(labels)
               .setSampleMimeType(sampleMimeType)
               .setAverageBitrate(parseRequiredInt(parser, KEY_BITRATE))
               .setLanguage((String) getNormalizedAttribute(KEY_LANGUAGE))

--- a/libraries/exoplayer_smoothstreaming/src/test/java/androidx/media3/exoplayer/smoothstreaming/manifest/SsManifestParserTest.java
+++ b/libraries/exoplayer_smoothstreaming/src/test/java/androidx/media3/exoplayer/smoothstreaming/manifest/SsManifestParserTest.java
@@ -51,6 +51,6 @@ public final class SsManifestParserTest {
             Uri.parse("https://example.com/test.ismc"),
             TestUtil.getInputStream(ApplicationProvider.getApplicationContext(), SAMPLE_ISMC_1));
 
-    assertThat(ssManifest.streamElements[0].formats[0].label).isEqualTo("video");
+    assertThat(ssManifest.streamElements[0].formats[0].labels).isEqualTo("video");
   }
 }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/avi/AviExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/avi/AviExtractor.java
@@ -21,6 +21,7 @@ import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.media3.common.Format;
+import androidx.media3.common.Label;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.ParserException;
 import androidx.media3.common.util.Assertions;
@@ -42,6 +43,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.ArrayList;
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /**
@@ -514,7 +516,9 @@ public final class AviExtractor implements Extractor {
     }
     StreamNameChunk streamName = streamList.getChild(StreamNameChunk.class);
     if (streamName != null) {
-      builder.setLabel(streamName.name);
+      List<Label> labels = new ArrayList<>();
+      labels.add(new Label(null, null, streamName.name));
+      builder.setLabels(labels);
     }
     int trackType = MimeTypes.getTrackType(streamFormat.sampleMimeType);
     if (trackType == C.TRACK_TYPE_AUDIO || trackType == C.TRACK_TYPE_VIDEO) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
@@ -33,6 +33,7 @@ import androidx.media3.common.ColorInfo;
 import androidx.media3.common.DrmInitData;
 import androidx.media3.common.DrmInitData.SchemeData;
 import androidx.media3.common.Format;
+import androidx.media3.common.Label;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.ParserException;
 import androidx.media3.common.util.Log;
@@ -2423,7 +2424,9 @@ public class MatroskaExtractor implements Extractor {
       }
 
       if (name != null && !TRACK_NAME_TO_ROTATION_DEGREES.containsKey(name)) {
-        formatBuilder.setLabel(name);
+        List<Label> labels = new ArrayList<>();
+        labels.add(new Label(null, null, name));
+        formatBuilder.setLabels(labels);
       }
 
       Format format =

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/DumpableFormat.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/DumpableFormat.java
@@ -100,7 +100,7 @@ public final class DumpableFormat implements Dumper.Dumpable {
         DEFAULT_FORMAT,
         format -> Util.getRoleFlagStrings(format.roleFlags));
     addIfNonDefault(dumper, "language", format, DEFAULT_FORMAT, format -> format.language);
-    addIfNonDefault(dumper, "label", format, DEFAULT_FORMAT, format -> format.label);
+    addIfNonDefault(dumper, "label", format, DEFAULT_FORMAT, format -> format.labels);
     if (format.drmInitData != null) {
       dumper.add("drmInitData", format.drmInitData.hashCode());
     }

--- a/libraries/ui/src/main/java/androidx/media3/ui/DefaultTrackNameProvider.java
+++ b/libraries/ui/src/main/java/androidx/media3/ui/DefaultTrackNameProvider.java
@@ -20,11 +20,14 @@ import android.text.TextUtils;
 import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.media3.common.Format;
+import androidx.media3.common.Label;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
+import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 /** A default {@link TrackNameProvider}. */
 @UnstableApi
@@ -101,7 +104,19 @@ public class DefaultTrackNameProvider implements TrackNameProvider {
   }
 
   private String buildLabelString(Format format) {
-    return TextUtils.isEmpty(format.label) ? "" : format.label;
+    if (format.labels == null || format.labels.isEmpty()) {
+      return "";
+    }
+    if (!TextUtils.isEmpty(format.language)) {
+      List<Label> labelsByLanguage =
+          format.labels.stream()
+              .filter(label -> format.language.equals(label.lang))
+              .collect(Collectors.toList());
+      if (!labelsByLanguage.isEmpty()) {
+        return labelsByLanguage.get(0).value;
+      }
+    }
+    return TextUtils.isEmpty(format.labels.get(0).value) ? "" : format.labels.get(0).value;
   }
 
   private String buildLanguageString(Format format) {


### PR DESCRIPTION
According to **ISO/IEC 23009-1 [4], clause 5.3.7.2 Table 13**, an AdaptationSet could include several Label elements (0..N), not only one. But right now Exoplayer only fetches the first Label and ignores the rest.

This PR fetches all the Labels and stores them in Format.labels that is a List of labels instead of only one label String. Also, instead of just storing a String, it creates the class `Label` that stores the three possible fields that can be related to the Label: id, lang and the value of the Label.

When a "label" field is included in the AdaptationSet, it will be added to the list as a Label without id or lang only when there are not actual Label elements. It will be ignored otherwise.