### PR TITLE
Allow setting repeat mode with Intent arguments

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -44,7 +44,7 @@
 *   Test Utilities:
 *   Remove deprecated symbols:
 *   Demo app:
-    *   Allow setting repeat mode with Intent arguments from command line
+    *   Allow setting repeat mode with `Intent` arguments from command line
         ([#1266](https://github.com/androidx/media/pull/1266)).
 
 ## 1.4

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -44,6 +44,8 @@
 *   Test Utilities:
 *   Remove deprecated symbols:
 *   Demo app:
+    *   Allow setting repeat mode with Intent arguments from command line
+        ([#1266](https://github.com/androidx/media/pull/1266)).
 
 ## 1.4
 

--- a/demos/main/src/main/java/androidx/media3/demo/main/IntentUtil.java
+++ b/demos/main/src/main/java/androidx/media3/demo/main/IntentUtil.java
@@ -78,8 +78,8 @@ public class IntentUtil {
       case "ALL":
         return Player.REPEAT_MODE_ALL;
       default:
-        throw new IllegalArgumentException("Argument " + repeatMode +
-            " does not match any of the repeat modes: OFF|ONE|ALL");
+        throw new IllegalArgumentException(
+            "Argument " + repeatMode + " does not match any of the repeat modes: OFF|ONE|ALL");
     }
   }
 

--- a/demos/main/src/main/java/androidx/media3/demo/main/IntentUtil.java
+++ b/demos/main/src/main/java/androidx/media3/demo/main/IntentUtil.java
@@ -45,6 +45,7 @@ public class IntentUtil {
   public static final String ACTION_VIEW_LIST = "androidx.media3.demo.main.action.VIEW_LIST";
 
   // Activity extras.
+  public static final String AV_ANALYSIS_MODE_EXTRA = "av_analysis_mode"; // copybara:strip
   public static final String PREFER_EXTENSION_DECODERS_EXTRA = "prefer_extension_decoders";
 
   // Media item configuration extras.
@@ -67,7 +68,7 @@ public class IntentUtil {
   public static final String SUBTITLE_URI_EXTRA = "subtitle_uri";
   public static final String SUBTITLE_MIME_TYPE_EXTRA = "subtitle_mime_type";
   public static final String SUBTITLE_LANGUAGE_EXTRA = "subtitle_language";
-  public static final String PLAYER_REPEAT_MODE_EXTRA = "repeat_mode";
+  public static final String REPEAT_MODE_EXTRA = "repeat_mode";
 
   public static @Player.RepeatMode int parseRepeatModeExtra(String repeatMode) {
     switch (repeatMode) {

--- a/demos/main/src/main/java/androidx/media3/demo/main/IntentUtil.java
+++ b/demos/main/src/main/java/androidx/media3/demo/main/IntentUtil.java
@@ -27,6 +27,7 @@ import androidx.media3.common.MediaItem;
 import androidx.media3.common.MediaItem.ClippingConfiguration;
 import androidx.media3.common.MediaItem.SubtitleConfiguration;
 import androidx.media3.common.MediaMetadata;
+import androidx.media3.common.Player;
 import androidx.media3.common.util.Util;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
@@ -66,6 +67,21 @@ public class IntentUtil {
   public static final String SUBTITLE_URI_EXTRA = "subtitle_uri";
   public static final String SUBTITLE_MIME_TYPE_EXTRA = "subtitle_mime_type";
   public static final String SUBTITLE_LANGUAGE_EXTRA = "subtitle_language";
+  public static final String PLAYER_REPEAT_MODE_EXTRA = "repeat_mode";
+
+  public static @Player.RepeatMode int parseRepeatModeExtra(String repeatMode) {
+    switch (repeatMode) {
+      case "OFF":
+        return Player.REPEAT_MODE_OFF;
+      case "ONE":
+        return Player.REPEAT_MODE_ONE;
+      case "ALL":
+        return Player.REPEAT_MODE_ALL;
+      default:
+        throw new IllegalArgumentException("Argument " + repeatMode +
+            " does not match any of the repeat modes: OFF|ONE|ALL");
+    }
+  }
 
   /** Creates a list of {@link MediaItem media items} from an {@link Intent}. */
   public static List<MediaItem> createMediaItemsFromIntent(Intent intent) {

--- a/demos/main/src/main/java/androidx/media3/demo/main/PlayerActivity.java
+++ b/demos/main/src/main/java/androidx/media3/demo/main/PlayerActivity.java
@@ -262,8 +262,8 @@ public class PlayerActivity extends AppCompatActivity
    * @return Whether initialization was successful.
    */
   protected boolean initializePlayer() {
+    Intent intent = getIntent();
     if (player == null) {
-      Intent intent = getIntent();
 
       mediaItems = createMediaItems(intent);
       if (mediaItems.isEmpty()) {
@@ -293,11 +293,9 @@ public class PlayerActivity extends AppCompatActivity
     }
     player.setMediaItems(mediaItems, /* resetPosition= */ !haveStartPosition);
     player.prepare();
-    String requestedRepeatModeExtra;
-    if ((requestedRepeatModeExtra =
-            this.getIntent().getStringExtra(IntentUtil.PLAYER_REPEAT_MODE_EXTRA))
-        != null) {
-      player.setRepeatMode(IntentUtil.parseRepeatModeExtra(requestedRepeatModeExtra));
+    String repeatModeExtra = intent.getStringExtra(IntentUtil.REPEAT_MODE_EXTRA);
+    if (repeatModeExtra != null) {
+      player.setRepeatMode(IntentUtil.parseRepeatModeExtra(repeatModeExtra));
     }
     updateButtonVisibility();
     return true;

--- a/demos/main/src/main/java/androidx/media3/demo/main/PlayerActivity.java
+++ b/demos/main/src/main/java/androidx/media3/demo/main/PlayerActivity.java
@@ -293,6 +293,10 @@ public class PlayerActivity extends AppCompatActivity
     }
     player.setMediaItems(mediaItems, /* resetPosition= */ !haveStartPosition);
     player.prepare();
+    String requestedRepeatModeExtra;
+    if ((requestedRepeatModeExtra = this.getIntent().getStringExtra(IntentUtil.PLAYER_REPEAT_MODE_EXTRA)) != null) {
+      player.setRepeatMode(IntentUtil.parseRepeatModeExtra(requestedRepeatModeExtra));
+    }
     updateButtonVisibility();
     return true;
   }

--- a/demos/main/src/main/java/androidx/media3/demo/main/PlayerActivity.java
+++ b/demos/main/src/main/java/androidx/media3/demo/main/PlayerActivity.java
@@ -294,7 +294,9 @@ public class PlayerActivity extends AppCompatActivity
     player.setMediaItems(mediaItems, /* resetPosition= */ !haveStartPosition);
     player.prepare();
     String requestedRepeatModeExtra;
-    if ((requestedRepeatModeExtra = this.getIntent().getStringExtra(IntentUtil.PLAYER_REPEAT_MODE_EXTRA)) != null) {
+    if ((requestedRepeatModeExtra =
+            this.getIntent().getStringExtra(IntentUtil.PLAYER_REPEAT_MODE_EXTRA))
+        != null) {
       player.setRepeatMode(IntentUtil.parseRepeatModeExtra(requestedRepeatModeExtra));
     }
     updateButtonVisibility();


### PR DESCRIPTION
Add a new boolean command line optional argument to allow the playback to run in loop. This would help to use the app in the automated video tests. The change does not enable the option view for switching the loop mode in the UI as providing an extra argument implies force, not optional, loop playback.