### PR TITLE
Fix potential side effects inside of the player.

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/ListenerSet.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/ListenerSet.java
@@ -74,7 +74,7 @@ public final class ListenerSet<T extends @NonNull Object> {
     void invoke(T listener, FlagSet eventFlags);
   }
 
-  private static final int MSG_ITERATION_FINISHED = 0;
+  private static final int MSG_ITERATION_FINISHED = 1;
 
   private final Clock clock;
   private final HandlerWrapper handler;

--- a/libraries/common/src/main/java/androidx/media3/common/util/SystemHandlerWrapper.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/SystemHandlerWrapper.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.common.util;
 
+import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.os.Handler;
@@ -46,6 +47,8 @@ import java.util.List;
 
   @Override
   public boolean hasMessages(int what) {
+    // Using what == 0 when using hasMessages is dangerous as it also checks for pending Runnables.
+    checkArgument(what != 0);
     return handler.hasMessages(what);
   }
 
@@ -93,6 +96,8 @@ import java.util.List;
 
   @Override
   public void removeMessages(int what) {
+    // Using what == 0 when removing messages is dangerous as it also removes all pending Runnables.
+    checkArgument(what != 0);
     handler.removeMessages(what);
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImplInternal.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImplInternal.java
@@ -135,7 +135,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
   }
 
   // Internal messages
-  private static final int MSG_PREPARE = 0;
   private static final int MSG_SET_PLAY_WHEN_READY = 1;
   private static final int MSG_DO_SOME_WORK = 2;
   private static final int MSG_SEEK_TO = 3;
@@ -163,6 +162,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
   private static final int MSG_RENDERER_CAPABILITIES_CHANGED = 26;
   private static final int MSG_UPDATE_MEDIA_SOURCES_WITH_MEDIA_ITEMS = 27;
   private static final int MSG_SET_PRELOAD_CONFIGURATION = 28;
+  private static final int MSG_PREPARE = 29;
 
   private static final long BUFFERING_MAXIMUM_INTERVAL_MS =
       Util.usToMs(Renderer.DEFAULT_DURATION_TO_PROGRESS_US);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/MetadataRetriever.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/MetadataRetriever.java
