### PR TITLE
Allows setting LoadErrorHandlingPolicy for DRM

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -19,6 +19,9 @@
 *   Metadata:
 *   Image:
 *   DRM:
+    *   Allow setting a `LoadErrorHandlingPolicy` on
+        `DefaultDrmSessionManagerProvider`
+        ([#1271](https://github.com/androidx/media/issues/1271)).
 *   Effect:
 *   Muxers:
 *   IMA extension:

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSessionManagerProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSessionManagerProvider.java
@@ -44,7 +44,7 @@ public final class DefaultDrmSessionManagerProvider implements DrmSessionManager
 
   @Nullable private DataSource.Factory drmHttpDataSourceFactory;
   @Nullable private String userAgent;
-  private LoadErrorHandlingPolicy drmLoadErrorHandlingPolicy;
+  @Nullable private LoadErrorHandlingPolicy drmLoadErrorHandlingPolicy;
 
   public DefaultDrmSessionManagerProvider() {
     lock = new Object();
@@ -72,10 +72,11 @@ public final class DefaultDrmSessionManagerProvider implements DrmSessionManager
   }
 
   /**
-   * Set a load error handling policy to user for the {@link DefaultDrmSessionManager}'s created
-   * by this provider
+   * Sets a load error handling policy to pass to {@link
+   * DefaultDrmSessionManager.Builder#setLoadErrorHandlingPolicy(LoadErrorHandlingPolicy)}.
    *
-   * @param drmLoadErrorHandlingPolicy - LoadErrorHandlingPolicy for DRM session management
+   * <p>If {@code null} is passed the setter is not called, so the default {@link
+   * LoadErrorHandlingPolicy} defined by {@link DefaultDrmSessionManager.Builder()} is used instead.
    */
   public void setDrmLoadErrorHandlingPolicy(LoadErrorHandlingPolicy drmLoadErrorHandlingPolicy) {
     this.drmLoadErrorHandlingPolicy = drmLoadErrorHandlingPolicy;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSessionManagerProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSessionManagerProvider.java
@@ -76,7 +76,8 @@ public final class DefaultDrmSessionManagerProvider implements DrmSessionManager
    * DefaultDrmSessionManager.Builder#setLoadErrorHandlingPolicy(LoadErrorHandlingPolicy)}.
    *
    * <p>If {@code null} is passed the setter is not called, so the default {@link
-   * LoadErrorHandlingPolicy} defined by {@link DefaultDrmSessionManager.Builder()} is used instead.
+   * LoadErrorHandlingPolicy} defined by {@link DefaultDrmSessionManager.Builder#Builder()} is used
+   * instead.
    */
   public void setDrmLoadErrorHandlingPolicy(LoadErrorHandlingPolicy drmLoadErrorHandlingPolicy) {
     this.drmLoadErrorHandlingPolicy = drmLoadErrorHandlingPolicy;


### PR DESCRIPTION
The `DefaultDrmSessionManager` allows setting this policy.  This change simply plumbs the setting up to the `DefaultDrmSessionManagerProvider`