### PR TITLE
Fixed missing skip padding issue when reading odd sized chunks from wav files.

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/wav/WavHeaderReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/wav/WavHeaderReader.java
@@ -172,6 +172,11 @@ import java.io.IOException;
     while (chunkHeader.id != chunkId) {
       Log.w(TAG, "Ignoring unknown WAV chunk: " + chunkHeader.id);
       long bytesToSkip = ChunkHeader.SIZE_IN_BYTES + chunkHeader.size;
+      // To align RIFF chunks to certain boundaries the RIFF specification includes a JUNK chunk.
+      // Its contents are to be skipped when reading.
+      if (chunkHeader.size % 2 != 0) {
+        bytesToSkip ++; // padding present if size is odd, skip it.
+      }
       if (bytesToSkip > Integer.MAX_VALUE) {
         throw ParserException.createForUnsupportedContainerFeature(
             "Chunk is too large (~2GB+) to skip; id: " + chunkHeader.id);


### PR DESCRIPTION
If a chunk body has an odd number of bytes, it must be followed by a padding byte with value 0. In other words, a chunk must always occupy an even number of bytes in the file. The padding byte should not be counted in the chunk header’s size field. For example, if a chunk body is 17 bytes in size, the header’s size field should be set to 17, even though the chunk body occupies 18 bytes (17 bytes of data followed by the padding byte).

https://wavefilegem.com/how_wave_files_work.html
