### PR TITLE
Remove outdated TODO about some module's `group`

### DIFF
--- a/libraries/session/build.gradle
+++ b/libraries/session/build.gradle
@@ -13,9 +13,6 @@
 // limitations under the License.
 apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
-// TODO(b/178560255): Remove the "group" override after the "group" in build.gradle changed
-group 'androidx.media3'
-
 android {
     namespace 'androidx.media3.session'
 

--- a/libraries/test_session_current/build.gradle
+++ b/libraries/test_session_current/build.gradle
@@ -13,9 +13,6 @@
 // limitations under the License.
 apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
-// TODO(b/178560255): Remove the "group" override after the "group" in build.gradle changed
-group 'androidx.media3'
-
 android {
     namespace 'androidx.media3.test.session'
 


### PR DESCRIPTION
The `group` is already set to `androidx.media3` in the root `build.gradle` file:
https://github.com/androidx/media/blob/d13a0f4ec62ca092b79746a5725b62a3244cc5b4/build.gradle#L42

These two TODOs are probably leftovers from when it was `com.google.android.exoplayer`. No other module override this property.