### PR TITLE
Remove unused `package` property from `AndroidManifest.xml` files

### DIFF
--- a/demos/cast/src/main/AndroidManifest.xml
+++ b/demos/cast/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="androidx.media3.demo.cast">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>

--- a/demos/gl/src/main/AndroidManifest.xml
+++ b/demos/gl/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="androidx.media3.demo.gl">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>

--- a/demos/main/src/main/AndroidManifest.xml
+++ b/demos/main/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.demo.main">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>

--- a/demos/session/src/main/AndroidManifest.xml
+++ b/demos/session/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
      limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.demo.session">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-sdk/>
   <uses-permission android:name="android.permission.INTERNET" />

--- a/demos/session_automotive/src/main/AndroidManifest.xml
+++ b/demos/session_automotive/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
      limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.demo.session.automotive">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-sdk/>
   <uses-permission android:name="android.permission.INTERNET" />

--- a/demos/session_service/src/main/AndroidManifest.xml
+++ b/demos/session_service/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="androidx.media3.demo.session.service">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-sdk />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 </manifest>

--- a/demos/shortform/src/main/AndroidManifest.xml
+++ b/demos/shortform/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
      limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="androidx.media3.demo.shortform">
+  xmlns:tools="http://schemas.android.com/tools">
 
   <application
     android:allowBackup="false"

--- a/demos/surface/src/main/AndroidManifest.xml
+++ b/demos/surface/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="androidx.media3.demo.surface">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>

--- a/demos/transformer/src/main/AndroidManifest.xml
+++ b/demos/transformer/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
   ~ limitations under the License.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.demo.transformer">
+    xmlns:tools="http://schemas.android.com/tools">
   <uses-sdk />
 
   <uses-permission android:name="android.permission.INTERNET"/>

