### PR TITLE
Fixes early transiton to `Player.STATE_ENDED` with MPD transition  dy…

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImplInternal.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImplInternal.java
@@ -3030,6 +3030,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
       }
     }
 
+    long periodPositionDeltaUs = checkPlayingPeriodPositionChanged(timeline, playbackInfo, period.windowIndex);
+    if (periodPositionDeltaUs > 0) {
+      periodPositionUs = periodPositionUs - periodPositionDeltaUs;
+    }
+
     return new PositionUpdateForPlaylistChange(
         newPeriodId,
         periodPositionUs,
@@ -3037,6 +3042,26 @@ import java.util.concurrent.atomic.AtomicBoolean;
         forceBufferingState,
         endPlayback,
         setTargetLiveOffset);
+  }
+
+  private static long checkPlayingPeriodPositionChanged(Timeline timeline, PlaybackInfo playbackInfo, int currentWindowIndex) {
+    long periodPositionDeltaUs = C.TIME_UNSET;
+    if (!playbackInfo.timeline.isEmpty()
+        && !timeline.isEmpty()
+        && !playbackInfo.periodId.isAd()
+        && playbackInfo.timeline.getWindowCount() == timeline.getWindowCount()
+        && currentWindowIndex < playbackInfo.timeline.getWindowCount()) {
+      Timeline.Window newWindow = timeline.getWindow(currentWindowIndex, new Timeline.Window());
+      Timeline.Window oldWindow = playbackInfo.timeline.getWindow(currentWindowIndex, new Timeline.Window());
+      if (oldWindow.isDynamic && ! newWindow.isDynamic) {
+        Timeline.Period newPeriod = timeline.getPeriodByUid(playbackInfo.periodId.periodUid, new Timeline.Period());
+        int windowIndex = newPeriod.windowIndex;
+        Pair<Object, Long> oldPositionZero = playbackInfo.timeline.getPeriodPosition(oldWindow, new Timeline.Period(), windowIndex, 0);
+        Pair<Object, Long> newPositionZero = timeline.getPeriodPosition(newWindow, new Timeline.Period(), windowIndex, 0);
+        periodPositionDeltaUs = oldPositionZero.second - newPositionZero.second;
+      }
+    }
+    return periodPositionDeltaUs;
   }
 
   private static boolean isIgnorableServerSideAdInsertionPeriodChange(


### PR DESCRIPTION
…namic to static

This checkin fixes Issue #1441 where the player transitons to `Player.STATE_ENDED` once the buffer runs out on a DASH start-over playlist that has transitioned from dynamic to static.

The fix detects the DASH Period has changed offset to the window, which occurs when the origin vendor follows the DASH-IF recommendations in *Section 4.6.4. Transition Phase between Live and On-Demand* ,  summerized as:

-	adds the attribute `MPD@mediaPresentationDuration`
-	removes the attribute `MPD@minimumUpdatePeriod`
-	`Period@start` is removed (if it was present)
-	`Period@duration` is added (in case more than 1 period is present)
-	`Adaptationset .SegmentTemplate@presentationTimeOffset` is set to earliest presentation time of a segment in the Adaptationset

The MPD change does not affect the render position or the segment timeline at all, however the cleanest way to implement this was to report a `PositionUpdateForPlaylistChange` which triggers a seek and flushes the current buffered content.