@@ -102,10 +102,10 @@ public final class MetadataRetriever {
 
   private static final class MetadataRetrieverInternal {
 
-    private static final int MESSAGE_PREPARE_SOURCE = 0;
-    private static final int MESSAGE_CHECK_FOR_FAILURE = 1;
-    private static final int MESSAGE_CONTINUE_LOADING = 2;
-    private static final int MESSAGE_RELEASE = 3;
+    private static final int MESSAGE_PREPARE_SOURCE = 1;
+    private static final int MESSAGE_CHECK_FOR_FAILURE = 2;
+    private static final int MESSAGE_CONTINUE_LOADING = 3;
+    private static final int MESSAGE_RELEASE = 4;
 
     private final MediaSource.Factory mediaSourceFactory;
     private final HandlerThread mediaSourceThread;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSession.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSession.java
@@ -116,8 +116,8 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
 
   private static final String TAG = "DefaultDrmSession";
 
-  private static final int MSG_PROVISION = 0;
-  private static final int MSG_KEYS = 1;
+  private static final int MSG_PROVISION = 1;
+  private static final int MSG_KEYS = 2;
   private static final int MAX_LICENSE_DURATION_TO_RENEW_SECONDS = 60;
 
   /** The DRM scheme datas, or null if this session uses offline keys. */

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/AsynchronousMediaCodecBufferEnqueuer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/AsynchronousMediaCodecBufferEnqueuer.java
@@ -44,10 +44,10 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 @RequiresApi(23)
 /* package */ class AsynchronousMediaCodecBufferEnqueuer implements MediaCodecBufferEnqueuer {
 
-  private static final int MSG_QUEUE_INPUT_BUFFER = 0;
-  private static final int MSG_QUEUE_SECURE_INPUT_BUFFER = 1;
-  private static final int MSG_OPEN_CV = 2;
-  private static final int MSG_SET_PARAMETERS = 3;
+  private static final int MSG_QUEUE_INPUT_BUFFER = 1;
+  private static final int MSG_QUEUE_SECURE_INPUT_BUFFER = 2;
+  private static final int MSG_OPEN_CV = 3;
+  private static final int MSG_SET_PARAMETERS = 4;
 
   @GuardedBy("MESSAGE_PARAMS_INSTANCE_POOL")
   private static final ArrayDeque<MessageParams> MESSAGE_PARAMS_INSTANCE_POOL = new ArrayDeque<>();

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/metadata/MetadataRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/metadata/MetadataRenderer.java
@@ -50,7 +50,7 @@ import org.checkerframework.dataflow.qual.SideEffectFree;
 public final class MetadataRenderer extends BaseRenderer implements Callback {
 
   private static final String TAG = "MetadataRenderer";
-  private static final int MSG_INVOKE_RENDERER = 0;
+  private static final int MSG_INVOKE_RENDERER = 1;
 
   private final MetadataDecoderFactory decoderFactory;
   private final MetadataOutput output;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DownloadHelper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DownloadHelper.java
@@ -847,13 +847,13 @@ public final class DownloadHelper {
   private static final class MediaPreparer
       implements MediaSourceCaller, MediaPeriod.Callback, Handler.Callback {
 
-    private static final int MESSAGE_PREPARE_SOURCE = 0;
-    private static final int MESSAGE_CHECK_FOR_FAILURE = 1;
-    private static final int MESSAGE_CONTINUE_LOADING = 2;
-    private static final int MESSAGE_RELEASE = 3;
+    private static final int MESSAGE_PREPARE_SOURCE = 1;
+    private static final int MESSAGE_CHECK_FOR_FAILURE = 2;
+    private static final int MESSAGE_CONTINUE_LOADING = 3;
+    private static final int MESSAGE_RELEASE = 4;
 
-    private static final int DOWNLOAD_HELPER_CALLBACK_MESSAGE_PREPARED = 0;
-    private static final int DOWNLOAD_HELPER_CALLBACK_MESSAGE_FAILED = 1;
+    private static final int DOWNLOAD_HELPER_CALLBACK_MESSAGE_PREPARED = 1;
+    private static final int DOWNLOAD_HELPER_CALLBACK_MESSAGE_FAILED = 2;
 
     private final MediaSource mediaSource;
     private final DownloadHelper downloadHelper;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DownloadManager.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DownloadManager.java
@@ -156,24 +156,24 @@ public final class DownloadManager {
   public static final Requirements DEFAULT_REQUIREMENTS = new Requirements(Requirements.NETWORK);
 
   // Messages posted to the main handler.
-  private static final int MSG_INITIALIZED = 0;
-  private static final int MSG_PROCESSED = 1;
-  private static final int MSG_DOWNLOAD_UPDATE = 2;
+  private static final int MSG_INITIALIZED = 1;
+  private static final int MSG_PROCESSED = 2;
+  private static final int MSG_DOWNLOAD_UPDATE = 3;
 
   // Messages posted to the background handler.
-  private static final int MSG_INITIALIZE = 0;
-  private static final int MSG_SET_DOWNLOADS_PAUSED = 1;
-  private static final int MSG_SET_NOT_MET_REQUIREMENTS = 2;
-  private static final int MSG_SET_STOP_REASON = 3;
-  private static final int MSG_SET_MAX_PARALLEL_DOWNLOADS = 4;
-  private static final int MSG_SET_MIN_RETRY_COUNT = 5;
-  private static final int MSG_ADD_DOWNLOAD = 6;
-  private static final int MSG_REMOVE_DOWNLOAD = 7;
-  private static final int MSG_REMOVE_ALL_DOWNLOADS = 8;
-  private static final int MSG_TASK_STOPPED = 9;
-  private static final int MSG_CONTENT_LENGTH_CHANGED = 10;
-  private static final int MSG_UPDATE_PROGRESS = 11;
-  private static final int MSG_RELEASE = 12;
+  private static final int MSG_INITIALIZE = 1;
+  private static final int MSG_SET_DOWNLOADS_PAUSED = 2;
+  private static final int MSG_SET_NOT_MET_REQUIREMENTS = 3;
+  private static final int MSG_SET_STOP_REASON = 4;
+  private static final int MSG_SET_MAX_PARALLEL_DOWNLOADS = 5;
+  private static final int MSG_SET_MIN_RETRY_COUNT = 6;
+  private static final int MSG_ADD_DOWNLOAD = 7;
+  private static final int MSG_REMOVE_DOWNLOAD = 8;
+  private static final int MSG_REMOVE_ALL_DOWNLOADS = 9;
+  private static final int MSG_TASK_STOPPED = 10;
+  private static final int MSG_CONTENT_LENGTH_CHANGED = 11;
+  private static final int MSG_UPDATE_PROGRESS = 12;
+  private static final int MSG_RELEASE = 13;
 
   private static final String TAG = "DownloadManager";
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ConcatenatingMediaSource.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ConcatenatingMediaSource.java
@@ -60,12 +60,12 @@ import java.util.Set;
 @UnstableApi
 public final class ConcatenatingMediaSource extends CompositeMediaSource<MediaSourceHolder> {
 
-  private static final int MSG_ADD = 0;
-  private static final int MSG_REMOVE = 1;
-  private static final int MSG_MOVE = 2;
-  private static final int MSG_SET_SHUFFLE_ORDER = 3;
-  private static final int MSG_UPDATE_TIMELINE = 4;
-  private static final int MSG_ON_COMPLETION = 5;
+  private static final int MSG_ADD = 1;
+  private static final int MSG_REMOVE = 2;
+  private static final int MSG_MOVE = 3;
+  private static final int MSG_SET_SHUFFLE_ORDER = 4;
+  private static final int MSG_UPDATE_TIMELINE = 5;
+  private static final int MSG_ON_COMPLETION = 6;
 
   private static final MediaItem PLACEHOLDER_MEDIA_ITEM =
       new MediaItem.Builder().setUri(Uri.EMPTY).build();

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ConcatenatingMediaSource2.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ConcatenatingMediaSource2.java
@@ -221,7 +221,7 @@ public final class ConcatenatingMediaSource2 extends CompositeMediaSource<Intege
     }
   }
 
-  private static final int MSG_UPDATE_TIMELINE = 0;
+  private static final int MSG_UPDATE_TIMELINE = 1;
 
   private final ImmutableList<MediaSourceHolder> mediaSourceHolders;
   private final IdentityHashMap<MediaPeriod, MediaSourceHolder> mediaSourceByMediaPeriod;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/text/TextRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/text/TextRenderer.java
@@ -95,7 +95,7 @@ public final class TextRenderer extends BaseRenderer implements Callback {
    */
   private static final int REPLACEMENT_STATE_WAIT_END_OF_STREAM = 2;
 
-  private static final int MSG_UPDATE_OUTPUT = 0;
+  private static final int MSG_UPDATE_OUTPUT = 1;
 
   // Fields used when handling CuesWithTiming objects from application/x-media3-cues samples.
   private final CueDecoder cueDecoder;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/Loader.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/Loader.java
@@ -326,10 +326,10 @@ public final class Loader implements LoaderErrorThrower {
 
     private static final String TAG = "LoadTask";
 
-    private static final int MSG_START = 0;
-    private static final int MSG_FINISH = 1;
-    private static final int MSG_IO_EXCEPTION = 2;
-    private static final int MSG_FATAL_ERROR = 3;
+    private static final int MSG_START = 1;
+    private static final int MSG_FINISH = 2;
+    private static final int MSG_IO_EXCEPTION = 3;
+    private static final int MSG_FATAL_ERROR = 4;
 
     public final int defaultMinRetryCount;
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/VideoFrameReleaseHelper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/VideoFrameReleaseHelper.java
@@ -494,9 +494,9 @@ public final class VideoFrameReleaseHelper {
 
     public volatile long sampledVsyncTimeNs;
 
-    private static final int CREATE_CHOREOGRAPHER = 0;
-    private static final int MSG_ADD_OBSERVER = 1;
-    private static final int MSG_REMOVE_OBSERVER = 2;
+    private static final int CREATE_CHOREOGRAPHER = 1;
+    private static final int MSG_ADD_OBSERVER = 2;
+    private static final int MSG_REMOVE_OBSERVER = 3;
 
     private static final VSyncSampler INSTANCE = new VSyncSampler();
 

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/FakeClock.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/FakeClock.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.test.utils;
 
+import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.os.Build;
@@ -405,6 +406,8 @@ public class FakeClock implements Clock {
 
     @Override
     public boolean hasMessages(int what) {
+      // Using what==0 when using hasMessages is dangerous as it also checks for pending Runnables.
+      checkArgument(what != 0);
       return hasPendingMessage(/* handler= */ this, what);
     }
 
@@ -470,6 +473,8 @@ public class FakeClock implements Clock {
 
     @Override
     public void removeMessages(int what) {
+      // Using what==0 when removing messages is dangerous as it also removes all pending Runnables.
+      checkArgument(what != 0);
       removePendingHandlerMessages(/* handler= */ this, what);
     }
 

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/CompositionPlayerInternal.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/CompositionPlayerInternal.java
@@ -47,11 +47,11 @@ import androidx.media3.exoplayer.video.CompositingVideoSinkProvider;
   }
 
   private static final String TAG = "CompPlayerInternal";
-  private static final int MSG_SET_OUTPUT_SURFACE_INFO = 0;
-  private static final int MSG_CLEAR_OUTPUT_SURFACE = 1;
-  private static final int MSG_START_SEEK = 2;
-  private static final int MSG_END_SEEK = 3;
-  private static final int MSG_RELEASE = 4;
+  private static final int MSG_SET_OUTPUT_SURFACE_INFO = 1;
+  private static final int MSG_CLEAR_OUTPUT_SURFACE = 2;
+  private static final int MSG_START_SEEK = 3;
+  private static final int MSG_END_SEEK = 4;
+  private static final int MSG_RELEASE = 5;
 
   private final Clock clock;
   private final HandlerWrapper handler;

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/TransformerInternal.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/TransformerInternal.java
@@ -109,10 +109,10 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
   private static final int END_REASON_ERROR = 2;
 
   // Internal messages.
-  private static final int MSG_START = 0;
-  private static final int MSG_REGISTER_SAMPLE_EXPORTER = 1;
-  private static final int MSG_DRAIN_EXPORTERS = 2;
-  private static final int MSG_END = 3;
+  private static final int MSG_START = 1;
+  private static final int MSG_REGISTER_SAMPLE_EXPORTER = 2;
+  private static final int MSG_DRAIN_EXPORTERS = 3;
+  private static final int MSG_END = 4;
 
   private static final String TAG = "TransformerInternal";
   private static final int DRAIN_EXPORTERS_DELAY_MS = 10;

--- a/libraries/ui/src/main/java/androidx/media3/ui/PlayerNotificationManager.java
+++ b/libraries/ui/src/main/java/androidx/media3/ui/PlayerNotificationManager.java
@@ -650,8 +650,8 @@ public class PlayerNotificationManager {
 
   // Internal messages.
 
-  private static final int MSG_START_OR_UPDATE_NOTIFICATION = 0;
-  private static final int MSG_UPDATE_NOTIFICATION_BITMAP = 1;
+  private static final int MSG_START_OR_UPDATE_NOTIFICATION = 1;
+  private static final int MSG_UPDATE_NOTIFICATION_BITMAP = 2;
 
   /**
    * Visibility of notification on the lock screen. One of {@link


### PR DESCRIPTION
ExoPlayer uses handlers extensively.
One of the hidden problem of handlers is removal of the messages with ID == 0.
There is a side effect of such a removal - it also removes all callbacks.

[postDelayed](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/os/Handler.java;l=498-500?q=Handler), creates a message through [Message.obtain](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/os/Message.java;l=196-201) call. What value is always 0 as a result.

So [removeMessages(what)](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/os/Handler.java;l=785-787?q=Handler) will drop the callbacks as well.

Here I'm fixing the cases what remove the 0 message in particular.
I expect some of the problems in the playback stack miraculously disappear as a result of the change.