### PR TITLE
Set pixel aspect ratio from output media format if set

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -66,6 +66,9 @@
         `Surface` in `configure` and calls to a new method `detachOutputSurface`
         to remove a previously set `Surface` if the codec supports this
         (`MediaCodecInfo.detachedSurfaceSupported`).
+    *   Use `MediaCodecAdapter` supplied pixel aspect ratio values if provided
+        when processing `onOutputFormatChanged`
+        ([#1371](https://github.com/androidx/media/pull/1371)).
 *   Text:
 *   Metadata:
 *   Image:

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1342,16 +1342,17 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
               ? mediaFormat.getInteger(KEY_CROP_BOTTOM) - mediaFormat.getInteger(KEY_CROP_TOP) + 1
               : mediaFormat.getInteger(MediaFormat.KEY_HEIGHT);
     }
-    boolean hasPixelAspectRatio =
-        (Util.SDK_INT >= 30)
-            && mediaFormat != null
-            && mediaFormat.containsKey(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH)
-            && mediaFormat.containsKey(MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT);
-    pixelWidthHeightRatio =
-        hasPixelAspectRatio
-            ? (float) mediaFormat.getInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH)
-                / mediaFormat.getInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT)
-            : format.pixelWidthHeightRatio;
+
+    pixelWidthHeightRatio = format.pixelWidthHeightRatio;
+    if (Util.SDK_INT >= 30
+        && mediaFormat != null
+        && mediaFormat.containsKey(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH)
+        && mediaFormat.containsKey(MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT)) {
+      pixelWidthHeightRatio =
+          (float) mediaFormat.getInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH)
+              / mediaFormat.getInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT);
+    }
+
     // The decoder applies the rotation when rendering to the surface. For 90 and 270 degree
     // rotations, we need to flip the width, height and pixel aspect ratio to reflect the rotation
     // that was applied.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1342,10 +1342,10 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
               ? mediaFormat.getInteger(KEY_CROP_BOTTOM) - mediaFormat.getInteger(KEY_CROP_TOP) + 1
               : mediaFormat.getInteger(MediaFormat.KEY_HEIGHT);
     }
-    boolean hasPixelAspectRatio = mediaFormat.containsKey(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH)
+    boolean hasPixelAspectRatio = (Util.SDK_INT >= 30) && mediaFormat != null && mediaFormat.containsKey(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH)
         && mediaFormat.containsKey(MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT);
     pixelWidthHeightRatio = hasPixelAspectRatio ?
-        mediaFormat.getInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH) /
+        (float)mediaFormat.getInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH) /
             mediaFormat.getInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT)
         : format.pixelWidthHeightRatio;
     // The decoder applies the rotation when rendering to the surface. For 90 and 270 degree

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1342,12 +1342,16 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
               ? mediaFormat.getInteger(KEY_CROP_BOTTOM) - mediaFormat.getInteger(KEY_CROP_TOP) + 1
               : mediaFormat.getInteger(MediaFormat.KEY_HEIGHT);
     }
-    boolean hasPixelAspectRatio = (Util.SDK_INT >= 30) && mediaFormat != null && mediaFormat.containsKey(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH)
-        && mediaFormat.containsKey(MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT);
-    pixelWidthHeightRatio = hasPixelAspectRatio ?
-        (float)mediaFormat.getInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH) /
-            mediaFormat.getInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT)
-        : format.pixelWidthHeightRatio;
+    boolean hasPixelAspectRatio =
+        (Util.SDK_INT >= 30)
+            && mediaFormat != null
+            && mediaFormat.containsKey(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH)
+            && mediaFormat.containsKey(MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT);
+    pixelWidthHeightRatio =
+        hasPixelAspectRatio
+            ? (float) mediaFormat.getInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH)
+                / mediaFormat.getInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT)
+            : format.pixelWidthHeightRatio;
     // The decoder applies the rotation when rendering to the surface. For 90 and 270 degree
     // rotations, we need to flip the width, height and pixel aspect ratio to reflect the rotation
     // that was applied.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1342,7 +1342,12 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
               ? mediaFormat.getInteger(KEY_CROP_BOTTOM) - mediaFormat.getInteger(KEY_CROP_TOP) + 1
               : mediaFormat.getInteger(MediaFormat.KEY_HEIGHT);
     }
-    pixelWidthHeightRatio = format.pixelWidthHeightRatio;
+    boolean hasPixelAspectRatio = mediaFormat.containsKey(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH)
+        && mediaFormat.containsKey(MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT);
+    pixelWidthHeightRatio = hasPixelAspectRatio ?
+        mediaFormat.getInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH) /
+            mediaFormat.getInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT)
+        : format.pixelWidthHeightRatio;
     // The decoder applies the rotation when rendering to the surface. For 90 and 270 degree
     // rotations, we need to flip the width, height and pixel aspect ratio to reflect the rotation
     // that was applied.

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/video/MediaCodecVideoRendererTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/video/MediaCodecVideoRendererTest.java
@@ -116,6 +116,7 @@ public class MediaCodecVideoRendererTest {
           .setSampleMimeType(MimeTypes.VIDEO_H264)
           .setWidth(1920)
           .setHeight(1080)
+          .setPixelWidthHeightRatio(1.0f)
           .build();
 
   private static final TrackGroup TRACK_GROUP_H264 = new TrackGroup(VIDEO_H264);
@@ -762,12 +763,9 @@ public class MediaCodecVideoRendererTest {
               public MediaFormat getOutputFormat() {
                 MediaFormat mediaFormat = adapter.getOutputFormat();
                 if (Util.SDK_INT >= 30) {
-                  int pixelAspectRatioHeight = 1 << 30; // Max integer power of 2.
-                  int pixelAspectRatioWidth = (int) (0.5f * pixelAspectRatioHeight);
-                  mediaFormat.setInteger(
-                      MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH, pixelAspectRatioWidth);
-                  mediaFormat.setInteger(
-                      MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT, pixelAspectRatioHeight);
+                  // Change to 9:16 Ratio
+                  mediaFormat.setInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_WIDTH, 9);
+                  mediaFormat.setInteger(MediaFormat.KEY_PIXEL_ASPECT_RATIO_HEIGHT, 16);
                 }
                 return mediaFormat;
               }
@@ -825,7 +823,9 @@ public class MediaCodecVideoRendererTest {
     verify(eventListener)
         .onVideoSizeChanged(
             new VideoSize(
-                VIDEO_H264.width, VIDEO_H264.height, VIDEO_H264.pixelWidthHeightRatio / 2));
+                VIDEO_H264.width,
+                VIDEO_H264.height,
+                /* pixelWidthHeightRatio= */ VIDEO_H264.pixelWidthHeightRatio * (9.0f / 16.0f)));
   }
 
   @Test


### PR DESCRIPTION
_Problem_
If a video effect is applied to the video, or an "enhancement" such as LCEVC, is applied, the output video may look distorted if the pixel aspect ratio was changed in the post-processing stage.

_Root cause_
The output pixel aspect ratio is taken from the input Format object, which is a property of the stream and not of the video decoding and post processing applied. Note that this has similarity with what was addressed in https://github.com/androidx/media/pull/1025.

_Proposed solution_
If pixel aspect ratio is set in the output MediaFormat object it is taken from there, since it may have been set in the post processing stage, otherwise set it from the Format object as per current behaviour.
