### PR TITLE
Fix ENCODING_DTS_UHD_P2 bugs.

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -1774,6 +1774,7 @@ public final class DefaultAudioSink implements AudioSink {
         return AacUtil.AAC_LD_AUDIO_SAMPLE_COUNT;
       case C.ENCODING_DTS:
       case C.ENCODING_DTS_HD:
+      case C.ENCODING_DTS_UHD_P2:
         return DtsUtil.parseDtsAudioSampleCount(buffer);
       case C.ENCODING_AC3:
       case C.ENCODING_E_AC3:

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioTrackBufferSizeProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioTrackBufferSizeProvider.java
@@ -303,6 +303,7 @@ public class DefaultAudioTrackBufferSizeProvider
         return Ac4Util.MAX_RATE_BYTES_PER_SECOND;
       case C.ENCODING_DTS:
         return DtsUtil.DTS_MAX_RATE_BYTES_PER_SECOND;
+      case C.ENCODING_DTS_UHD_P2:
       case C.ENCODING_DTS_HD:
         return DtsUtil.DTS_HD_MAX_RATE_BYTES_PER_SECOND;
       case C.ENCODING_DOLBY_TRUEHD:


### PR DESCRIPTION
During Direct Passthrough Audio Playback on platforms that supports AudioFormat.ENCODING_DTS_UHD_P2, we need to include C.ENCODING_DTS_UHD_P2 in DefaultAudioSink.getFramesPerEncodedSample() and DefaultAudioTrackBufferSizeProvider.getMaximumEncodedRateBytesPerSecond(). 