### PR TITLE
Fix wav format pcm encoding detection error

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/ParsableByteArray.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/ParsableByteArray.java
@@ -24,6 +24,7 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.UUID;
 
 /**
  * Wraps a byte array, providing a set of methods for parsing data from it. Numerical values are
@@ -619,6 +620,26 @@ public final class ParsableByteArray {
       }
     }
     return null;
+  }
+
+  /**
+   * Reads microsoft GUID as java UUID
+   *
+   * @throws IllegalStateException if there is not enough data decoding
+   * @return Decoded UUID
+   * */
+  public UUID readMSGUID() {
+    if (bytesLeft() < 16) {
+      throw new IllegalStateException("Not enough data");
+    }
+    // flip little ending to big ending
+    // https://learn.microsoft.com/en-us/windows/win32/api/guiddef/ns-guiddef-guid
+    long d1 = readLittleEndianUnsignedInt();
+    long d2 = readLittleEndianUnsignedShort();
+    long d3 = readLittleEndianUnsignedShort();
+    long mostSigBits = d1 << 32 | d2 << 16 | d3;
+    long leastSigBits = readLong();
+    return new UUID(mostSigBits, leastSigBits);
   }
 
   /**

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/WavUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/WavUtil.java
@@ -20,6 +20,8 @@ import androidx.media3.common.Format;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
 
+import java.util.UUID;
+
 /** Utilities for handling WAVE files. */
 @UnstableApi
 public final class WavUtil {
@@ -59,6 +61,14 @@ public final class WavUtil {
 
   /** WAVE type value for extended WAVE format. */
   public static final int TYPE_WAVE_FORMAT_EXTENSIBLE = 0xFFFE;
+
+  public static final UUID KSDATAFORMAT_SUBTYPE_PCM = UUID.fromString("00000001-0000-0010-8000-00aa00389b71");
+
+  public static final UUID KSDATAFORMAT_SUBTYPE_IEEE_FLOAT = UUID.fromString("00000003-0000-0010-8000-00aa00389b71");
+
+  public static final UUID KSDATAFORMAT_SUBTYPE_ALAW = UUID.fromString("00000006-0000-0010-8000-00aa00389b71");
+
+  public static final UUID KSDATAFORMAT_SUBTYPE_MULAW = UUID.fromString("00000007-0000-0010-8000-00aa00389b71");
 
   /**
    * Returns the WAVE format type value for the given {@link C.PcmEncoding}.

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/wav/WavFormat.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/wav/WavFormat.java
@@ -15,6 +15,9 @@
  */
 package androidx.media3.extractor.wav;
 
+import java.util.UUID;
+import org.jetbrains.annotations.Nullable;
+
 /** Format information for a WAV file. */
 /* package */ final class WavFormat {
 
@@ -42,6 +45,16 @@ package androidx.media3.extractor.wav;
   /** Extra data appended to the format chunk. */
   public final byte[] extraData;
 
+  /** Number of valid bits */
+  public final int validBitsPerSample;
+
+  /** Speaker position mask */
+  public final int channelMask;
+
+  /** GUID, including the data format code */
+  @Nullable
+  public final UUID uuid;
+
   public WavFormat(
       int formatType,
       int numChannels,
@@ -57,5 +70,32 @@ package androidx.media3.extractor.wav;
     this.blockSize = blockSize;
     this.bitsPerSample = bitsPerSample;
     this.extraData = extraData;
+    this.validBitsPerSample = 0;
+    this.channelMask = 0;
+    this.uuid = null;
   }
+
+  public WavFormat(
+      int formatType,
+      int numChannels,
+      int frameRateHz,
+      int averageBytesPerSecond,
+      int blockSize,
+      int bitsPerSample,
+      byte[] extraData,
+      int validBitsPerSample,
+      int channelMask,
+      @Nullable UUID uuid) {
+    this.formatType = formatType;
+    this.numChannels = numChannels;
+    this.frameRateHz = frameRateHz;
+    this.averageBytesPerSecond = averageBytesPerSecond;
+    this.blockSize = blockSize;
+    this.bitsPerSample = bitsPerSample;
+    this.extraData = extraData;
+    this.validBitsPerSample = validBitsPerSample;
+    this.channelMask = channelMask;
+    this.uuid = uuid;
+  }
+
 }


### PR DESCRIPTION
### Problem
I exported some long-duration audio files in wav format from Adobe Audition, but there was a harsh noise when played on exoplayer.
### Root Cause
`WavExtractor#readFormat` ignores GUIDs declared in fmt blocks when making PCM format selections.
Only integer bit depths are considered when `TYPE_WAVE_FORMAT_EXTENSIBLE (0xFFFE)` is detected.
### Solution
Parse `WavFormat.extraData` to get GUID to determine PCM data type.
### Links
[Original issue](https://github.com/google/ExoPlayer/issues/10953)
