### PR TITLE
Fix DASH thumbnails cropping the incorrect tile for non-square images

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -45,6 +45,8 @@
     *   Propagate ID3 `TCON` frame to `MediaMetadata.genre`
         ([#1305](https://github.com/androidx/media/issues/1305)).
 *   Image:
+    *   Add support for non-square DASH thumbnail grids
+        ([#1255](https://github.com/androidx/media/pull/1300)).
 *   DRM:
     *   Allow setting a `LoadErrorHandlingPolicy` on
         `DefaultDrmSessionManagerProvider`

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/image/ImageRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/image/ImageRenderer.java
@@ -571,7 +571,7 @@ public class ImageRenderer extends BaseRenderer {
     checkStateNotNull(outputBitmap);
     int tileWidth = outputBitmap.getWidth() / checkStateNotNull(inputFormat).tileCountHorizontal;
     int tileHeight = outputBitmap.getHeight() / checkStateNotNull(inputFormat).tileCountVertical;
-    int tileStartXCoordinate = tileWidth * (tileIndex % inputFormat.tileCountVertical);
+    int tileStartXCoordinate = tileWidth * (tileIndex % inputFormat.tileCountHorizontal);
     int tileStartYCoordinate = tileHeight * (tileIndex / inputFormat.tileCountHorizontal);
     return Bitmap.createBitmap(
         outputBitmap, tileStartXCoordinate, tileStartYCoordinate, tileWidth, tileHeight);

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/image/ImageRendererTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/image/ImageRendererTest.java
@@ -66,6 +66,12 @@ public class ImageRendererTest {
           .setTileCountVertical(1)
           .setTileCountHorizontal(1)
           .build();
+  private static final Format JPEG_FORMAT_WITH_FOUR_TILES =
+      new Format.Builder()
+          .setSampleMimeType(MimeTypes.IMAGE_JPEG)
+          .setTileCountVertical(2)
+          .setTileCountHorizontal(2)
+          .build();
   private static final Format JPEG_FORMAT_WITH_SIX_TILES =
       new Format.Builder()
           .setSampleMimeType(MimeTypes.IMAGE_JPEG)
@@ -75,19 +81,28 @@ public class ImageRendererTest {
 
   private final List<Pair<Long, Bitmap>> renderedBitmaps = new ArrayList<>();
   private final Bitmap fakeDecodedBitmap1 =
-      Bitmap.createBitmap(/* width= */ 2, /* height= */ 3, Bitmap.Config.ARGB_8888);
+      Bitmap.createBitmap(/* width= */ 2, /* height= */ 2, Bitmap.Config.ARGB_8888);
   private final Bitmap fakeDecodedBitmap2 =
       Bitmap.createBitmap(/* width= */ 4, /* height= */ 4, Bitmap.Config.ARGB_8888);
+  private final Bitmap fakeDecodedBitmap3 =
+      Bitmap.createBitmap(/* width= */ 2, /* height= */ 3, Bitmap.Config.ARGB_8888);
 
   private ImageRenderer renderer;
   private int decodeCallCount;
+  private Bitmap overridenBitmap = null;
 
   @Before
   public void setUp() throws Exception {
     decodeCallCount = 0;
     ImageDecoder.Factory fakeDecoderFactory =
         new BitmapFactoryImageDecoder.Factory(
-            (data, length) -> ++decodeCallCount == 1 ? fakeDecodedBitmap1 : fakeDecodedBitmap2);
+            (data, length) -> {
+              if (overridenBitmap != null) {
+                return overridenBitmap;
+              } else {
+                return ++decodeCallCount == 1 ? fakeDecodedBitmap1 : fakeDecodedBitmap2;
+              }
+            });
     ImageOutput queuingImageOutput =
         new ImageOutput() {
           @Override
@@ -223,18 +238,16 @@ public class ImageRendererTest {
           throws Exception {
     FakeSampleStream fakeSampleStream1 =
         createSampleStream(
-            JPEG_FORMAT_WITH_SIX_TILES,
+            JPEG_FORMAT_WITH_FOUR_TILES,
             ImmutableList.of(
                 oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
                 emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
                 emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 400_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 500_000L, /* flags= */ 0)));
+                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0)));
     fakeSampleStream1.writeData(/* startPositionUs= */ 0);
     FakeSampleStream fakeSampleStream2 =
         createSampleStream(
-            JPEG_FORMAT_WITH_SIX_TILES,
+            JPEG_FORMAT_WITH_FOUR_TILES,
             ImmutableList.of(
                 oneByteSample(/* timeUs= */ 10L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
                 END_OF_STREAM_ITEM));
@@ -256,27 +269,25 @@ public class ImageRendererTest {
     renderer.start();
     renderer.render(/* positionUs= */ 200_000L, /* elapsedRealtimeUs= */ 0);
     renderer.render(/* positionUs= */ 300_000L, /* elapsedRealtimeUs= */ 0);
-    renderer.render(/* positionUs= */ 400_000L, /* elapsedRealtimeUs= */ 0);
-    renderer.render(/* positionUs= */ 500_000L, /* elapsedRealtimeUs= */ 0);
 
     renderer.replaceStream(
         new Format[] {PNG_FORMAT},
         fakeSampleStream2,
         /* startPositionUs= */ 10,
-        /* offsetUs= */ 650_000L,
+        /* offsetUs= */ 450_000L,
         new MediaSource.MediaPeriodId(new Object()));
     renderer.setCurrentStreamFinal();
     // Render last sample of first stream
-    renderer.render(/* positionUs= */ 600_000L, /* elapsedRealtimeUs= */ 0);
+    renderer.render(/* positionUs= */ 400_000L, /* elapsedRealtimeUs= */ 0);
     StopWatch hasReadStreamToEndStopWatch = new StopWatch(HAS_READ_STREAM_TO_END_TIMEOUT_MESSAGE);
     while (!renderer.hasReadStreamToEnd() && hasReadStreamToEndStopWatch.ensureNotExpired()) {
-      renderer.render(/* positionUs= */ 650_010L, /* elapsedRealtimeUs= */ 0L);
+      renderer.render(/* positionUs= */ 450_010L, /* elapsedRealtimeUs= */ 0L);
     }
     renderer.stop();
 
-    assertThat(renderedBitmaps).hasSize(7);
+    assertThat(renderedBitmaps).hasSize(5);
     assertThat(renderedBitmaps.get(0).first).isEqualTo(0);
-    assertThat(renderedBitmaps.get(6).first).isEqualTo(10L);
+    assertThat(renderedBitmaps.get(4).first).isEqualTo(10L);
   }
 
   @Test
@@ -284,7 +295,7 @@ public class ImageRendererTest {
       throws Exception {
     FakeSampleStream fakeSampleStream1 =
         createSampleStream(
-            JPEG_FORMAT_WITH_SIX_TILES,
+            JPEG_FORMAT_WITH_FOUR_TILES,
             ImmutableList.of(
                 oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
                 emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
@@ -293,7 +304,7 @@ public class ImageRendererTest {
     fakeSampleStream1.writeData(/* startPositionUs= */ 0);
     FakeSampleStream fakeSampleStream2 =
         createSampleStream(
-            JPEG_FORMAT_WITH_SIX_TILES,
+            JPEG_FORMAT_WITH_FOUR_TILES,
             ImmutableList.of(
                 oneByteSample(/* timeUs= */ 10L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
                 END_OF_STREAM_ITEM));
@@ -401,6 +412,325 @@ public class ImageRendererTest {
   public void render_tiledImage_cropsAndRendersToImageOutput() throws Exception {
     FakeSampleStream fakeSampleStream =
         createSampleStream(
+            JPEG_FORMAT_WITH_FOUR_TILES,
+            ImmutableList.of(
+                oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
+                emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
+                END_OF_STREAM_ITEM));
+    fakeSampleStream.writeData(/* startPositionUs= */ 0);
+    renderer.enable(
+        RendererConfiguration.DEFAULT,
+        new Format[] {JPEG_FORMAT_WITH_FOUR_TILES},
+        fakeSampleStream,
+        /* positionUs= */ 0,
+        /* joining= */ false,
+        /* mayRenderStartOfStream= */ true,
+        /* startPositionUs= */ 0,
+        /* offsetUs= */ 0,
+        new MediaSource.MediaPeriodId(new Object()));
+    renderer.setCurrentStreamFinal();
+
+    StopWatch isReadyStopWatch = new StopWatch(IS_READY_TIMEOUT_MESSAGE);
+    while (!renderer.isReady() && isReadyStopWatch.ensureNotExpired()) {
+      renderer.render(
+          /* positionUs= */ 0,
+          /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+    }
+    StopWatch isEndedStopWatch = new StopWatch(IS_ENDED_TIMEOUT_MESSAGE);
+    long positionUs = 0;
+    while (!renderer.isEnded() && isEndedStopWatch.ensureNotExpired()) {
+      renderer.render(
+          positionUs, /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+      positionUs += 100_000;
+    }
+
+    assertThat(renderedBitmaps).hasSize(4);
+    assertThat(renderedBitmaps.get(0).first).isEqualTo(0L);
+    assertThat(renderedBitmaps.get(0).second.getHeight()).isEqualTo(1);
+    assertThat(renderedBitmaps.get(0).second.getWidth()).isEqualTo(1);
+    assertThat(renderedBitmaps.get(1).first).isEqualTo(100_000L);
+    assertThat(renderedBitmaps.get(1).second.getHeight()).isEqualTo(1);
+    assertThat(renderedBitmaps.get(1).second.getWidth()).isEqualTo(1);
+    assertThat(renderedBitmaps.get(2).first).isEqualTo(200_000L);
+    assertThat(renderedBitmaps.get(2).second.getHeight()).isEqualTo(1);
+    assertThat(renderedBitmaps.get(2).second.getWidth()).isEqualTo(1);
+    assertThat(renderedBitmaps.get(3).first).isEqualTo(300_000L);
+    assertThat(renderedBitmaps.get(3).second.getHeight()).isEqualTo(1);
+    assertThat(renderedBitmaps.get(3).second.getWidth()).isEqualTo(1);
+  }
+
+  @Test
+  public void render_tiledImageWithNonZeroStartPosition_rendersToImageOutput() throws Exception {
+    FakeSampleStream fakeSampleStream =
+        createSampleStream(
+            JPEG_FORMAT_WITH_FOUR_TILES,
+            ImmutableList.of(
+                oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
+                emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
+                END_OF_STREAM_ITEM));
+    fakeSampleStream.writeData(/* startPositionUs= */ 0);
+    renderer.enable(
+        RendererConfiguration.DEFAULT,
+        new Format[] {JPEG_FORMAT_WITH_FOUR_TILES},
+        fakeSampleStream,
+        /* positionUs= */ 200_000,
+        /* joining= */ false,
+        /* mayRenderStartOfStream= */ true,
+        /* startPositionUs= */ 0,
+        /* offsetUs= */ 0,
+        new MediaSource.MediaPeriodId(new Object()));
+    renderer.setCurrentStreamFinal();
+
+    StopWatch isReadyStopWatch = new StopWatch(IS_READY_TIMEOUT_MESSAGE);
+    while (!renderer.isReady() && isReadyStopWatch.ensureNotExpired()) {
+      renderer.render(
+          /* positionUs= */ 200_000,
+          /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+    }
+    StopWatch isEndedStopWatch = new StopWatch(IS_ENDED_TIMEOUT_MESSAGE);
+    long positionUs = 200_000;
+    while (!renderer.isEnded() && isEndedStopWatch.ensureNotExpired()) {
+      renderer.render(
+          positionUs, /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+      positionUs += 100_000;
+    }
+
+    assertThat(renderedBitmaps).hasSize(2);
+    assertThat(renderedBitmaps.get(0).first).isEqualTo(200_000L);
+    assertThat(renderedBitmaps.get(1).first).isEqualTo(300_000L);
+  }
+
+  @Test
+  public void render_tiledImageStartPositionIsAfterLastTile_rendersToImageOutput()
+      throws Exception {
+    FakeSampleStream fakeSampleStream =
+        createSampleStream(
+            JPEG_FORMAT_WITH_FOUR_TILES,
+            ImmutableList.of(
+                oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
+                emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
+                END_OF_STREAM_ITEM));
+    fakeSampleStream.writeData(/* startPositionUs= */ 0);
+    renderer.enable(
+        RendererConfiguration.DEFAULT,
+        new Format[] {JPEG_FORMAT_WITH_FOUR_TILES},
+        fakeSampleStream,
+        /* positionUs= */ 0,
+        /* joining= */ false,
+        /* mayRenderStartOfStream= */ true,
+        /* startPositionUs= */ 0,
+        /* offsetUs= */ 0,
+        new MediaSource.MediaPeriodId(new Object()));
+    renderer.setCurrentStreamFinal();
+
+    StopWatch isReadyStopWatch = new StopWatch(IS_READY_TIMEOUT_MESSAGE);
+    while (!renderer.isReady() && isReadyStopWatch.ensureNotExpired()) {
+      renderer.render(
+          /* positionUs= */ 350_000,
+          /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+    }
+    StopWatch isEndedStopWatch = new StopWatch(IS_ENDED_TIMEOUT_MESSAGE);
+    long positionUs = 350_000;
+    while (!renderer.isEnded() && isEndedStopWatch.ensureNotExpired()) {
+      renderer.render(
+          positionUs, /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+      positionUs += 100_000;
+    }
+
+    assertThat(renderedBitmaps).hasSize(1);
+    assertThat(renderedBitmaps.get(0).first).isEqualTo(300_000L);
+  }
+
+  @Test
+  public void render_tiledImageStartPositionIsBeforeLastTileAndNotWithinThreshold_rendersPriorTile()
+      throws Exception {
+    FakeSampleStream fakeSampleStream =
+        createSampleStream(
+            JPEG_FORMAT_WITH_FOUR_TILES,
+            ImmutableList.of(
+                oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
+                emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
+                END_OF_STREAM_ITEM));
+    fakeSampleStream.writeData(/* startPositionUs= */ 0);
+    renderer.enable(
+        RendererConfiguration.DEFAULT,
+        new Format[] {JPEG_FORMAT_WITH_FOUR_TILES},
+        fakeSampleStream,
+        /* positionUs= */ 0,
+        /* joining= */ false,
+        /* mayRenderStartOfStream= */ true,
+        /* startPositionUs= */ 0,
+        /* offsetUs= */ 0,
+        new MediaSource.MediaPeriodId(new Object()));
+    renderer.setCurrentStreamFinal();
+
+    StopWatch isReadyStopWatch = new StopWatch(IS_READY_TIMEOUT_MESSAGE);
+    while (!renderer.isReady() && isReadyStopWatch.ensureNotExpired()) {
+      renderer.render(
+          /* positionUs= */ 250_000L,
+          /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+    }
+    StopWatch isEndedStopWatch = new StopWatch(IS_ENDED_TIMEOUT_MESSAGE);
+    long positionUs = 250_000L;
+    while (!renderer.isEnded() && isEndedStopWatch.ensureNotExpired()) {
+      renderer.render(
+          positionUs, /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+      positionUs += 100_000L;
+    }
+
+    assertThat(renderedBitmaps).hasSize(2);
+    assertThat(renderedBitmaps.get(0).first).isEqualTo(200_000L);
+    assertThat(renderedBitmaps.get(1).first).isEqualTo(300_000L);
+  }
+
+  @Test
+  public void
+      render_tiledImageStartPositionBeforePresentationTimeAndWithinThreshold_rendersIncomingTile()
+          throws Exception {
+    FakeSampleStream fakeSampleStream =
+        createSampleStream(
+            JPEG_FORMAT_WITH_FOUR_TILES,
+            ImmutableList.of(
+                oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
+                emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
+                END_OF_STREAM_ITEM));
+    fakeSampleStream.writeData(/* startPositionUs= */ 0);
+    renderer.enable(
+        RendererConfiguration.DEFAULT,
+        new Format[] {JPEG_FORMAT_WITH_FOUR_TILES},
+        fakeSampleStream,
+        /* positionUs= */ 0,
+        /* joining= */ false,
+        /* mayRenderStartOfStream= */ true,
+        /* startPositionUs= */ 0,
+        /* offsetUs= */ 0,
+        new MediaSource.MediaPeriodId(new Object()));
+    renderer.setCurrentStreamFinal();
+
+    StopWatch isReadyStopWatch = new StopWatch(IS_READY_TIMEOUT_MESSAGE);
+    while (!renderer.isReady() && isReadyStopWatch.ensureNotExpired()) {
+      renderer.render(
+          /* positionUs= */ 70_000,
+          /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+    }
+    StopWatch isEndedStopWatch = new StopWatch(IS_ENDED_TIMEOUT_MESSAGE);
+    long positionUs = 70_000;
+    while (!renderer.isEnded() && isEndedStopWatch.ensureNotExpired()) {
+      renderer.render(
+          positionUs, /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+      positionUs += 100_000;
+    }
+
+    assertThat(renderedBitmaps).hasSize(3);
+    assertThat(renderedBitmaps.get(0).first).isEqualTo(100_000L);
+    assertThat(renderedBitmaps.get(1).first).isEqualTo(200_000L);
+    assertThat(renderedBitmaps.get(2).first).isEqualTo(300_000L);
+  }
+
+  @Test
+  public void
+      render_tiledImageStartPositionAfterPresentationTimeAndWithinThreshold_rendersLastReadTile()
+          throws Exception {
+    FakeSampleStream fakeSampleStream =
+        createSampleStream(
+            JPEG_FORMAT_WITH_FOUR_TILES,
+            ImmutableList.of(
+                oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
+                emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
+                END_OF_STREAM_ITEM));
+    fakeSampleStream.writeData(/* startPositionUs= */ 0);
+    renderer.enable(
+        RendererConfiguration.DEFAULT,
+        new Format[] {JPEG_FORMAT_WITH_FOUR_TILES},
+        fakeSampleStream,
+        /* positionUs= */ 0,
+        /* joining= */ false,
+        /* mayRenderStartOfStream= */ true,
+        /* startPositionUs= */ 0,
+        /* offsetUs= */ 0,
+        new MediaSource.MediaPeriodId(new Object()));
+    renderer.setCurrentStreamFinal();
+
+    StopWatch isReadyStopWatch = new StopWatch(IS_READY_TIMEOUT_MESSAGE);
+    while (!renderer.isReady() && isReadyStopWatch.ensureNotExpired()) {
+      renderer.render(
+          /* positionUs= */ 130_000,
+          /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+    }
+    StopWatch isEndedStopWatch = new StopWatch(IS_ENDED_TIMEOUT_MESSAGE);
+    long positionUs = 130_000;
+    while (!renderer.isEnded() && isEndedStopWatch.ensureNotExpired()) {
+      renderer.render(
+          positionUs, /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+      positionUs += 100_000;
+    }
+
+    assertThat(renderedBitmaps).hasSize(3);
+    assertThat(renderedBitmaps.get(0).first).isEqualTo(100_000L);
+    assertThat(renderedBitmaps.get(1).first).isEqualTo(200_000L);
+    assertThat(renderedBitmaps.get(2).first).isEqualTo(300_000L);
+  }
+
+  @Test
+  public void render_tiledImageStartPositionRightBeforeEOSAndWithinThreshold_rendersLastTileInGrid()
+      throws Exception {
+    FakeSampleStream fakeSampleStream =
+        createSampleStream(
+            JPEG_FORMAT_WITH_FOUR_TILES,
+            ImmutableList.of(
+                oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
+                emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
+                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
+                END_OF_STREAM_ITEM));
+    fakeSampleStream.writeData(/* startPositionUs= */ 0);
+    renderer.enable(
+        RendererConfiguration.DEFAULT,
+        new Format[] {JPEG_FORMAT_WITH_FOUR_TILES},
+        fakeSampleStream,
+        /* positionUs= */ 0,
+        /* joining= */ false,
+        /* mayRenderStartOfStream= */ true,
+        /* startPositionUs= */ 0,
+        /* offsetUs= */ 0,
+        new MediaSource.MediaPeriodId(new Object()));
+    renderer.setCurrentStreamFinal();
+
+    StopWatch isReadyStopWatch = new StopWatch(IS_READY_TIMEOUT_MESSAGE);
+    while (!renderer.isReady() && isReadyStopWatch.ensureNotExpired()) {
+      renderer.render(
+          /* positionUs= */ 330_000,
+          /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+    }
+    StopWatch isEndedStopWatch = new StopWatch(IS_ENDED_TIMEOUT_MESSAGE);
+    long positionUs = 330_000;
+    while (!renderer.isEnded() && isEndedStopWatch.ensureNotExpired()) {
+      renderer.render(
+          positionUs, /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
+      positionUs += 100_000;
+    }
+
+    assertThat(renderedBitmaps).hasSize(1);
+    assertThat(renderedBitmaps.get(0).first).isEqualTo(300_000L);
+  }
+
+  @Test
+  public void render_tiledImageNonSquare_rendersAllImagesToOutput() throws Exception {
+    overridenBitmap = fakeDecodedBitmap3;
+    FakeSampleStream fakeSampleStream =
+        createSampleStream(
             JPEG_FORMAT_WITH_SIX_TILES,
             ImmutableList.of(
                 oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
@@ -456,289 +786,6 @@ public class ImageRendererTest {
     assertThat(renderedBitmaps.get(5).first).isEqualTo(500_000L);
     assertThat(renderedBitmaps.get(5).second.getHeight()).isEqualTo(1);
     assertThat(renderedBitmaps.get(5).second.getWidth()).isEqualTo(1);
-  }
-
-  @Test
-  public void render_tiledImageWithNonZeroStartPosition_rendersToImageOutput() throws Exception {
-    FakeSampleStream fakeSampleStream =
-        createSampleStream(
-            JPEG_FORMAT_WITH_SIX_TILES,
-            ImmutableList.of(
-                oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
-                emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 400_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 500_000L, /* flags= */ 0),
-                END_OF_STREAM_ITEM));
-    fakeSampleStream.writeData(/* startPositionUs= */ 0);
-    renderer.enable(
-        RendererConfiguration.DEFAULT,
-        new Format[] {JPEG_FORMAT_WITH_SIX_TILES},
-        fakeSampleStream,
-        /* positionUs= */ 200_000,
-        /* joining= */ false,
-        /* mayRenderStartOfStream= */ true,
-        /* startPositionUs= */ 0,
-        /* offsetUs= */ 0,
-        new MediaSource.MediaPeriodId(new Object()));
-    renderer.setCurrentStreamFinal();
-
-    StopWatch isReadyStopWatch = new StopWatch(IS_READY_TIMEOUT_MESSAGE);
-    while (!renderer.isReady() && isReadyStopWatch.ensureNotExpired()) {
-      renderer.render(
-          /* positionUs= */ 200_000,
-          /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
-    }
-    StopWatch isEndedStopWatch = new StopWatch(IS_ENDED_TIMEOUT_MESSAGE);
-    long positionUs = 200_000;
-    while (!renderer.isEnded() && isEndedStopWatch.ensureNotExpired()) {
-      renderer.render(
-          positionUs, /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
-      positionUs += 100_000;
-    }
-
-    assertThat(renderedBitmaps).hasSize(4);
-    assertThat(renderedBitmaps.get(0).first).isEqualTo(200_000L);
-    assertThat(renderedBitmaps.get(1).first).isEqualTo(300_000L);
-    assertThat(renderedBitmaps.get(2).first).isEqualTo(400_000L);
-    assertThat(renderedBitmaps.get(3).first).isEqualTo(500_000L);
-  }
-
-  @Test
-  public void render_tiledImageStartPositionIsAfterLastTile_rendersToImageOutput()
-      throws Exception {
-    FakeSampleStream fakeSampleStream =
-        createSampleStream(
-            JPEG_FORMAT_WITH_SIX_TILES,
-            ImmutableList.of(
-                oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
-                emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 400_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 500_000L, /* flags= */ 0),
-                END_OF_STREAM_ITEM));
-    fakeSampleStream.writeData(/* startPositionUs= */ 0);
-    renderer.enable(
-        RendererConfiguration.DEFAULT,
-        new Format[] {JPEG_FORMAT_WITH_SIX_TILES},
-        fakeSampleStream,
-        /* positionUs= */ 0,
-        /* joining= */ false,
-        /* mayRenderStartOfStream= */ true,
-        /* startPositionUs= */ 0,
-        /* offsetUs= */ 0,
-        new MediaSource.MediaPeriodId(new Object()));
-    renderer.setCurrentStreamFinal();
-
-    StopWatch isReadyStopWatch = new StopWatch(IS_READY_TIMEOUT_MESSAGE);
-    while (!renderer.isReady() && isReadyStopWatch.ensureNotExpired()) {
-      renderer.render(
-          /* positionUs= */ 550_000,
-          /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
-    }
-    StopWatch isEndedStopWatch = new StopWatch(IS_ENDED_TIMEOUT_MESSAGE);
-    long positionUs = 550_000;
-    while (!renderer.isEnded() && isEndedStopWatch.ensureNotExpired()) {
-      renderer.render(
-          positionUs, /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
-      positionUs += 100_000;
-    }
-
-    assertThat(renderedBitmaps).hasSize(1);
-    assertThat(renderedBitmaps.get(0).first).isEqualTo(500_000L);
-  }
-
-  @Test
-  public void render_tiledImageStartPositionIsBeforeLastTileAndNotWithinThreshold_rendersPriorTile()
-      throws Exception {
-    FakeSampleStream fakeSampleStream =
-        createSampleStream(
-            JPEG_FORMAT_WITH_SIX_TILES,
-            ImmutableList.of(
-                oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
-                emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 400_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 500_000L, /* flags= */ 0),
-                END_OF_STREAM_ITEM));
-    fakeSampleStream.writeData(/* startPositionUs= */ 0);
-    renderer.enable(
-        RendererConfiguration.DEFAULT,
-        new Format[] {JPEG_FORMAT_WITH_SIX_TILES},
-        fakeSampleStream,
-        /* positionUs= */ 0,
-        /* joining= */ false,
-        /* mayRenderStartOfStream= */ true,
-        /* startPositionUs= */ 0,
-        /* offsetUs= */ 0,
-        new MediaSource.MediaPeriodId(new Object()));
-    renderer.setCurrentStreamFinal();
-
-    StopWatch isReadyStopWatch = new StopWatch(IS_READY_TIMEOUT_MESSAGE);
-    while (!renderer.isReady() && isReadyStopWatch.ensureNotExpired()) {
-      renderer.render(
-          /* positionUs= */ 450_000L,
-          /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
-    }
-    StopWatch isEndedStopWatch = new StopWatch(IS_ENDED_TIMEOUT_MESSAGE);
-    long positionUs = 450_000L;
-    while (!renderer.isEnded() && isEndedStopWatch.ensureNotExpired()) {
-      renderer.render(
-          positionUs, /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
-      positionUs += 100_000L;
-    }
-
-    assertThat(renderedBitmaps).hasSize(2);
-    assertThat(renderedBitmaps.get(0).first).isEqualTo(400_000L);
-    assertThat(renderedBitmaps.get(1).first).isEqualTo(500_000L);
-  }
-
-  @Test
-  public void
-      render_tiledImageStartPositionBeforePresentationTimeAndWithinThreshold_rendersIncomingTile()
-          throws Exception {
-    FakeSampleStream fakeSampleStream =
-        createSampleStream(
-            JPEG_FORMAT_WITH_SIX_TILES,
-            ImmutableList.of(
-                oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
-                emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 400_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 500_000L, /* flags= */ 0),
-                END_OF_STREAM_ITEM));
-    fakeSampleStream.writeData(/* startPositionUs= */ 0);
-    renderer.enable(
-        RendererConfiguration.DEFAULT,
-        new Format[] {JPEG_FORMAT_WITH_SIX_TILES},
-        fakeSampleStream,
-        /* positionUs= */ 0,
-        /* joining= */ false,
-        /* mayRenderStartOfStream= */ true,
-        /* startPositionUs= */ 0,
-        /* offsetUs= */ 0,
-        new MediaSource.MediaPeriodId(new Object()));
-    renderer.setCurrentStreamFinal();
-
-    StopWatch isReadyStopWatch = new StopWatch(IS_READY_TIMEOUT_MESSAGE);
-    while (!renderer.isReady() && isReadyStopWatch.ensureNotExpired()) {
-      renderer.render(
-          /* positionUs= */ 70_000,
-          /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
-    }
-    StopWatch isEndedStopWatch = new StopWatch(IS_ENDED_TIMEOUT_MESSAGE);
-    long positionUs = 70_000;
-    while (!renderer.isEnded() && isEndedStopWatch.ensureNotExpired()) {
-      renderer.render(
-          positionUs, /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
-      positionUs += 100_000;
-    }
-
-    assertThat(renderedBitmaps).hasSize(5);
-    assertThat(renderedBitmaps.get(0).first).isEqualTo(100_000L);
-    assertThat(renderedBitmaps.get(1).first).isEqualTo(200_000L);
-    assertThat(renderedBitmaps.get(2).first).isEqualTo(300_000L);
-    assertThat(renderedBitmaps.get(3).first).isEqualTo(400_000L);
-    assertThat(renderedBitmaps.get(4).first).isEqualTo(500_000L);
-  }
-
-  @Test
-  public void
-      render_tiledImageStartPositionAfterPresentationTimeAndWithinThreshold_rendersLastReadTile()
-          throws Exception {
-    FakeSampleStream fakeSampleStream =
-        createSampleStream(
-            JPEG_FORMAT_WITH_SIX_TILES,
-            ImmutableList.of(
-                oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
-                emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 400_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 500_000L, /* flags= */ 0),
-                END_OF_STREAM_ITEM));
-    fakeSampleStream.writeData(/* startPositionUs= */ 0);
-    renderer.enable(
-        RendererConfiguration.DEFAULT,
-        new Format[] {JPEG_FORMAT_WITH_SIX_TILES},
-        fakeSampleStream,
-        /* positionUs= */ 0,
-        /* joining= */ false,
-        /* mayRenderStartOfStream= */ true,
-        /* startPositionUs= */ 0,
-        /* offsetUs= */ 0,
-        new MediaSource.MediaPeriodId(new Object()));
-    renderer.setCurrentStreamFinal();
-
-    StopWatch isReadyStopWatch = new StopWatch(IS_READY_TIMEOUT_MESSAGE);
-    while (!renderer.isReady() && isReadyStopWatch.ensureNotExpired()) {
-      renderer.render(
-          /* positionUs= */ 130_000,
-          /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
-    }
-    StopWatch isEndedStopWatch = new StopWatch(IS_ENDED_TIMEOUT_MESSAGE);
-    long positionUs = 130_000;
-    while (!renderer.isEnded() && isEndedStopWatch.ensureNotExpired()) {
-      renderer.render(
-          positionUs, /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
-      positionUs += 100_000;
-    }
-
-    assertThat(renderedBitmaps).hasSize(5);
-    assertThat(renderedBitmaps.get(0).first).isEqualTo(100_000L);
-    assertThat(renderedBitmaps.get(1).first).isEqualTo(200_000L);
-    assertThat(renderedBitmaps.get(2).first).isEqualTo(300_000L);
-    assertThat(renderedBitmaps.get(3).first).isEqualTo(400_000L);
-    assertThat(renderedBitmaps.get(4).first).isEqualTo(500_000L);
-  }
-
-  @Test
-  public void render_tiledImageStartPositionRightBeforeEOSAndWithinThreshold_rendersLastTileInGrid()
-      throws Exception {
-    FakeSampleStream fakeSampleStream =
-        createSampleStream(
-            JPEG_FORMAT_WITH_SIX_TILES,
-            ImmutableList.of(
-                oneByteSample(/* timeUs= */ 0L, /* flags= */ C.BUFFER_FLAG_KEY_FRAME),
-                emptySample(/* timeUs= */ 100_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 200_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 300_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 400_000L, /* flags= */ 0),
-                emptySample(/* timeUs= */ 500_000L, /* flags= */ 0),
-                END_OF_STREAM_ITEM));
-    fakeSampleStream.writeData(/* startPositionUs= */ 0);
-    renderer.enable(
-        RendererConfiguration.DEFAULT,
-        new Format[] {JPEG_FORMAT_WITH_SIX_TILES},
-        fakeSampleStream,
-        /* positionUs= */ 0,
-        /* joining= */ false,
-        /* mayRenderStartOfStream= */ true,
-        /* startPositionUs= */ 0,
-        /* offsetUs= */ 0,
-        new MediaSource.MediaPeriodId(new Object()));
-    renderer.setCurrentStreamFinal();
-
-    StopWatch isReadyStopWatch = new StopWatch(IS_READY_TIMEOUT_MESSAGE);
-    while (!renderer.isReady() && isReadyStopWatch.ensureNotExpired()) {
-      renderer.render(
-          /* positionUs= */ 530_000,
-          /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
-    }
-    StopWatch isEndedStopWatch = new StopWatch(IS_ENDED_TIMEOUT_MESSAGE);
-    long positionUs = 330_000;
-    while (!renderer.isEnded() && isEndedStopWatch.ensureNotExpired()) {
-      renderer.render(
-          positionUs, /* elapsedRealtimeUs= */ SystemClock.DEFAULT.elapsedRealtime() * 1000);
-      positionUs += 100_000;
-    }
-
-    assertThat(renderedBitmaps).hasSize(1);
-    assertThat(renderedBitmaps.get(0).first).isEqualTo(500_000L);
   }
 
   private static FakeSampleStream.FakeSampleStreamItem emptySample(

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/image/ImageRendererTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/image/ImageRendererTest.java
@@ -735,10 +735,8 @@ public class ImageRendererTest {
             // Do nothing.
           }
         };
-
     renderer = new ImageRenderer(fakeDecoderFactory, queuingImageOutput);
     renderer.init(/* index= */ 0, PlayerId.UNSET, Clock.DEFAULT);
-
     FakeSampleStream fakeSampleStream =
         createSampleStream(
             JPEG_FORMAT_WITH_SIX_TILES,


### PR DESCRIPTION
The calculation for finding the column a `tileIndex` corresponds to is currently `tileIndex % inputFormat.tileCountVertical`. This should instead be `tileIndex % inputFormat.tileCountHorizontal` (see [this](https://stackoverflow.com/a/11821923/7750841) SO answer) to work for non-square images. It works for square images since `tileCountVertical == tileCountHorizontal`, so the same values are produced.

Using `tileCountVertical` for non-square images results in either:
- When `tileCountVertical` is equal to 1 (sprites with one row of images) it always crops out the first tile
- When `tileCountVertical` is larger than 1 it will attempt to crop out a bitmap outside the bounds of the larger bitmap, resulting in `Bitmap.createBitmap()` throwing an exception.

<details>
<summary>Exception thrown</summary>

```
Playback error
  androidx.media3.exoplayer.ExoPlaybackException: Unexpected runtime error
   at androidx.media3.exoplayer.ExoPlayerImplInternal.handleMessage(ExoPlayerImplInternal.java:703)
   at android.os.Handler.dispatchMessage(Handler.java:103)
   at android.os.Looper.loopOnce(Looper.java:232)
   at android.os.Looper.loop(Looper.java:317)
   at android.os.HandlerThread.run(HandlerThread.java:85)
 Caused by: java.lang.IllegalArgumentException: x + width must be <= bitmap.width()
   at android.graphics.Bitmap.createBitmap(Bitmap.java:910)
   at android.graphics.Bitmap.createBitmap(Bitmap.java:869)
   at androidx.media3.exoplayer.image.ImageRenderer.cropTileFromImageGrid(ImageRenderer.java:575)
   at androidx.media3.exoplayer.image.ImageRenderer.drainOutput(ImageRenderer.java:343)
   at androidx.media3.exoplayer.image.ImageRenderer.render(ImageRenderer.java:182)
   at androidx.media3.exoplayer.ExoPlayerImplInternal.doSomeWork(ExoPlayerImplInternal.java:1114)
   at androidx.media3.exoplayer.ExoPlayerImplInternal.handleMessage(ExoPlayerImplInternal.java:546)
   at android.os.Handler.dispatchMessage(Handler.java:103) 
   at android.os.Looper.loopOnce(Looper.java:232) 
   at android.os.Looper.loop(Looper.java:317) 
   at android.os.HandlerThread.run(HandlerThread.java:85) 
```

</details>

I have updated `ImageRenderTest` to use a 2x3 image instead of 2x2. Reverting my change will make the updated tests fail, as expected, but please verify they still work as intended.

I have created a [separate branch](https://github.com/hakonschia/media/tree/fix-dash-thumbnails-cropping-demo/) that displays thumbnails in the demo app that can be used for testing. Two samples are added, one for the one row case and one for non-squares with more than one row. The videos below are taken from this branch.

<details>
<summary>Before</summary>

https://github.com/androidx/media/assets/33124564/3f5ee00c-8a97-49bf-9398-12c9960212f6


</details>

<details>
<summary>After</summary>

https://github.com/androidx/media/assets/33124564/63d7f909-acee-440d-b369-8358c798fe69


</details>