--- a/libraries/cast/build.gradle
+++ b/libraries/cast/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.cast'
+    testNamespace 'androidx.media3.cast.test'
 
     publishing {
         singleVariant('release') {

--- a/libraries/cast/src/main/AndroidManifest.xml
+++ b/libraries/cast/src/main/AndroidManifest.xml
@@ -13,6 +13,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest package="androidx.media3.cast">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/cast/src/test/AndroidManifest.xml
+++ b/libraries/cast/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.cast.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/common/build.gradle
+++ b/libraries/common/build.gradle
@@ -26,6 +26,7 @@ rootProject.allprojects.forEach {
 
 android {
     namespace 'androidx.media3.common'
+    testNamespace 'androidx.media3.common.test'
 
     buildTypes {
         debug {

--- a/libraries/common/src/main/AndroidManifest.xml
+++ b/libraries/common/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
      limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="androidx.media3.common">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-sdk />
 </manifest>

--- a/libraries/common/src/test/AndroidManifest.xml
+++ b/libraries/common/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.common.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/container/build.gradle
+++ b/libraries/container/build.gradle
@@ -15,6 +15,7 @@
 apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 android {
     namespace 'androidx.media3.container'
+    testNamespace 'androidx.media3.container.test'
 
     defaultConfig {
         // The following argument makes the Android Test Orchestrator run its

--- a/libraries/container/src/main/AndroidManifest.xml
+++ b/libraries/container/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.container">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/container/src/test/AndroidManifest.xml
+++ b/libraries/container/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.container.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/database/build.gradle
+++ b/libraries/database/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.database'
+    testNamespace 'androidx.media3.database.test'
 
     buildTypes {
         debug {

--- a/libraries/database/src/main/AndroidManifest.xml
+++ b/libraries/database/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.database">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/database/src/test/AndroidManifest.xml
+++ b/libraries/database/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.database.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/datasource/build.gradle
+++ b/libraries/datasource/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.datasource'
+    testNamespace 'androidx.media3.datasource.test'
 
     buildTypes {
         debug {

--- a/libraries/datasource/src/androidTest/AndroidManifest.xml
+++ b/libraries/datasource/src/androidTest/AndroidManifest.xml
@@ -15,8 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.datasource.test">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>

--- a/libraries/datasource/src/main/AndroidManifest.xml
+++ b/libraries/datasource/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.datasource">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/datasource/src/test/AndroidManifest.xml
+++ b/libraries/datasource/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.datasource.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/datasource_cronet/build.gradle
+++ b/libraries/datasource_cronet/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.datasource.cronet'
+    testNamespace 'androidx.media3.datasource.cronet.test'
 
     publishing {
         singleVariant('release') {

--- a/libraries/datasource_cronet/src/androidTest/AndroidManifest.xml
+++ b/libraries/datasource_cronet/src/androidTest/AndroidManifest.xml
@@ -15,8 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.datasource.cronet.test">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>

--- a/libraries/datasource_cronet/src/main/AndroidManifest.xml
+++ b/libraries/datasource_cronet/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
      limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="androidx.media3.datasource.cronet">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-sdk />

--- a/libraries/datasource_cronet/src/test/AndroidManifest.xml
+++ b/libraries/datasource_cronet/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.datasource.cronet.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/datasource_okhttp/build.gradle
+++ b/libraries/datasource_okhttp/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.datasource.okhttp'
+    testNamespace 'androidx.media3.datasource.okhttp.test'
 
     defaultConfig.minSdkVersion 21
 

--- a/libraries/datasource_okhttp/src/main/AndroidManifest.xml
+++ b/libraries/datasource_okhttp/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.datasource.okhttp">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/datasource_okhttp/src/test/AndroidManifest.xml
+++ b/libraries/datasource_okhttp/src/test/AndroidManifest.xml
@@ -15,6 +15,6 @@
   ~ limitations under the License.
   -->
 
-<manifest package="androidx.media3.datasource.okhttp.test">
+<manifest>
     <uses-sdk/>
 </manifest>

--- a/libraries/datasource_rtmp/build.gradle
+++ b/libraries/datasource_rtmp/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.datasource.rtmp'
+    testNamespace 'androidx.media3.datasource.rtmp.test'
 
     publishing {
         singleVariant('release') {

--- a/libraries/datasource_rtmp/src/main/AndroidManifest.xml
+++ b/libraries/datasource_rtmp/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.datasource.rtmp">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/datasource_rtmp/src/test/AndroidManifest.xml
+++ b/libraries/datasource_rtmp/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.datasource.rtmp.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/decoder/build.gradle
+++ b/libraries/decoder/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.decoder'
+    testNamespace 'androidx.media3.decoder.test'
 
     buildTypes {
         debug {

--- a/libraries/decoder/src/main/AndroidManifest.xml
+++ b/libraries/decoder/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.decoder">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/decoder/src/test/AndroidManifest.xml
+++ b/libraries/decoder/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.decoder.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/decoder_av1/src/main/AndroidManifest.xml
+++ b/libraries/decoder_av1/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.decoder.av1">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/decoder_ffmpeg/build.gradle
+++ b/libraries/decoder_ffmpeg/build.gradle
@@ -13,7 +13,10 @@
 // limitations under the License.
 apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
-android.namespace = 'androidx.media3.decoder.ffmpeg'
+android {
+    namespace 'androidx.media3.decoder.ffmpeg'
+    testNamespace 'androidx.media3.decoder.ffmpeg.test'
+}
 
 // Configure the native build only if ffmpeg is present to avoid gradle sync
 // failures if ffmpeg hasn't been built according to the README instructions.

--- a/libraries/decoder_ffmpeg/src/main/AndroidManifest.xml
+++ b/libraries/decoder_ffmpeg/src/main/AndroidManifest.xml
@@ -14,4 +14,4 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.decoder.ffmpeg"/>
+<manifest/>

--- a/libraries/decoder_ffmpeg/src/test/AndroidManifest.xml
+++ b/libraries/decoder_ffmpeg/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.decoder.ffmpeg.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/decoder_flac/build.gradle
+++ b/libraries/decoder_flac/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.decoder.flac'
+    testNamespace 'androidx.media3.decoder.flac.test'
 
     sourceSets {
         main {

--- a/libraries/decoder_flac/src/androidTest/AndroidManifest.xml
+++ b/libraries/decoder_flac/src/androidTest/AndroidManifest.xml
@@ -15,8 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.decoder.flac.test">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-sdk/>

--- a/libraries/decoder_flac/src/main/AndroidManifest.xml
+++ b/libraries/decoder_flac/src/main/AndroidManifest.xml
@@ -14,4 +14,4 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.decoder.flac"/>
+<manifest/>

--- a/libraries/decoder_flac/src/test/AndroidManifest.xml
+++ b/libraries/decoder_flac/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.decoder.flac.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/decoder_midi/build.gradle
+++ b/libraries/decoder_midi/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.decoder.midi'
+    testNamespace 'androidx.media3.decoder.midi.test'
 
     sourceSets.test.assets.srcDir '../test_data/src/test/assets/'
 

--- a/libraries/decoder_midi/src/main/AndroidManifest.xml
+++ b/libraries/decoder_midi/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.decoder.midi">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/decoder_midi/src/test/AndroidManifest.xml
+++ b/libraries/decoder_midi/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.decoder.midi.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/decoder_opus/build.gradle
+++ b/libraries/decoder_opus/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.decoder.opus'
+    testNamespace 'androidx.media3.decoder.opus.test'
 
     sourceSets {
         main {

--- a/libraries/decoder_opus/src/androidTest/AndroidManifest.xml
+++ b/libraries/decoder_opus/src/androidTest/AndroidManifest.xml
@@ -15,8 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.decoder.opus.test">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-sdk/>

--- a/libraries/decoder_opus/src/main/AndroidManifest.xml
+++ b/libraries/decoder_opus/src/main/AndroidManifest.xml
@@ -14,4 +14,4 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.decoder.opus"/>
+<manifest/>

--- a/libraries/decoder_opus/src/test/AndroidManifest.xml
+++ b/libraries/decoder_opus/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.decoder.opus.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/decoder_vp9/build.gradle
+++ b/libraries/decoder_vp9/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.decoder.vp9'
+    testNamespace 'androidx.media3.decoder.vp9.test'
 
     sourceSets {
         main {

--- a/libraries/decoder_vp9/src/androidTest/AndroidManifest.xml
+++ b/libraries/decoder_vp9/src/androidTest/AndroidManifest.xml
@@ -15,8 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.decoder.vp9.test">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-sdk/>

--- a/libraries/decoder_vp9/src/main/AndroidManifest.xml
+++ b/libraries/decoder_vp9/src/main/AndroidManifest.xml
@@ -14,4 +14,4 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.decoder.vp9"/>
+<manifest/>

--- a/libraries/decoder_vp9/src/test/AndroidManifest.xml
+++ b/libraries/decoder_vp9/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.decoder.vp9.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/effect/build.gradle
+++ b/libraries/effect/build.gradle
@@ -14,6 +14,7 @@
 apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 android {
     namespace 'androidx.media3.effect'
+    testNamespace 'androidx.media3.effect.test'
 
     defaultConfig {
         // The following argument makes the Android Test Orchestrator run its

--- a/libraries/effect/src/androidTest/AndroidManifest.xml
+++ b/libraries/effect/src/androidTest/AndroidManifest.xml
@@ -15,8 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.effect.test">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-sdk/>
 

--- a/libraries/effect/src/main/AndroidManifest.xml
+++ b/libraries/effect/src/main/AndroidManifest.xml
@@ -13,6 +13,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest package="androidx.media3.effect">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/effect/src/test/AndroidManifest.xml
+++ b/libraries/effect/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.effect.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/exoplayer/build.gradle
+++ b/libraries/exoplayer/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.exoplayer'
+    testNamespace 'androidx.media3.exoplayer.test'
 
     defaultConfig {
         // The following argument makes the Android Test Orchestrator run its

--- a/libraries/exoplayer/src/androidTest/AndroidManifest.xml
+++ b/libraries/exoplayer/src/androidTest/AndroidManifest.xml
@@ -15,8 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.exoplayer.test">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.INTERNET"/>

--- a/libraries/exoplayer/src/main/AndroidManifest.xml
+++ b/libraries/exoplayer/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
      limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="androidx.media3.exoplayer">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-sdk />
 </manifest>

--- a/libraries/exoplayer/src/test/AndroidManifest.xml
+++ b/libraries/exoplayer/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.exoplayer.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/exoplayer_dash/build.gradle
+++ b/libraries/exoplayer_dash/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.exoplayer.dash'
+    testNamespace 'androidx.media3.exoplayer.dash.test'
 
     buildTypes {
         debug {

--- a/libraries/exoplayer_dash/src/main/AndroidManifest.xml
+++ b/libraries/exoplayer_dash/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.exoplayer.dash">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/exoplayer_dash/src/test/AndroidManifest.xml
+++ b/libraries/exoplayer_dash/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.exoplayer.dash.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/exoplayer_hls/build.gradle
+++ b/libraries/exoplayer_hls/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.exoplayer.hls'
+    testNamespace 'androidx.media3.exoplayer.hls.test'
 
     buildTypes {
         debug {

--- a/libraries/exoplayer_hls/src/main/AndroidManifest.xml
+++ b/libraries/exoplayer_hls/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.exoplayer.hls">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/exoplayer_hls/src/test/AndroidManifest.xml
+++ b/libraries/exoplayer_hls/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.exoplayer.hls.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/exoplayer_ima/build.gradle
+++ b/libraries/exoplayer_ima/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.exoplayer.ima'
+    testNamespace 'androidx.media3.exoplayer.ima.test'
 
     sourceSets {
         androidTest.assets.srcDir '../test_data/src/test/assets'

--- a/libraries/exoplayer_ima/src/androidTest/AndroidManifest.xml
+++ b/libraries/exoplayer_ima/src/androidTest/AndroidManifest.xml
@@ -15,8 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.exoplayer.ima.test">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.INTERNET"/>

--- a/libraries/exoplayer_ima/src/main/AndroidManifest.xml
+++ b/libraries/exoplayer_ima/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="androidx.media3.exoplayer.ima">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-sdk />
   <application>
     <meta-data android:name="com.google.android.gms.ads.AD_MANAGER_APP"

--- a/libraries/exoplayer_ima/src/test/AndroidManifest.xml
+++ b/libraries/exoplayer_ima/src/test/AndroidManifest.xml
@@ -13,6 +13,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest package="androidx.media3.exoplayer.ima.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/exoplayer_rtsp/build.gradle
+++ b/libraries/exoplayer_rtsp/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.exoplayer.rtsp'
+    testNamespace 'androidx.media3.exoplayer.rtsp.test'
 
     buildTypes {
         debug {

--- a/libraries/exoplayer_rtsp/src/main/AndroidManifest.xml
+++ b/libraries/exoplayer_rtsp/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.exoplayer.rtsp">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/exoplayer_rtsp/src/test/AndroidManifest.xml
+++ b/libraries/exoplayer_rtsp/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.exoplayer.rtsp.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/exoplayer_smoothstreaming/build.gradle
+++ b/libraries/exoplayer_smoothstreaming/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.exoplayer.smoothstreaming'
+    testNamespace 'androidx.media3.exoplayer.smoothstreaming.test'
 
     buildTypes {
         debug {

--- a/libraries/exoplayer_smoothstreaming/src/main/AndroidManifest.xml
+++ b/libraries/exoplayer_smoothstreaming/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.exoplayer.smoothstreaming">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/exoplayer_smoothstreaming/src/test/AndroidManifest.xml
+++ b/libraries/exoplayer_smoothstreaming/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.exoplayer.smoothstreaming.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/exoplayer_workmanager/src/main/AndroidManifest.xml
+++ b/libraries/exoplayer_workmanager/src/main/AndroidManifest.xml
@@ -15,6 +15,6 @@
   ~ limitations under the License.
   -->
 
-<manifest package="androidx.media3.exoplayer.workmanager">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/extractor/build.gradle
+++ b/libraries/extractor/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.extractor'
+    testNamespace 'androidx.media3.extractor.test'
 
     buildTypes {
         debug {

--- a/libraries/extractor/src/androidTest/AndroidManifest.xml
+++ b/libraries/extractor/src/androidTest/AndroidManifest.xml
@@ -15,8 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.extractor.test">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-sdk/>
 

--- a/libraries/extractor/src/main/AndroidManifest.xml
+++ b/libraries/extractor/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.extractor">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/extractor/src/test/AndroidManifest.xml
+++ b/libraries/extractor/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.extractor.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/muxer/build.gradle
+++ b/libraries/muxer/build.gradle
@@ -15,6 +15,7 @@
 apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 android {
     namespace 'androidx.media3.muxer'
+    testNamespace 'androidx.media3.muxer.test'
 
     defaultConfig {
         // The following argument makes the Android Test Orchestrator run its

--- a/libraries/muxer/src/androidTest/AndroidManifest.xml
+++ b/libraries/muxer/src/androidTest/AndroidManifest.xml
@@ -15,8 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="androidx.media3.muxer.test">
+  xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>

--- a/libraries/muxer/src/main/AndroidManifest.xml
+++ b/libraries/muxer/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.muxer">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/muxer/src/test/AndroidManifest.xml
+++ b/libraries/muxer/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.muxer.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/session/build.gradle
+++ b/libraries/session/build.gradle
@@ -18,6 +18,7 @@ group 'androidx.media3'
 
 android {
     namespace 'androidx.media3.session'
+    testNamespace 'androidx.media3.session.test'
 
     buildTypes {
         debug {

--- a/libraries/session/src/main/AndroidManifest.xml
+++ b/libraries/session/src/main/AndroidManifest.xml
@@ -13,6 +13,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest package="androidx.media3.session">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/session/src/test/AndroidManifest.xml
+++ b/libraries/session/src/test/AndroidManifest.xml
@@ -13,6 +13,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest package="androidx.media3.session.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/test_data/src/main/AndroidManifest.xml
+++ b/libraries/test_data/src/main/AndroidManifest.xml
@@ -14,4 +14,4 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.test.data"/>
+<manifest/>

--- a/libraries/test_exoplayer_playback/build.gradle
+++ b/libraries/test_exoplayer_playback/build.gradle
@@ -13,7 +13,10 @@
 // limitations under the License.
 apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
-android.namespace 'androidx.media3.test.exoplayer.playback'
+android {
+    namespace 'androidx.media3.test.exoplayer.playback'
+    testNamespace 'androidx.media3.test.exoplayer.playback.test'
+}
 
 dependencies {
     androidTestImplementation 'androidx.test:rules:' + androidxTestRulesVersion

--- a/libraries/test_exoplayer_playback/src/androidTest/AndroidManifest.xml
+++ b/libraries/test_exoplayer_playback/src/androidTest/AndroidManifest.xml
@@ -15,8 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.test.exoplayer.playback.test">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.INTERNET"/>

--- a/libraries/test_exoplayer_playback/src/main/AndroidManifest.xml
+++ b/libraries/test_exoplayer_playback/src/main/AndroidManifest.xml
@@ -14,4 +14,4 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.test.exoplayer.playback"/>
+<manifest/>

--- a/libraries/test_session_common/src/main/AndroidManifest.xml
+++ b/libraries/test_session_common/src/main/AndroidManifest.xml
@@ -13,6 +13,6 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest package="androidx.media3.test.session.common">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/test_session_current/build.gradle
+++ b/libraries/test_session_current/build.gradle
@@ -18,6 +18,7 @@ group 'androidx.media3'
 
 android {
     namespace 'androidx.media3.test.session'
+    testNamespace 'androidx.media3.test.session.test'
 
     compileSdkVersion project.ext.compileSdkVersion
 

--- a/libraries/test_session_current/src/androidTest/AndroidManifest.xml
+++ b/libraries/test_session_current/src/androidTest/AndroidManifest.xml
@@ -14,8 +14,7 @@
      limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.test.session.test">
+    xmlns:tools="http://schemas.android.com/tools">
   <uses-sdk />
 
   <application

--- a/libraries/test_session_current/src/main/AndroidManifest.xml
+++ b/libraries/test_session_current/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="androidx.media3.test.session">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-sdk/>
 
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/libraries/test_utils/build.gradle
+++ b/libraries/test_utils/build.gradle
@@ -15,6 +15,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.test.utils'
+    testNamespace 'androidx.media3.test.utils.test'
 
     sourceSets {
         test.assets.srcDir '../test_data/src/test/assets/'

--- a/libraries/test_utils/src/main/AndroidManifest.xml
+++ b/libraries/test_utils/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.test.utils">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/test_utils/src/test/AndroidManifest.xml
+++ b/libraries/test_utils/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.test.utils.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/test_utils_robolectric/build.gradle
+++ b/libraries/test_utils_robolectric/build.gradle
@@ -16,6 +16,7 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.test.utils.robolectric'
+    testNamespace 'androidx.media3.test.utils.robolectric.test'
 
     publishing {
         singleVariant('release') {

--- a/libraries/test_utils_robolectric/src/main/AndroidManifest.xml
+++ b/libraries/test_utils_robolectric/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.test.utils.robolectric">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/test_utils_robolectric/src/test/AndroidManifest.xml
+++ b/libraries/test_utils_robolectric/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.test.utils.robolectric.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/transformer/build.gradle
+++ b/libraries/transformer/build.gradle
@@ -14,6 +14,7 @@
 apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 android {
     namespace 'androidx.media3.transformer'
+    testNamespace 'androidx.media3.transformer.test'
 
     defaultConfig {
         minSdkVersion 21

--- a/libraries/transformer/src/androidTest/AndroidManifest.xml
+++ b/libraries/transformer/src/androidTest/AndroidManifest.xml
@@ -15,8 +15,7 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="androidx.media3.transformer.test">
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>

--- a/libraries/transformer/src/main/AndroidManifest.xml
+++ b/libraries/transformer/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.transformer">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/transformer/src/test/AndroidManifest.xml
+++ b/libraries/transformer/src/test/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.transformer.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/ui/build.gradle
+++ b/libraries/ui/build.gradle
@@ -17,6 +17,7 @@ android.buildTypes.debug.testCoverageEnabled true
 
 android {
     namespace 'androidx.media3.ui'
+    testNamespace 'androidx.media3.ui.test'
 
     lint {
         baseline = file("lint-baseline.xml")

--- a/libraries/ui/src/main/AndroidManifest.xml
+++ b/libraries/ui/src/main/AndroidManifest.xml
@@ -14,6 +14,6 @@
      limitations under the License.
 -->
 
-<manifest package="androidx.media3.ui">
+<manifest>
   <uses-sdk />
 </manifest>

--- a/libraries/ui/src/test/AndroidManifest.xml
+++ b/libraries/ui/src/test/AndroidManifest.xml
@@ -15,6 +15,6 @@
   ~ limitations under the License.
   -->
 
-<manifest package="androidx.media3.ui.test">
+<manifest>
   <uses-sdk/>
 </manifest>

--- a/libraries/ui_leanback/src/main/AndroidManifest.xml
+++ b/libraries/ui_leanback/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
 -->
 
 <manifest xmlns:tools="http://schemas.android.com/tools"
-  package="androidx.media3.ui.leanback"
   tools:ignore="MissingLeanbackLauncher,ImpliedTouchscreenHardware,MissingLeanbackSupport">
   <uses-sdk />
 </manifest>


### PR DESCRIPTION
Since Android Gradle Plugin 8.0, it is [recommended](https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl) to set the namespace in the module's `build.gradle` file, rather than in its `AndroidManifest.xml` file.
The `namespace`s were already set in the `build.gradle` files, but the `package` equivalent were still present in the `AndroidManifest.xml` files.