### PR TITLE
Fix input type in `shortform` demo

### DIFF
--- a/demos/shortform/src/main/res/layout/activity_main.xml
+++ b/demos/shortform/src/main/res/layout/activity_main.xml
@@ -42,7 +42,7 @@
     android:background="@color/purple_700"
     android:gravity="center"
     android:hint="@string/num_of_players"
-    android:inputType="numberDecimal"
+    android:inputType="number"
     android:textColorHint="@color/grey" />
 
 </LinearLayout>


### PR DESCRIPTION
Currently, in the `shortform` demo, the `How Many Players?` input has the `numberDecimal` type. When parsing the value in `MainActivity.afterTextChanged()`, the app may crash if the provided value is a decimal.
This PR changes the input type to `number`, so it is no longer possible to provide a decimal value.