### PR TITLE
TranscodeQualityTest: Fix TranscodeQualityTest

### DIFF
--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TranscodeQualityTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TranscodeQualityTest.java
@@ -134,7 +134,7 @@ public final class TranscodeQualityTest {
   }
 
   @Test
-  public void transcodeAvcToAvc320x240_ssimIsGreaterThan90Percent() throws Exception {
+  public void transcodeAvcToAvc320x240_ssimIsGreaterThan87Percent() throws Exception {
     Context context = ApplicationProvider.getApplicationContext();
 
     // Don't skip based on format support as input and output formats should be within CDD
@@ -160,7 +160,7 @@ public final class TranscodeQualityTest {
             .run(testId, editedMediaItem);
 
     if (result.ssim != ExportTestResult.SSIM_UNSET) {
-      assertThat(result.ssim).isGreaterThan(0.90);
+      assertThat(result.ssim).isGreaterThan(0.87);
     }
   }
 }


### PR DESCRIPTION
TranscodeQualityTest is failing on media3 version 1.4.0 becasue transcoded output is not matching with input clip by 90%. Issue is comming due "Work around SurfaceTexture implicit scale" CL which crop the image buffer by 2 pixels from each dimension.

Change-Id: I7fad514674b6b6f529d79c9a29ef51cbabb8c232