### PR TITLE
Adds load info to `DrmSessionEventListeneronDrmKeysLoaded()`

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSession.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSession.java
@@ -21,6 +21,7 @@ import static java.lang.Math.min;
 
 import android.annotation.SuppressLint;
 import android.media.NotProvisionedException;
+import android.net.Uri;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
@@ -36,6 +37,7 @@ import androidx.media3.common.util.Consumer;
 import androidx.media3.common.util.CopyOnWriteMultiset;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.Util;
+import androidx.media3.datasource.DataSpec;
 import androidx.media3.decoder.CryptoConfig;
 import androidx.media3.exoplayer.analytics.PlayerId;
 import androidx.media3.exoplayer.drm.ExoMediaDrm.KeyRequest;
@@ -149,6 +151,7 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
   private byte @MonotonicNonNull [] offlineLicenseKeySetId;
 
   @Nullable private KeyRequest currentKeyRequest;
+  @Nullable private KeyLoadInfo currentKeyLoadInfo;
   @Nullable private ProvisionRequest currentProvisionRequest;
 
   /**
@@ -489,6 +492,9 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
 
   private void postKeyRequest(byte[] scope, int type, boolean allowRetry) {
     try {
+      if (type == ExoMediaDrm.KEY_TYPE_STREAMING) {
+        currentKeyLoadInfo = new KeyLoadInfo();
+      }
       currentKeyRequest = mediaDrm.getKeyRequest(scope, schemeDatas, type, keyRequestParameters);
       Util.castNonNull(requestHandler)
           .post(MSG_KEYS, Assertions.checkNotNull(currentKeyRequest), allowRetry);
@@ -524,7 +530,8 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
           offlineLicenseKeySetId = keySetId;
         }
         state = STATE_OPENED_WITH_KEYS;
-        dispatchEvent(DrmSessionEventListener.EventDispatcher::drmKeysLoaded);
+        dispatchEvent(eventDispatcher -> eventDispatcher.drmKeysLoaded(currentKeyLoadInfo));
+        currentKeyLoadInfo = null;
       }
     } catch (Exception e) {
       onKeysError(e, /* thrownByExoMediaDrm= */ true);
@@ -644,6 +651,19 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
             break;
           case MSG_KEYS:
             response = callback.executeKeyRequest(uuid, (KeyRequest) requestTask.request);
+            if (currentKeyLoadInfo != null) {
+              String requestUrl = ((KeyRequest) requestTask.request).getLicenseServerUrl();
+              LoadEventInfo loadEventInfo =
+                  new LoadEventInfo(
+                      requestTask.taskId,
+                      new DataSpec.Builder().setUri(requestUrl).build(),
+                      Uri.parse(requestUrl),
+                      Collections.emptyMap(),
+                      SystemClock.elapsedRealtime(),
+                      /* loadDurationMs= */ SystemClock.elapsedRealtime() - requestTask.startTimeMs,
+                      ((byte []) response).length);
+              currentKeyLoadInfo.setMainLoadRequest(loadEventInfo);
+            }
             break;
           default:
             throw new RuntimeException();
@@ -699,6 +719,7 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
         // The error is fatal.
         return false;
       }
