### PR TITLE
Fixed removal of user info for URLs that contain encoded @ characters

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -44,6 +44,8 @@
 *   DASH Extension:
 *   Smooth Streaming Extension:
 *   RTSP Extension:
+    *   Fix user info removal for URLs that contain encoded @ characters
+        ([#1138](https://github.com/androidx/media/pull/1138)).
 *   Decoder Extensions (FFmpeg, VP9, AV1, etc.):
 *   MIDI extension:
 *   Leanback extension:

--- a/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMessageUtil.java
+++ b/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMessageUtil.java
@@ -192,7 +192,7 @@ import java.util.regex.Pattern;
     }
 
     // The Uri must include a "@" if the user info is non-null.
-    String authorityWithUserInfo = checkNotNull(uri.getAuthority());
+    String authorityWithUserInfo = checkNotNull(uri.getEncodedAuthority());
     checkArgument(authorityWithUserInfo.contains("@"));
     String authority = Util.split(authorityWithUserInfo, "@")[1];
     return uri.buildUpon().encodedAuthority(authority).build();

--- a/libraries/exoplayer_rtsp/src/test/java/androidx/media3/exoplayer/rtsp/RtspMessageUtilTest.java
+++ b/libraries/exoplayer_rtsp/src/test/java/androidx/media3/exoplayer/rtsp/RtspMessageUtilTest.java
@@ -452,8 +452,7 @@ public final class RtspMessageUtilTest {
   @Test
   public void removeUserInfo_withEncodedAtInUserInfo() {
     Uri uri = Uri.parse("rtsp://user%40name:pass@foo.bar/foo.mkv");
-    assertThat(RtspMessageUtil.removeUserInfo(uri))
-        .isEqualTo(Uri.parse("rtsp://foo.bar/foo.mkv"));
+    assertThat(RtspMessageUtil.removeUserInfo(uri)).isEqualTo(Uri.parse("rtsp://foo.bar/foo.mkv"));
   }
 
   @Test

--- a/libraries/exoplayer_rtsp/src/test/java/androidx/media3/exoplayer/rtsp/RtspMessageUtilTest.java
+++ b/libraries/exoplayer_rtsp/src/test/java/androidx/media3/exoplayer/rtsp/RtspMessageUtilTest.java
@@ -450,6 +450,13 @@ public final class RtspMessageUtilTest {
   }
 
   @Test
+  public void removeUserInfo_withEncodedAtInUserInfo() {
+    Uri uri = Uri.parse("rtsp://user%40name:pass@foo.bar/foo.mkv");
+    assertThat(RtspMessageUtil.removeUserInfo(uri))
+        .isEqualTo(Uri.parse("rtsp://foo.bar/foo.mkv"));
+  }
+
+  @Test
   public void parseContentLengthHeader_withContentLengthOver31Bits_succeeds() throws Exception {
     String line = "Content-Length: 1000000000000000";
     long contentLength = RtspMessageUtil.parseContentLengthHeader(line);


### PR DESCRIPTION
This bug occurs when using email addresses encoded as the user (i.e: `rtsp://user%40name:pass@foo.bar/foo.mkv`)

The solution is simply to use the `getEncodedAuthority` method instead of `getAuthority`. This resolves the issue because getAuthority decodes the encoded "@" symbols before splitting, resulting in a malformed URL.

Malformed URL example: `rtsp://name:pass/foo.mkv`

After the fix, it properly returns: `rtsp://foo.bar/foo.mkv`