### PR TITLE
Update Guava to 33.0.0-android

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -28,7 +28,7 @@ project.ext {
     junitVersion = '4.13.2'
     // Use the same Guava version as the Android repo:
     // https://cs.android.com/android/platform/superproject/main/+/main:external/guava/METADATA
-    guavaVersion = '32.1.3-android'
+    guavaVersion = '33.0.0-android'
     mockitoVersion = '3.12.4'
     robolectricVersion = '4.11'
     // Keep this in sync with Google's internal Checker Framework version.


### PR DESCRIPTION
Following the recommendation in `constants.gradle`: https://github.com/androidx/media/blob/d13a0f4ec62ca092b79746a5725b62a3244cc5b4/constants.gradle#L29-L31

This PR updates Guava to the version used in the Android repository: 33.0.0.

The changelog for Guava 33.0.0 is available [here](https://github.com/google/guava/releases/tag/v33.0.0).