### PR TITLE
Do not flush eac3(joc) decoder on reuse

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DecoderReuseEvaluation.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DecoderReuseEvaluation.java
@@ -137,6 +137,9 @@ public final class DecoderReuseEvaluation {
   /** The audio bypass mode is possible. */
   public static final int DISCARD_REASON_AUDIO_BYPASS_POSSIBLE = 1 << 15;
 
+  /** The codec is changing. */
+  public static final int DISCARD_REASON_CODEC_CHANGED = 1 << 16;
+
   /** The name of the decoder. */
   public final String decoderName;
 

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfoTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfoTest.java
@@ -16,6 +16,9 @@
 package androidx.media3.exoplayer.mediacodec;
 
 import static androidx.media3.common.MimeTypes.AUDIO_AAC;
+import static androidx.media3.common.MimeTypes.AUDIO_AC4;
+import static androidx.media3.common.MimeTypes.AUDIO_E_AC3;
+import static androidx.media3.common.MimeTypes.AUDIO_E_AC3_JOC;
 import static androidx.media3.common.MimeTypes.VIDEO_AV1;
 import static androidx.media3.common.MimeTypes.VIDEO_H264;
 import static androidx.media3.exoplayer.DecoderReuseEvaluation.DISCARD_REASON_AUDIO_CHANNEL_COUNT_CHANGED;
@@ -72,6 +75,30 @@ public final class MediaCodecInfoTest {
           .setSampleRate(44100)
           .setAverageBitrate(5000)
           .setInitializationData(ImmutableList.of(new byte[] {4, 4, 1, 0, 0}))
+          .build();
+
+  private static final Format FORMAT_EAC3 =
+      new Format.Builder()
+          .setSampleMimeType(AUDIO_E_AC3)
+          .setChannelCount(6)
+          .setSampleRate(48000)
+          .setAverageBitrate(5000)
+          .build();
+
+  private static final Format FORMAT_EAC3JOC =
+      new Format.Builder()
+          .setSampleMimeType(AUDIO_E_AC3_JOC)
+          .setChannelCount(12)
+          .setSampleRate(48000)
+          .setAverageBitrate(5000)
+          .build();
+
+  private static final Format FORMAT_AC4 =
+      new Format.Builder()
+          .setSampleMimeType(AUDIO_AC4)
+          .setChannelCount(21)
+          .setSampleRate(48000)
+          .setAverageBitrate(5000)
           .build();
 
   @Test
@@ -318,6 +345,63 @@ public final class MediaCodecInfoTest {
                 DISCARD_REASON_WORKAROUND));
   }
 
+  @Test
+  public void canReuseCodec_eac3_returnsYesWithoutReconfiguration() {
+    MediaCodecInfo codecInfo = buildEac3CodecInfo();
+
+    Format variantFormat =
+        FORMAT_EAC3
+            .buildUpon()
+            .setInitializationData(ImmutableList.of(new byte[] {0}))
+            .build();
+    assertThat(codecInfo.canReuseCodec(FORMAT_EAC3, variantFormat))
+        .isEqualTo(
+            new DecoderReuseEvaluation(
+                codecInfo.name,
+                FORMAT_EAC3,
+                variantFormat,
+                DecoderReuseEvaluation.REUSE_RESULT_YES_WITHOUT_RECONFIGURATION,
+                /* discardReasons= */ 0));
+  }
+
+  @Test
+  public void canReuseCodec_eac3joc_returnsYesWithoutReconfiguration() {
+    MediaCodecInfo codecInfo = buildEac3JocCodecInfo();
+
+    Format variantFormat =
+        FORMAT_EAC3JOC
+            .buildUpon()
+            .setInitializationData(ImmutableList.of(new byte[] {0}))
+            .build();
+    assertThat(codecInfo.canReuseCodec(FORMAT_EAC3JOC, variantFormat))
+        .isEqualTo(
+            new DecoderReuseEvaluation(
+                codecInfo.name,
+                FORMAT_EAC3JOC,
+                variantFormat,
+                DecoderReuseEvaluation.REUSE_RESULT_YES_WITHOUT_RECONFIGURATION,
+                /* discardReasons= */ 0));
+  }
+
+  @Test
+  public void canReuseCodec_ac4_returnsYesWithoutReconfiguration() {
+    MediaCodecInfo codecInfo = buildAc4CodecInfo();
+
+    Format variantFormat =
+        FORMAT_AC4
+            .buildUpon()
+            .setInitializationData(ImmutableList.of(new byte[] {0}))
+            .build();
+    assertThat(codecInfo.canReuseCodec(FORMAT_AC4, variantFormat))
+        .isEqualTo(
+            new DecoderReuseEvaluation(
+                codecInfo.name,
+                FORMAT_AC4,
+                variantFormat,
+                DecoderReuseEvaluation.REUSE_RESULT_YES_WITHOUT_RECONFIGURATION,
+                /* discardReasons= */ 0));
+  }
+
   private static MediaCodecInfo buildH264CodecInfo(boolean adaptive) {
     return new MediaCodecInfo(
         "h264",
@@ -342,6 +426,51 @@ public final class MediaCodecInfoTest {
         /* hardwareAccelerated= */ false,
         /* softwareOnly= */ true,
         /* vendor= */ false,
+        /* adaptive= */ false,
+        /* tunneling= */ false,
+        /* secure= */ false,
+        /* detachedSurfaceSupported= */ false);
+  }
+
+  private static MediaCodecInfo buildEac3CodecInfo() {
+    return new MediaCodecInfo(
+        "eac3joc",
+        AUDIO_E_AC3,
+        AUDIO_E_AC3,
+        /* capabilities= */ null,
+        /* hardwareAccelerated= */ false,
+        /* softwareOnly= */ true,
+        /* vendor= */ true,
+        /* adaptive= */ false,
+        /* tunneling= */ false,
+        /* secure= */ false,
+        /* detachedSurfaceSupported= */ false);
+  }
+
+  private static MediaCodecInfo buildEac3JocCodecInfo() {
+    return new MediaCodecInfo(
+        "eac3joc",
+        AUDIO_E_AC3_JOC,
+        AUDIO_E_AC3_JOC,
+        /* capabilities= */ null,
+        /* hardwareAccelerated= */ false,
+        /* softwareOnly= */ true,
+        /* vendor= */ true,
+        /* adaptive= */ false,
+        /* tunneling= */ false,
+        /* secure= */ false,
+        /* detachedSurfaceSupported= */ false);
+  }
+
+  private static MediaCodecInfo buildAc4CodecInfo() {
+    return new MediaCodecInfo(
+        "ac4",
+        AUDIO_AC4,
+        AUDIO_AC4,
+        /* capabilities= */ null,
+        /* hardwareAccelerated= */ false,
+        /* softwareOnly= */ true,
+        /* vendor= */ true,
         /* adaptive= */ false,
         /* tunneling= */ false,
         /* secure= */ false,


### PR DESCRIPTION
eac3(joc) decoders do not need to be flushed to be reused for the next compatible track. This change allows for gapless playback on devices with Dolby decoders that require internal re-initialization on flush.