### PR TITLE
Update README instructions for depending on modules locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ First, clone the repository into a local directory:
 
 ```sh
 git clone https://github.com/androidx/media.git
-cd media
 ```
 
 Next, add the following to your project's `settings.gradle.kts` file, replacing
@@ -130,7 +129,7 @@ apply(from = file("path/to/media/core_settings.gradle"))
 Or in Gradle Groovy DSL `settings.gradle`:
 
 ```groovy
-gradle.ext.androidxMediaModulePrefix = 'media-'
+gradle.ext.androidxMediaModulePrefix = 'media3-'
 apply from: file("path/to/media/core_settings.gradle")
 ```
 
@@ -139,17 +138,17 @@ You can depend on them from `build.gradle.kts` as you would on any other local
 module, for example:
 
 ```kotlin
-implementation(project(":media-lib-exoplayer"))
-implementation(project(":media-lib-exoplayer-dash"))
-implementation(project(":media-lib-ui"))
+implementation(project(":media3-lib-exoplayer"))
+implementation(project(":media3-lib-exoplayer-dash"))
+implementation(project(":media3-lib-ui"))
 ```
 
 Or in Gradle Groovy DSL `build.gradle`:
 
 ```groovy
-implementation project(':media-lib-exoplayer')
-implementation project(':media-lib-exoplayer-dash')
-implementation project(':media-lib-ui')
+implementation project(':media3-lib-exoplayer')
+implementation project(':media3-lib-exoplayer-dash')
+implementation project(':media3-lib-ui')
 ```
 
 #### MIDI module


### PR DESCRIPTION
Fixes dependencies based on instructions for setting up module:

```
Next, add the following to your project's settings.gradle.kts file, replacing path/to/media with the path to your local copy:

(gradle as ExtensionAware).extra["androidxMediaModulePrefix"] = "media3-"
apply(from = file("path/to/media/core_settings.gradle"))
```