### PR TITLE
Avoid unnecessary getSystemService call on WifiLockManager and WakeLo…

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/WakeLockManager.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/WakeLockManager.java
@@ -32,10 +32,11 @@ import androidx.media3.common.util.Log;
 
   private static final String TAG = "WakeLockManager";
   private static final String WAKE_LOCK_TAG = "ExoPlayer:WakeLockManager";
+
+  private final Context applicationContext;
   @Nullable private WakeLock wakeLock;
   private boolean enabled;
   private boolean stayAwake;
-  private final Context applicationContext;
 
   public WakeLockManager(Context context) {
     applicationContext = context.getApplicationContext();
@@ -54,7 +55,7 @@ import androidx.media3.common.util.Log;
   public void setEnabled(boolean enabled) {
     if (enabled) {
       if (wakeLock == null) {
-        final PowerManager powerManager =
+        PowerManager powerManager =
             (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
         if (powerManager == null) {
           Log.w(TAG, "PowerManager is null, therefore not creating the WakeLock.");

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/WakeLockManager.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/WakeLockManager.java
@@ -32,15 +32,13 @@ import androidx.media3.common.util.Log;
 
   private static final String TAG = "WakeLockManager";
   private static final String WAKE_LOCK_TAG = "ExoPlayer:WakeLockManager";
-
-  @Nullable private final PowerManager powerManager;
   @Nullable private WakeLock wakeLock;
   private boolean enabled;
   private boolean stayAwake;
+  private final Context applicationContext;
 
   public WakeLockManager(Context context) {
-    powerManager =
-        (PowerManager) context.getApplicationContext().getSystemService(Context.POWER_SERVICE);
+    applicationContext = context.getApplicationContext();
   }
 
   /**
@@ -56,6 +54,8 @@ import androidx.media3.common.util.Log;
   public void setEnabled(boolean enabled) {
     if (enabled) {
       if (wakeLock == null) {
+        final PowerManager powerManager =
+            (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
         if (powerManager == null) {
           Log.w(TAG, "PowerManager is null, therefore not creating the WakeLock.");
           return;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/WifiLockManager.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/WifiLockManager.java
@@ -31,15 +31,13 @@ import androidx.media3.common.util.Log;
 
   private static final String TAG = "WifiLockManager";
   private static final String WIFI_LOCK_TAG = "ExoPlayer:WifiLockManager";
-
-  @Nullable private final WifiManager wifiManager;
   @Nullable private WifiLock wifiLock;
   private boolean enabled;
   private boolean stayAwake;
+  private Context applicationContext;
 
   public WifiLockManager(Context context) {
-    wifiManager =
-        (WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+    applicationContext = context.getApplicationContext();
   }
 
   /**
@@ -54,6 +52,9 @@ import androidx.media3.common.util.Log;
    */
   public void setEnabled(boolean enabled) {
     if (enabled && wifiLock == null) {
+      final WifiManager wifiManager =
+          (WifiManager) applicationContext.getApplicationContext()
+              .getSystemService(Context.WIFI_SERVICE);
       if (wifiManager == null) {
         Log.w(TAG, "WifiManager is null, therefore not creating the WifiLock.");
         return;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/WifiLockManager.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/WifiLockManager.java
@@ -31,10 +31,11 @@ import androidx.media3.common.util.Log;
 
   private static final String TAG = "WifiLockManager";
   private static final String WIFI_LOCK_TAG = "ExoPlayer:WifiLockManager";
+
+  private final Context applicationContext;
   @Nullable private WifiLock wifiLock;
   private boolean enabled;
   private boolean stayAwake;
-  private Context applicationContext;
 
   public WifiLockManager(Context context) {
     applicationContext = context.getApplicationContext();
@@ -52,9 +53,9 @@ import androidx.media3.common.util.Log;
    */
   public void setEnabled(boolean enabled) {
     if (enabled && wifiLock == null) {
-      final WifiManager wifiManager =
-          (WifiManager) applicationContext.getApplicationContext()
-              .getSystemService(Context.WIFI_SERVICE);
+      WifiManager wifiManager =
+          (WifiManager)
+              applicationContext.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
       if (wifiManager == null) {
         Log.w(TAG, "WifiManager is null, therefore not creating the WifiLock.");
         return;


### PR DESCRIPTION
…ckManager if not enabled


getSystemService is expensive during initialization if it is never used. This delays the need to make the getSystemService call to only instances when the lock managers are actually needed