### PR TITLE
[exoplayer] Fix to handle multiple concurrent discontinuity updates.

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImplInternal.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImplInternal.java
@@ -119,9 +119,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
     public void setPositionDiscontinuity(@DiscontinuityReason int discontinuityReason) {
       if (positionDiscontinuity
           && this.discontinuityReason != Player.DISCONTINUITY_REASON_INTERNAL) {
-        // We always prefer non-internal discontinuity reasons. We also assume that we won't report
-        // more than one non-internal discontinuity per message iteration.
-        Assertions.checkArgument(discontinuityReason == Player.DISCONTINUITY_REASON_INTERNAL);
+        // We always prefer non-internal discontinuity reasons. Multiple non-internal discontinuity
+        // reasons are possible, but rare. Report the first reason seen.
         return;
       }
       hasPendingChange = true;


### PR DESCRIPTION
## Summary
This pull request fixes issue #1483  where multiple concurrent discontinuity updates can lead to an `IllegalArgumentException` in ExoPlayer and potentially an app-crash. The issue arises when the player encounters renderer errors while the playing period differs from the reading period, leading to multiple non-internal discontinuity reasons being reported in quick succession. This regression was introduced with commit 79b688ef30d4a3306d4d321ddf4464b428074ea2, having added another path to report non-internal discontinuity.

## Changes
### Modification to ExoPlayerImplInternal:
 * Adjusted the `setPositionDiscontinuity` method in `PlaybackInfoUpdate` to handle multiple concurrent discontinuity events more gracefully by allowing multiple non-internal discontinuity reasons, though only reporting the first seen. Implemented by removing `assert` statement that no longer holds true.

### Added Unit Test:
 * Introduced a unit test to ensure that multiple non-internal discontinuity reasons are handled without causing assertion failures.