+      currentKeyLoadInfo.addRetryLoadRequest(loadEventInfo);
       synchronized (this) {
         if (!isReleased) {
           sendMessageDelayed(Message.obtain(originalMsg), retryDelayMs);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DrmSessionEventListener.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DrmSessionEventListener.java
@@ -47,12 +47,20 @@ public interface DrmSessionEventListener {
       int windowIndex, @Nullable MediaPeriodId mediaPeriodId, @DrmSession.State int state) {}
 
   /**
+   * @deprecated Implement {@link #onDrmKeysLoaded(int, MediaPeriodId, KeyLoadInfo)} instead
+   */
+  @Deprecated
+  default void onDrmKeysLoaded(int windowIndex, @Nullable MediaPeriodId mediaPeriodId) {}
+
+  /**
    * Called each time keys are loaded.
    *
    * @param windowIndex The window index in the timeline this media period belongs to.
    * @param mediaPeriodId The {@link MediaPeriodId} associated with the drm session.
+   * @param keyLoadInfo The {@link KeyLoadInfo} with load info for the drm server request[s]
    */
-  default void onDrmKeysLoaded(int windowIndex, @Nullable MediaPeriodId mediaPeriodId) {}
+  default void onDrmKeysLoaded(
+      int windowIndex, @Nullable MediaPeriodId mediaPeriodId, @Nullable KeyLoadInfo keyLoadInfo) {}
 
   /**
    * Called when a drm error occurs.
@@ -177,12 +185,17 @@ public interface DrmSessionEventListener {
       }
     }
 
-    /** Dispatches {@link #onDrmKeysLoaded(int, MediaPeriodId)}. */
-    public void drmKeysLoaded() {
+    /** Dispatches {@link #onDrmKeysLoaded(int, MediaPeriodId)}.
+     * and {@link #onDrmKeysLoaded(int, MediaPeriodId, KeyLoadInfo)}*/
+    public void drmKeysLoaded(@Nullable KeyLoadInfo keyLoadInfo) {
       for (ListenerAndHandler listenerAndHandler : listenerAndHandlers) {
         DrmSessionEventListener listener = listenerAndHandler.listener;
         postOrRun(
-            listenerAndHandler.handler, () -> listener.onDrmKeysLoaded(windowIndex, mediaPeriodId));
+            listenerAndHandler.handler,
+            () -> {
+              listener.onDrmKeysLoaded(windowIndex, mediaPeriodId);
+              listener.onDrmKeysLoaded(windowIndex, mediaPeriodId, keyLoadInfo);
+            });
       }
     }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/KeyLoadInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/KeyLoadInfo.java
@@ -1,0 +1,26 @@
+package androidx.media3.exoplayer.drm;
+
+import androidx.media3.exoplayer.source.LoadEventInfo;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Encapsulates info for the sequence of load requests ({@link LoadEventInfo}, which were required
+ * to complete loading a DRM key
+ */
+public class KeyLoadInfo {
+  public LoadEventInfo loadEventInfo;
+  public final List<LoadEventInfo> retriedLoadRequests;
+
+  public KeyLoadInfo() {
+    retriedLoadRequests = new ArrayList<>();
+  }
+
+  void setMainLoadRequest(LoadEventInfo loadEventInfo) {
+    this.loadEventInfo = loadEventInfo;
+  }
+
+  void addRetryLoadRequest(LoadEventInfo loadEventInfo) {
+    retriedLoadRequests.add(loadEventInfo);
+  }
+}

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/OfflineLicenseHelper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/OfflineLicenseHelper.java
@@ -144,7 +144,8 @@ public final class OfflineLicenseHelper {
     DrmSessionEventListener eventListener =
         new DrmSessionEventListener() {
           @Override
-          public void onDrmKeysLoaded(int windowIndex, @Nullable MediaPeriodId mediaPeriodId) {
+          public void onDrmKeysLoaded(int windowIndex, @Nullable MediaPeriodId mediaPeriodId,
+              @Nullable KeyLoadInfo keyLoadInfo) {
             drmListenerConditionVariable.open();
           }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/CompositeMediaSource.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/CompositeMediaSource.java
@@ -26,6 +26,7 @@ import androidx.media3.common.util.Util;
 import androidx.media3.datasource.TransferListener;
 import androidx.media3.exoplayer.drm.DrmSession;
 import androidx.media3.exoplayer.drm.DrmSessionEventListener;
+import androidx.media3.exoplayer.drm.KeyLoadInfo;
 import java.io.IOException;
 import java.util.HashMap;
 
@@ -316,9 +317,10 @@ public abstract class CompositeMediaSource<T> extends BaseMediaSource {
     }
 
     @Override
-    public void onDrmKeysLoaded(int windowIndex, @Nullable MediaPeriodId mediaPeriodId) {
+    public void onDrmKeysLoaded(
+        int windowIndex, @Nullable MediaPeriodId mediaPeriodId, @Nullable KeyLoadInfo keyLoadInfo) {
       if (maybeUpdateEventDispatcher(windowIndex, mediaPeriodId)) {
-        drmEventDispatcher.drmKeysLoaded();
+        drmEventDispatcher.drmKeysLoaded(keyLoadInfo);
       }
     }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ads/ServerSideAdInsertionMediaSource.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ads/ServerSideAdInsertionMediaSource.java
@@ -46,6 +46,7 @@ import androidx.media3.exoplayer.LoadingInfo;
 import androidx.media3.exoplayer.SeekParameters;
 import androidx.media3.exoplayer.drm.DrmSession;
 import androidx.media3.exoplayer.drm.DrmSessionEventListener;
+import androidx.media3.exoplayer.drm.KeyLoadInfo;
 import androidx.media3.exoplayer.source.BaseMediaSource;
 import androidx.media3.exoplayer.source.EmptySampleStream;
 import androidx.media3.exoplayer.source.ForwardingTimeline;
@@ -357,15 +358,15 @@ public final class ServerSideAdInsertionMediaSource extends BaseMediaSource
   }
 
   @Override
-  public void onDrmKeysLoaded(int windowIndex, @Nullable MediaPeriodId mediaPeriodId) {
+  public void onDrmKeysLoaded(int windowIndex, @Nullable MediaPeriodId mediaPeriodId, @Nullable KeyLoadInfo keyLoadInfo) {
     @Nullable
     MediaPeriodImpl mediaPeriod =
         getMediaPeriodForEvent(
             mediaPeriodId, /* mediaLoadData= */ null, /* useLoadingPeriod= */ false);
     if (mediaPeriod == null) {
-      drmEventDispatcherWithoutId.drmKeysLoaded();
+      drmEventDispatcherWithoutId.drmKeysLoaded(keyLoadInfo);
     } else {
-      mediaPeriod.drmEventDispatcher.drmKeysLoaded();
+      mediaPeriod.drmEventDispatcher.drmKeysLoaded(keyLoadInfo);
     }
   }
 


### PR DESCRIPTION
This is a first pass at what we talked about in issue https://github.com/androidx/media/issues/1001

* added the wrapper class `KeyLoadInfo` to embody the requests required  to fetch the key
* added `KeyLoadInfo` to the `DrmSessionEventListener.drmKeysLoaded()` method
* Deprecated `DrmSessionEventListener.onDrmKeysLoaded(int, MediaPeriodId)`
* added new `onDrmKeysLoaded()` with the `KeyLoadInfo`, setup so both method are called

Next steps are to add it to `AnalyticsListener` and update any broken test cases possibly add some new ones