### PR TITLE
Add support for setting the max seek to previous position on `ExoPlayer.Builder` and `CastPlayer`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,6 +6,9 @@
 *   ExoPlayer:
     *   Add `ExoPlayer.isReleased()` to check whether `Exoplayer.release()` has
         been called.
+    *   Add `ExoPlayer.Builder.setMaxSeekToPreviousPositionMs` to configure the
+        maximum position for which `seekToPrevious()` seeks to the previous item
+        ([#1425](https://github.com/androidx/media/issues/1425)).
 *   Transformer:
     *   Remove `ExportResult.processedInputs` field. If you use this field for
         codec details, then use `DefaultDecoderFactory.listener` instead. In

--- a/libraries/cast/src/main/java/androidx/media3/cast/CastPlayer.java
+++ b/libraries/cast/src/main/java/androidx/media3/cast/CastPlayer.java
@@ -217,7 +217,7 @@ public final class CastPlayer extends BasePlayer {
    * @param seekBackIncrementMs The {@link #seekBack()} increment, in milliseconds.
    * @param seekForwardIncrementMs The {@link #seekForward()} increment, in milliseconds.
    * @param maxSeekToPreviousPositionMs The maximum position for which {@link #seekToPrevious()}
-   *                                    seeks to the previous {@link MediaItem}, in milliseconds.
+   *     seeks to the previous {@link MediaItem}, in milliseconds.
    * @throws IllegalArgumentException If {@code seekBackIncrementMs} or {@code
    *     seekForwardIncrementMs} is non-positive, or if {@code maxSeekToPreviousPositionMs} is
    *     negative.

--- a/libraries/cast/src/main/java/androidx/media3/cast/CastPlayer.java
+++ b/libraries/cast/src/main/java/androidx/media3/cast/CastPlayer.java
@@ -124,6 +124,7 @@ public final class CastPlayer extends BasePlayer {
   private final MediaItemConverter mediaItemConverter;
   private final long seekBackIncrementMs;
   private final long seekForwardIncrementMs;
+  private final long maxSeekToPreviousPositionMs;
   // TODO: Allow custom implementations of CastTimelineTracker.
   private final CastTimelineTracker timelineTracker;
   private final Timeline.Period period;
@@ -200,11 +201,40 @@ public final class CastPlayer extends BasePlayer {
       MediaItemConverter mediaItemConverter,
       @IntRange(from = 1) long seekBackIncrementMs,
       @IntRange(from = 1) long seekForwardIncrementMs) {
+    this(
+        castContext,
+        mediaItemConverter,
+        seekBackIncrementMs,
+        seekForwardIncrementMs,
+        C.DEFAULT_MAX_SEEK_TO_PREVIOUS_POSITION_MS);
+  }
+
+  /**
+   * Creates a new cast player.
+   *
+   * @param castContext The context from which the cast session is obtained.
+   * @param mediaItemConverter The {@link MediaItemConverter} to use.
+   * @param seekBackIncrementMs The {@link #seekBack()} increment, in milliseconds.
+   * @param seekForwardIncrementMs The {@link #seekForward()} increment, in milliseconds.
+   * @param maxSeekToPreviousPositionMs The maximum position for which {@link #seekToPrevious()}
+   *                                    seeks to the previous {@link MediaItem}, in milliseconds.
+   * @throws IllegalArgumentException If {@code seekBackIncrementMs} or {@code
+   *     seekForwardIncrementMs} is non-positive, or if {@code maxSeekToPreviousPositionMs} is
+   *     negative.
+   */
+  public CastPlayer(
+      CastContext castContext,
+      MediaItemConverter mediaItemConverter,
+      @IntRange(from = 1) long seekBackIncrementMs,
+      @IntRange(from = 1) long seekForwardIncrementMs,
+      @IntRange(from = 0) long maxSeekToPreviousPositionMs) {
     checkArgument(seekBackIncrementMs > 0 && seekForwardIncrementMs > 0);
+    checkArgument(maxSeekToPreviousPositionMs >= 0L);
     this.castContext = castContext;
     this.mediaItemConverter = mediaItemConverter;
     this.seekBackIncrementMs = seekBackIncrementMs;
     this.seekForwardIncrementMs = seekForwardIncrementMs;
+    this.maxSeekToPreviousPositionMs = maxSeekToPreviousPositionMs;
     timelineTracker = new CastTimelineTracker(mediaItemConverter);
     period = new Timeline.Period();
     statusListener = new StatusListener();
@@ -481,7 +511,7 @@ public final class CastPlayer extends BasePlayer {
 
   @Override
   public long getMaxSeekToPreviousPosition() {
-    return C.DEFAULT_MAX_SEEK_TO_PREVIOUS_POSITION_MS;
+    return maxSeekToPreviousPositionMs;
   }
 
   @Override

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayer.java
@@ -543,6 +543,7 @@ public interface ExoPlayer extends Player {
      *   <li>{@link SeekParameters}: {@link SeekParameters#DEFAULT}
      *   <li>{@code seekBackIncrementMs}: {@link C#DEFAULT_SEEK_BACK_INCREMENT_MS}
      *   <li>{@code seekForwardIncrementMs}: {@link C#DEFAULT_SEEK_FORWARD_INCREMENT_MS}
+     *   <li>{@code maxSeekToPreviousPositionMs}: {@link C#DEFAULT_MAX_SEEK_TO_PREVIOUS_POSITION_MS}
      *   <li>{@code releaseTimeoutMs}: {@link #DEFAULT_RELEASE_TIMEOUT_MS}
      *   <li>{@code detachSurfaceTimeoutMs}: {@link #DEFAULT_DETACH_SURFACE_TIMEOUT_MS}
      *   <li>{@code pauseAtEndOfMediaItems}: {@code false}
@@ -1137,7 +1138,8 @@ public interface ExoPlayer extends Player {
      */
     @CanIgnoreReturnValue
     @UnstableApi
-    public Builder setMaxSeekToPreviousPosition(long maxSeekToPreviousPositionMs) {
+    public Builder setMaxSeekToPreviousPositionMs(
+        @IntRange(from = 0) long maxSeekToPreviousPositionMs) {
       checkArgument(maxSeekToPreviousPositionMs >= 0L);
       checkState(!buildCalled);
       this.maxSeekToPreviousPositionMs = maxSeekToPreviousPositionMs;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayer.java
@@ -495,6 +495,7 @@ public interface ExoPlayer extends Player {
     /* package */ SeekParameters seekParameters;
     /* package */ long seekBackIncrementMs;
     /* package */ long seekForwardIncrementMs;
+    /* package */ long maxSeekToPreviousPositionMs;
     /* package */ LivePlaybackSpeedControl livePlaybackSpeedControl;
     /* package */ long releaseTimeoutMs;
     /* package */ long detachSurfaceTimeoutMs;
@@ -702,6 +703,7 @@ public interface ExoPlayer extends Player {
       seekParameters = SeekParameters.DEFAULT;
       seekBackIncrementMs = C.DEFAULT_SEEK_BACK_INCREMENT_MS;
       seekForwardIncrementMs = C.DEFAULT_SEEK_FORWARD_INCREMENT_MS;
+      maxSeekToPreviousPositionMs = C.DEFAULT_MAX_SEEK_TO_PREVIOUS_POSITION_MS;
       livePlaybackSpeedControl = new DefaultLivePlaybackSpeedControl.Builder().build();
       clock = Clock.DEFAULT;
       releaseTimeoutMs = DEFAULT_RELEASE_TIMEOUT_MS;
@@ -1121,6 +1123,24 @@ public interface ExoPlayer extends Player {
       checkArgument(seekForwardIncrementMs > 0);
       checkState(!buildCalled);
       this.seekForwardIncrementMs = seekForwardIncrementMs;
+      return this;
+    }
+
+    /**
+     * Sets the maximum position for which {@link #seekToPrevious()} seeks to the previous {@link
+     * MediaItem}.
+     *
+     * @param maxSeekToPreviousPositionMs The maximum position, in milliseconds.
+     * @return This builder.
+     * @throws IllegalArgumentException If {@code maxSeekToPreviousPositionMs} is negative.
+     * @throws IllegalStateException If {@link #build()} has already been called.
+     */
+    @CanIgnoreReturnValue
+    @UnstableApi
+    public Builder setMaxSeekToPreviousPosition(long maxSeekToPreviousPositionMs) {
+      checkArgument(maxSeekToPreviousPositionMs >= 0L);
+      checkState(!buildCalled);
+      this.maxSeekToPreviousPositionMs = maxSeekToPreviousPositionMs;
       return this;
     }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
@@ -174,6 +174,7 @@ import java.util.concurrent.TimeoutException;
   private final BandwidthMeter bandwidthMeter;
   private final long seekBackIncrementMs;
   private final long seekForwardIncrementMs;
+  private final long maxSeekToPreviousPositionMs;
   private final Clock clock;
   private final ComponentListener componentListener;
   private final FrameMetadataListener frameMetadataListener;
@@ -286,6 +287,7 @@ import java.util.concurrent.TimeoutException;
       this.seekParameters = builder.seekParameters;
       this.seekBackIncrementMs = builder.seekBackIncrementMs;
       this.seekForwardIncrementMs = builder.seekForwardIncrementMs;
+      this.maxSeekToPreviousPositionMs = builder.maxSeekToPreviousPositionMs;
       this.pauseAtEndOfMediaItems = builder.pauseAtEndOfMediaItems;
       this.applicationLooper = builder.looper;
       this.clock = builder.clock;
@@ -972,7 +974,7 @@ import java.util.concurrent.TimeoutException;
   @Override
   public long getMaxSeekToPreviousPosition() {
     verifyApplicationThread();
-    return C.DEFAULT_MAX_SEEK_TO_PREVIOUS_POSITION_MS;
+    return maxSeekToPreviousPositionMs;
   }
 
   @Override

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/ExoPlayerTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/ExoPlayerTest.java
@@ -12990,9 +12990,12 @@ public class ExoPlayerTest {
 
   @Test
   public void seekToPrevious_withPreviousWindowAndCloseToStart_seeksToPreviousWindow() {
-    ExoPlayer player = parameterizeTestExoPlayerBuilder(new TestExoPlayerBuilder(context)).build();
+    ExoPlayer player =
+        parameterizeTestExoPlayerBuilder(
+                new TestExoPlayerBuilder(context).setMaxSeekToPreviousPositionMs(10_000))
+            .build();
     player.addMediaSources(ImmutableList.of(new FakeMediaSource(), new FakeMediaSource()));
-    player.seekTo(/* mediaItemIndex= */ 1, C.DEFAULT_MAX_SEEK_TO_PREVIOUS_POSITION_MS);
+    player.seekTo(/* mediaItemIndex= */ 1, 10_000);
 
     player.seekToPrevious();
 
@@ -13004,9 +13007,12 @@ public class ExoPlayerTest {
 
   @Test
   public void seekToPrevious_notCloseToStart_seeksToZero() {
-    ExoPlayer player = parameterizeTestExoPlayerBuilder(new TestExoPlayerBuilder(context)).build();
+    ExoPlayer player =
+        parameterizeTestExoPlayerBuilder(
+                new TestExoPlayerBuilder(context).setMaxSeekToPreviousPositionMs(10_000))
+            .build();
     player.addMediaSources(ImmutableList.of(new FakeMediaSource(), new FakeMediaSource()));
-    player.seekTo(/* mediaItemIndex= */ 1, C.DEFAULT_MAX_SEEK_TO_PREVIOUS_POSITION_MS + 1);
+    player.seekTo(/* mediaItemIndex= */ 1, 10_001);
 
     player.seekToPrevious();
 

--- a/libraries/session/src/main/java/androidx/media3/session/ConnectionState.java
+++ b/libraries/session/src/main/java/androidx/media3/session/ConnectionState.java
@@ -173,7 +173,9 @@ import java.util.List;
     @Nullable Bundle sessionExtras = bundle.getBundle(FIELD_SESSION_EXTRAS);
     @Nullable Bundle playerInfoBundle = bundle.getBundle(FIELD_PLAYER_INFO);
     PlayerInfo playerInfo =
-        playerInfoBundle == null ? PlayerInfo.DEFAULT : PlayerInfo.fromBundle(playerInfoBundle);
+        playerInfoBundle == null
+            ? PlayerInfo.DEFAULT
+            : PlayerInfo.fromBundle(playerInfoBundle, sessionInterfaceVersion);
     return new ConnectionState(
         libraryVersion,
         sessionInterfaceVersion,

--- a/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplLegacy.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplLegacy.java
@@ -938,7 +938,7 @@ import org.checkerframework.checker.initialization.qual.UnderInitialization;
 
   @Override
   public long getMaxSeekToPreviousPosition() {
-    return 0L;
+    return controllerInfo.playerInfo.maxSeekToPreviousPositionMs;
   }
 
   @Override

--- a/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplLegacy.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplLegacy.java
@@ -2132,6 +2132,7 @@ import org.checkerframework.checker.initialization.qual.UnderInitialization;
         LegacyConversions.convertToIsDeviceMuted(newLegacyPlayerInfo.playbackInfoCompat);
     long seekBackIncrementMs = oldControllerInfo.playerInfo.seekBackIncrementMs;
     long seekForwardIncrementMs = oldControllerInfo.playerInfo.seekForwardIncrementMs;
+    long maxSeekToPreviousPositionMs = oldControllerInfo.playerInfo.maxSeekToPreviousPositionMs;
 
     return createControllerInfo(
         currentTimeline,
@@ -2161,7 +2162,8 @@ import org.checkerframework.checker.initialization.qual.UnderInitialization;
         deviceVolume,
         deviceMuted,
         seekBackIncrementMs,
-        seekForwardIncrementMs);
+        seekForwardIncrementMs,
+        maxSeekToPreviousPositionMs);
   }
 
   /**
@@ -2330,7 +2332,8 @@ import org.checkerframework.checker.initialization.qual.UnderInitialization;
       int deviceVolume,
       boolean deviceMuted,
       long seekBackIncrementMs,
-      long seekForwardIncrementMs) {
+      long seekForwardIncrementMs,
+      long maxSeekToPreviousPositionMs) {
 
     @Nullable MediaItem currentMediaItem = currentTimeline.getMediaItemAt(currentMediaItemIndex);
     PositionInfo positionInfo =
@@ -2379,7 +2382,7 @@ import org.checkerframework.checker.initialization.qual.UnderInitialization;
             /* mediaMetadata= */ mediaMetadata,
             seekBackIncrementMs,
             seekForwardIncrementMs,
-            /* maxSeekToPreviousPositionMs= */ 0L,
+            maxSeekToPreviousPositionMs,
             /* currentTracks= */ Tracks.EMPTY,
             /* parameters= */ TrackSelectionParameters.DEFAULT_WITHOUT_CONTEXT);
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaControllerStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaControllerStub.java
@@ -24,6 +24,7 @@ import android.os.Handler;
 import android.os.RemoteException;
 import android.text.TextUtils;
 import androidx.annotation.Nullable;
+import androidx.media3.common.C;
 import androidx.media3.common.Player.Commands;
 import androidx.media3.common.util.BundleCollectionUtil;
 import androidx.media3.common.util.Log;
@@ -38,7 +39,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
   private static final String TAG = "MediaControllerStub";
 
   /** The version of the IMediaController interface. */
-  public static final int VERSION_INT = 5;
+  public static final int VERSION_INT = 6;
 
   private final WeakReference<MediaControllerImplBase> controller;
 
@@ -112,14 +113,11 @@ import org.checkerframework.checker.nullness.qual.NonNull;
     }
     List<CommandButton> layout;
     try {
-      @Nullable MediaControllerImplBase controller = this.controller.get();
-      @Nullable
-      SessionToken connectedToken = controller == null ? null : controller.getConnectedToken();
-      if (connectedToken == null) {
+      int sessionInterfaceVersion = getSessionInterfaceVersion();
+      if (sessionInterfaceVersion == C.INDEX_UNSET) {
         // Stale event.
         return;
       }
-      int sessionInterfaceVersion = connectedToken.getInterfaceVersion();
       layout =
           BundleCollectionUtil.fromBundleList(
               bundle -> CommandButton.fromBundle(bundle, sessionInterfaceVersion),
@@ -239,7 +237,12 @@ import org.checkerframework.checker.nullness.qual.NonNull;
     }
     PlayerInfo playerInfo;
     try {
-      playerInfo = PlayerInfo.fromBundle(playerInfoBundle);
+      int sessionInterfaceVersion = getSessionInterfaceVersion();
+      if (sessionInterfaceVersion == C.INDEX_UNSET) {
+        // Stale event.
+        return;
+      }
+      playerInfo = PlayerInfo.fromBundle(playerInfoBundle, sessionInterfaceVersion);
     } catch (RuntimeException e) {
       Log.w(TAG, "Ignoring malformed Bundle for PlayerInfo", e);
       return;
@@ -373,6 +376,20 @@ import org.checkerframework.checker.nullness.qual.NonNull;
     } finally {
       Binder.restoreCallingIdentity(token);
     }
+  }
+
+  /** Returns session interface version or {@link C#INDEX_UNSET} for stale events. */
+  private int getSessionInterfaceVersion() {
+    @Nullable MediaControllerImplBase controller = this.controller.get();
+    if (controller == null) {
+      return C.INDEX_UNSET;
+    }
+    @Nullable SessionToken connectedToken = controller.getConnectedToken();
+    if (connectedToken == null) {
+      // Stale event.
+      return C.INDEX_UNSET;
+    }
+    return connectedToken.getInterfaceVersion();
   }
 
   /* @FunctionalInterface */

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
@@ -118,7 +118,7 @@ import java.util.concurrent.ExecutionException;
   private static final String TAG = "MediaSessionStub";
 
   /** The version of the IMediaSession interface. */
-  public static final int VERSION_INT = 3;
+  public static final int VERSION_INT = 4;
 
   /**
    * Sequence number used when a controller method is triggered on the sesison side that wasn't

--- a/libraries/session/src/test/java/androidx/media3/session/PlayerInfoTest.java
+++ b/libraries/session/src/test/java/androidx/media3/session/PlayerInfoTest.java
@@ -163,7 +163,8 @@ public class PlayerInfoTest {
             .setVideoSize(new VideoSize(/* width= */ 1024, /* height= */ 768))
             .build();
 
-    PlayerInfo infoAfterBundling = PlayerInfo.fromBundle(playerInfo.toBundleInProcess());
+    PlayerInfo infoAfterBundling =
+        PlayerInfo.fromBundle(playerInfo.toBundleInProcess(), MediaSessionStub.VERSION_INT);
 
     assertThat(infoAfterBundling.oldPositionInfo.mediaItemIndex).isEqualTo(5);
     assertThat(infoAfterBundling.oldPositionInfo.periodIndex).isEqualTo(4);
@@ -292,7 +293,8 @@ public class PlayerInfoTest {
                         .build(),
                     /* excludeTimeline= */ false,
                     /* excludeTracks= */ false)
-                .toBundleInProcess());
+                .toBundleInProcess(),
+            MediaSessionStub.VERSION_INT);
 
     assertThat(infoAfterBundling.oldPositionInfo.mediaItemIndex).isEqualTo(5);
     assertThat(infoAfterBundling.oldPositionInfo.periodIndex).isEqualTo(4);
@@ -413,7 +415,8 @@ public class PlayerInfoTest {
                         .build(),
                     /* excludeTimeline= */ true,
                     /* excludeTracks= */ false)
-                .toBundleInProcess());
+                .toBundleInProcess(),
+            MediaSessionStub.VERSION_INT);
 
     assertThat(infoAfterBundling.oldPositionInfo.mediaItemIndex).isEqualTo(0);
     assertThat(infoAfterBundling.oldPositionInfo.periodIndex).isEqualTo(0);
@@ -482,7 +485,8 @@ public class PlayerInfoTest {
                         .build(),
                     /* excludeTimeline= */ false,
                     /* excludeTracks= */ false)
-                .toBundleInProcess());
+                .toBundleInProcess(),
+            MediaSessionStub.VERSION_INT);
 
     assertThat(infoAfterBundling.mediaMetadata).isEqualTo(MediaMetadata.EMPTY);
     assertThat(infoAfterBundling.playlistMetadata).isEqualTo(MediaMetadata.EMPTY);
@@ -502,7 +506,8 @@ public class PlayerInfoTest {
                         .build(),
                     /* excludeTimeline= */ false,
                     /* excludeTracks= */ false)
-                .toBundleInProcess());
+                .toBundleInProcess(),
+            MediaSessionStub.VERSION_INT);
 
     assertThat(infoAfterBundling.volume).isEqualTo(1f);
   }
@@ -522,7 +527,8 @@ public class PlayerInfoTest {
                         .build(),
                     /* excludeTimeline= */ false,
                     /* excludeTracks= */ false)
-                .toBundleInProcess());
+                .toBundleInProcess(),
+            MediaSessionStub.VERSION_INT);
 
     assertThat(infoAfterBundling.deviceVolume).isEqualTo(0);
     assertThat(infoAfterBundling.deviceMuted).isFalse();
@@ -546,7 +552,8 @@ public class PlayerInfoTest {
                         .build(),
                     /* excludeTimeline= */ false,
                     /* excludeTracks= */ false)
-                .toBundleInProcess());
+                .toBundleInProcess(),
+            MediaSessionStub.VERSION_INT);
 
     assertThat(infoAfterBundling.audioAttributes).isEqualTo(AudioAttributes.DEFAULT);
   }
@@ -568,7 +575,8 @@ public class PlayerInfoTest {
                         .build(),
                     /* excludeTimeline= */ false,
                     /* excludeTracks= */ false)
-                .toBundleInProcess());
+                .toBundleInProcess(),
+            MediaSessionStub.VERSION_INT);
 
     assertThat(infoAfterBundling.cueGroup).isEqualTo(CueGroup.EMPTY_TIME_ZERO);
   }
@@ -598,14 +606,16 @@ public class PlayerInfoTest {
                         .build(),
                     /* excludeTimeline= */ false,
                     /* excludeTracks= */ true)
-                .toBundleInProcess());
+                .toBundleInProcess(),
+            MediaSessionStub.VERSION_INT);
 
     assertThat(infoAfterBundling.currentTracks).isEqualTo(Tracks.EMPTY);
   }
 
   @Test
   public void toBundleFromBundle_withDefaultValues_restoresAllData() {
-    PlayerInfo roundTripValue = PlayerInfo.fromBundle(PlayerInfo.DEFAULT.toBundleInProcess());
+    PlayerInfo roundTripValue =
+        PlayerInfo.fromBundle(PlayerInfo.DEFAULT.toBundleInProcess(), MediaSessionStub.VERSION_INT);
 
     assertThat(roundTripValue.oldPositionInfo).isEqualTo(PlayerInfo.DEFAULT.oldPositionInfo);
     assertThat(roundTripValue.newPositionInfo).isEqualTo(PlayerInfo.DEFAULT.newPositionInfo);
@@ -661,6 +671,21 @@ public class PlayerInfoTest {
 
   @Test
   public void
+      toBundleForRemoteProcess_withDefaultValuesForControllerInterfaceBefore6_includesSeekLimits() {
+    // Controller before version 6 uses 0 values for the three seek limit default values. The
+    // Bundle should include these to overwrite the presumed 0 on the controller side.
+    Bundle bundle =
+        PlayerInfo.DEFAULT.toBundleForRemoteProcess(/* controllerInterfaceVersion= */ 5);
+
+    assertThat(bundle.keySet())
+        .containsAtLeast(
+            PlayerInfo.FIELD_SEEK_BACK_INCREMENT_MS,
+            PlayerInfo.FIELD_SEEK_FORWARD_INCREMENT_MS,
+            PlayerInfo.FIELD_MAX_SEEK_TO_PREVIOUS_POSITION_MS);
+  }
+
+  @Test
+  public void
       toBundleForRemoteProcess_withDefaultValuesForControllerInterfaceBefore3_includesPositionInfos() {
     // Controller before version 3 uses invalid default values for indices in (Session)PositionInfo.
     // The Bundle should always include these fields to avoid using the invalid defaults.
@@ -672,5 +697,17 @@ public class PlayerInfoTest {
             PlayerInfo.FIELD_SESSION_POSITION_INFO,
             PlayerInfo.FIELD_NEW_POSITION_INFO,
             PlayerInfo.FIELD_OLD_POSITION_INFO);
+  }
+
+  @Test
+  public void fromBundle_withEmptyBundleForSessionInterfaceBefore4_restoresSeekLimitsAsZero() {
+    // Session before version 4 uses 0 values for the three seek limit default values. We need to
+    // restore those instead of current default.
+
+    PlayerInfo playerInfo = PlayerInfo.fromBundle(Bundle.EMPTY, /* sessionInterfaceVersion= */ 3);
+
+    assertThat(playerInfo.seekBackIncrementMs).isEqualTo(0);
+    assertThat(playerInfo.seekForwardIncrementMs).isEqualTo(0);
+    assertThat(playerInfo.maxSeekToPreviousPositionMs).isEqualTo(0);
   }
 }

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestExoPlayerBuilder.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestExoPlayerBuilder.java
@@ -325,7 +325,7 @@ public class TestExoPlayerBuilder {
    * @return This builder.
    */
   @CanIgnoreReturnValue
-  public TestExoPlayerBuilder setMaxSeekToPreviousPosition(long maxSeekToPreviousPositionMs) {
+  public TestExoPlayerBuilder setMaxSeekToPreviousPositionMs(long maxSeekToPreviousPositionMs) {
     this.maxSeekToPreviousPositionMs = maxSeekToPreviousPositionMs;
     return this;
   }
@@ -398,7 +398,7 @@ public class TestExoPlayerBuilder {
             .setLooper(looper)
             .setSeekBackIncrementMs(seekBackIncrementMs)
             .setSeekForwardIncrementMs(seekForwardIncrementMs)
-            .setMaxSeekToPreviousPosition(maxSeekToPreviousPositionMs)
+            .setMaxSeekToPreviousPositionMs(maxSeekToPreviousPositionMs)
             .setDeviceVolumeControlEnabled(deviceVolumeControlEnabled)
             .setSuppressPlaybackOnUnsuitableOutput(suppressPlaybackWhenUnsuitableOutput)
             .experimentalSetDynamicSchedulingEnabled(dynamicSchedulingEnabled);

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestExoPlayerBuilder.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestExoPlayerBuilder.java
@@ -54,6 +54,7 @@ public class TestExoPlayerBuilder {
   private @MonotonicNonNull Looper looper;
   private long seekBackIncrementMs;
   private long seekForwardIncrementMs;
+  private long maxSeekToPreviousPositionMs;
   private boolean deviceVolumeControlEnabled;
   private boolean suppressPlaybackWhenUnsuitableOutput;
   @Nullable private ExoPlayer.PreloadConfiguration preloadConfiguration;
@@ -71,6 +72,7 @@ public class TestExoPlayerBuilder {
     }
     seekBackIncrementMs = C.DEFAULT_SEEK_BACK_INCREMENT_MS;
     seekForwardIncrementMs = C.DEFAULT_SEEK_FORWARD_INCREMENT_MS;
+    maxSeekToPreviousPositionMs = C.DEFAULT_MAX_SEEK_TO_PREVIOUS_POSITION_MS;
     deviceVolumeControlEnabled = false;
   }
 
@@ -317,6 +319,23 @@ public class TestExoPlayerBuilder {
   }
 
   /**
+   * Sets the max seek to previous position, in milliseconds, to be used by the player.
+   *
+   * @param maxSeekToPreviousPositionMs The max seek to previous position to be used by the player.
+   * @return This builder.
+   */
+  @CanIgnoreReturnValue
+  public TestExoPlayerBuilder setMaxSeekToPreviousPosition(long maxSeekToPreviousPositionMs) {
+    this.maxSeekToPreviousPositionMs = maxSeekToPreviousPositionMs;
+    return this;
+  }
+
+  /** Returns the max seek to previous position used by the player. */
+  public long getMaxSeekToPreviousPosition() {
+    return maxSeekToPreviousPositionMs;
+  }
+
+  /**
    * See {@link ExoPlayer.Builder#setSuppressPlaybackOnUnsuitableOutput(boolean)} for details.
    *
    * @param suppressPlaybackOnUnsuitableOutput Whether the player should suppress the playback when
@@ -379,6 +398,7 @@ public class TestExoPlayerBuilder {
             .setLooper(looper)
             .setSeekBackIncrementMs(seekBackIncrementMs)
             .setSeekForwardIncrementMs(seekForwardIncrementMs)
+            .setMaxSeekToPreviousPosition(maxSeekToPreviousPositionMs)
             .setDeviceVolumeControlEnabled(deviceVolumeControlEnabled)
             .setSuppressPlaybackOnUnsuitableOutput(suppressPlaybackWhenUnsuitableOutput)
             .experimentalSetDynamicSchedulingEnabled(dynamicSchedulingEnabled);


### PR DESCRIPTION
This PR introduces the following changes:
- Add a new constructor to `CastPlayer` to provide a `maxSeekToPreviousPositionMs` argument.
- Add `ExoPlayer.Builder.setMaxSeekToPreviousPosition(long).
- Update `MediaControllerImplLegacy.getMaxSeekToPreviousPosition()` to return the value from `controllerInfo.playerInfo.maxSeekToPreviousPositionMs` instead of 0.
- Add `TestExoPlayerBuilder.setMaxSeekToPreviousPosition(long)`.
- Add `TestExoPlayerBuilder.getMaxSeekToPreviousPosition()`.

> [!NOTE]
> This new functionality only allows setting the value at initialisation (for `ExoPlayer` and `CastPlayer`). Let me know if I should also add a dedicated setter on these classes (or on `Player` directly).

Fixes #1425