### PR TITLE
Remove unused constants version

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -45,9 +45,7 @@ project.ext {
     // Updating this to 1.9.0+ will import Kotlin stdlib [internal ref: b/277891049].
     androidxCoreVersion = '1.8.0'
     androidxExifInterfaceVersion = '1.3.6'
-    androidxFuturesVersion = '1.1.0'
     androidxMediaVersion = '1.7.0'
-    androidxMedia2Version = '1.2.1'
     androidxMultidexVersion = '2.0.1'
     androidxRecyclerViewVersion = '1.3.0'
     androidxMaterialVersion = '1.8.0'
@@ -56,7 +54,6 @@ project.ext {
     androidxTestJUnitVersion = '1.1.5'
     androidxTestRunnerVersion = '1.5.2'
     androidxTestRulesVersion = '1.5.0'
-    androidxTestServicesStorageVersion = '1.4.2'
     androidxTestTruthVersion = '1.5.0'
     truthVersion = '1.1.3'
     okhttpVersion = '4.12.0'


### PR DESCRIPTION
These dependency versions don't appear to be used:
- `androidxFuturesVersion`
- `androidxMedia2Version`
- `androidxTestServicesStorageVersion`