### PR TITLE
Git: Ignore .cxx intermediate output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ tmp
 
 # External native builds
 .externalNativeBuild
+.cxx
 
 # VP9 decoder extension
 libraries/decoder_vp9/src/main/jni/libvpx


### PR DESCRIPTION
This is produced by CMake e.g. in FFmpeg extension. The directory is created in projectDir rather than buildDir.