### PR TITLE
Add a static rendererSupportsFormat method for MCVR

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -486,6 +486,14 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   @Override
   protected @Capabilities int supportsFormat(MediaCodecSelector mediaCodecSelector, Format format)
       throws DecoderQueryException {
+        return rendererSupportsFormat(context, mediaCodecSelector, format);
+      }
+
+  public static @Capabilities int rendererSupportsFormat(
+      Context context,
+      MediaCodecSelector mediaCodecSelector,
+      Format format)
+      throws DecoderQueryException {  
     String mimeType = format.sampleMimeType;
     if (!MimeTypes.isVideo(mimeType)) {
       return RendererCapabilities.create(C.FORMAT_UNSUPPORTED_TYPE);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -67,6 +67,7 @@ import androidx.media3.exoplayer.ExoPlaybackException;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.FormatHolder;
 import androidx.media3.exoplayer.PlayerMessage.Target;
+import androidx.media3.exoplayer.Renderer;
 import androidx.media3.exoplayer.RendererCapabilities;
 import androidx.media3.exoplayer.mediacodec.MediaCodecAdapter;
 import androidx.media3.exoplayer.mediacodec.MediaCodecDecoderException;
@@ -483,13 +484,29 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     return TAG;
   }
 
+  /**
+   * Returns the extent to which a {@link MediaCodecVideoRenderer} instance would support a given
+   * format.
+   *
+   * @param context A context.
+   * @param mediaCodecSelector The decoder selector.
+   * @param format for which to retrieve the {@code MediaCodecVideoRenderer} support.
+   * @return The {@link Capabilities} for this format.
+   * @throws DecoderQueryException Thrown if there was an error querying decoders.
+   */
+  public static @Capabilities int supportsFormat(
+      Context context, MediaCodecSelector mediaCodecSelector, Format format)
+      throws DecoderQueryException {
+    return supportsFormatInternal(context, mediaCodecSelector, format);
+  }
+
   @Override
   protected @Capabilities int supportsFormat(MediaCodecSelector mediaCodecSelector, Format format)
       throws DecoderQueryException {
-    return rendererSupportsFormat(context, mediaCodecSelector, format);
+    return supportsFormatInternal(context, mediaCodecSelector, format);
   }
 
-  public static @Capabilities int rendererSupportsFormat(
+  private static @Capabilities int supportsFormatInternal(
       Context context, MediaCodecSelector mediaCodecSelector, Format format)
       throws DecoderQueryException {
     String mimeType = format.sampleMimeType;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -486,14 +486,12 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   @Override
   protected @Capabilities int supportsFormat(MediaCodecSelector mediaCodecSelector, Format format)
       throws DecoderQueryException {
-        return rendererSupportsFormat(context, mediaCodecSelector, format);
-      }
+    return rendererSupportsFormat(context, mediaCodecSelector, format);
+  }
 
   public static @Capabilities int rendererSupportsFormat(
-      Context context,
-      MediaCodecSelector mediaCodecSelector,
-      Format format)
-      throws DecoderQueryException {  
+      Context context, MediaCodecSelector mediaCodecSelector, Format format)
+      throws DecoderQueryException {
     String mimeType = format.sampleMimeType;
     if (!MimeTypes.isVideo(mimeType)) {
       return RendererCapabilities.create(C.FORMAT_UNSUPPORTED_TYPE);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -67,7 +67,6 @@ import androidx.media3.exoplayer.ExoPlaybackException;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.FormatHolder;
 import androidx.media3.exoplayer.PlayerMessage.Target;
-import androidx.media3.exoplayer.Renderer;
 import androidx.media3.exoplayer.RendererCapabilities;
 import androidx.media3.exoplayer.mediacodec.MediaCodecAdapter;
 import androidx.media3.exoplayer.mediacodec.MediaCodecDecoderException;
@@ -485,12 +484,12 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   }
 
   /**
-   * Returns the extent to which a {@link MediaCodecVideoRenderer} instance would support a given
-   * format.
+   * Returns the {@link Capabilities} of MediaCodecVideoRenderer for a given {@link Format}.
    *
    * @param context A context.
    * @param mediaCodecSelector The decoder selector.
-   * @param format for which to retrieve the {@code MediaCodecVideoRenderer} support.
+   * @param format The {@link Format} for which to check the {@code MediaCodecVideoRenderer}'s
+   *     support.
    * @return The {@link Capabilities} for this format.
    * @throws DecoderQueryException Thrown if there was an error querying decoders.
    */


### PR DESCRIPTION
This refactors the `supportsFormat` method on the MediaCodecVideoRenderer to be a static method that can be called from external components to determine if a video format is supported by the device renderers. Since `context` is the only component that is part of the MCVR, it can easily be obtained externally and passed to the method.

This can help optimize format support decisions ahead of time of a player having been instantiated, such as removing unsupported representations from a dash manifest.

This could also be done for the MCAR but would also require passing in the AudioSink and isn't required at this time.