### PR TITLE
Incorporate injection of custom Executor to the eventual Loader

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ProgressiveMediaPeriod.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ProgressiveMediaPeriod.java
@@ -54,6 +54,7 @@ import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy.LoadErrorInfo;
 import androidx.media3.exoplayer.upstream.Loader;
 import androidx.media3.exoplayer.upstream.Loader.LoadErrorAction;
 import androidx.media3.exoplayer.upstream.Loader.Loadable;
+import androidx.media3.exoplayer.util.ReleasableExecutor;
 import androidx.media3.extractor.DiscardingTrackOutput;
 import androidx.media3.extractor.Extractor;
 import androidx.media3.extractor.ExtractorOutput;
@@ -70,7 +71,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Executor;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
@@ -173,8 +173,8 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
    * @param continueLoadingCheckIntervalBytes The number of bytes that should be loaded between each
    *     invocation of {@link Callback#onContinueLoadingRequested(SequenceableLoader)}.
    * @param singleSampleDurationUs The duration of media with a single sample in microseconds.
-   * @param downloadExecutor An optional externally provided {@link Executor} for loading and
-   *     extracting media.
+   * @param downloadExecutor An optional externally provided {@link ReleasableExecutor} for loading
+   *     and extracting media.
    */
   // maybeFinishPrepare is not posted to the handler until initialization completes.
   @SuppressWarnings({"nullness:argument", "nullness:methodref.receiver.bound"})
@@ -191,7 +191,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
       @Nullable String customCacheKey,
       int continueLoadingCheckIntervalBytes,
       long singleSampleDurationUs,
-      @Nullable Executor downloadExecutor) {
+      @Nullable ReleasableExecutor downloadExecutor) {
     this.uri = uri;
     this.dataSource = dataSource;
     this.drmSessionManager = drmSessionManager;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ProgressiveMediaPeriod.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ProgressiveMediaPeriod.java
@@ -70,6 +70,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
@@ -172,6 +173,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
    * @param continueLoadingCheckIntervalBytes The number of bytes that should be loaded between each
    *     invocation of {@link Callback#onContinueLoadingRequested(SequenceableLoader)}.
    * @param singleSampleDurationUs The duration of media with a single sample in microseconds.
+   * @param downloadExecutor An {@link Executor} for supplying the loader's thread.
    */
   // maybeFinishPrepare is not posted to the handler until initialization completes.
   @SuppressWarnings({"nullness:argument", "nullness:methodref.receiver.bound"})
@@ -187,7 +189,8 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
       Allocator allocator,
       @Nullable String customCacheKey,
       int continueLoadingCheckIntervalBytes,
-      long singleSampleDurationUs) {
+      long singleSampleDurationUs,
+      @Nullable Executor downloadExecutor) {
     this.uri = uri;
     this.dataSource = dataSource;
     this.drmSessionManager = drmSessionManager;
@@ -198,7 +201,8 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     this.allocator = allocator;
     this.customCacheKey = customCacheKey;
     this.continueLoadingCheckIntervalBytes = continueLoadingCheckIntervalBytes;
-    loader = new Loader("ProgressiveMediaPeriod");
+    loader = downloadExecutor != null ?
+        new Loader(downloadExecutor) : new Loader("ProgressiveMediaPeriod");
     this.progressiveMediaExtractor = progressiveMediaExtractor;
     this.singleSampleDurationUs = singleSampleDurationUs;
     loadCondition = new ConditionVariable();

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ProgressiveMediaPeriod.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ProgressiveMediaPeriod.java
@@ -173,7 +173,8 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
    * @param continueLoadingCheckIntervalBytes The number of bytes that should be loaded between each
    *     invocation of {@link Callback#onContinueLoadingRequested(SequenceableLoader)}.
    * @param singleSampleDurationUs The duration of media with a single sample in microseconds.
-   * @param downloadExecutor An {@link Executor} for supplying the loader's thread.
+   * @param downloadExecutor An optional externally provided {@link Executor} for loading and
+   *     extracting media.
    */
   // maybeFinishPrepare is not posted to the handler until initialization completes.
   @SuppressWarnings({"nullness:argument", "nullness:methodref.receiver.bound"})
@@ -201,8 +202,10 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     this.allocator = allocator;
     this.customCacheKey = customCacheKey;
     this.continueLoadingCheckIntervalBytes = continueLoadingCheckIntervalBytes;
-    loader = downloadExecutor != null ?
-        new Loader(downloadExecutor) : new Loader("ProgressiveMediaPeriod");
+    loader =
+        downloadExecutor != null
+            ? new Loader(downloadExecutor)
+            : new Loader("ProgressiveMediaPeriod");
     this.progressiveMediaExtractor = progressiveMediaExtractor;
     this.singleSampleDurationUs = singleSampleDurationUs;
     loadCondition = new ConditionVariable();

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ProgressiveMediaSource.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ProgressiveMediaSource.java
@@ -39,7 +39,6 @@ import androidx.media3.extractor.Extractor;
 import androidx.media3.extractor.ExtractorsFactory;
 import com.google.common.base.Supplier;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.util.Optional;
 import java.util.concurrent.Executor;
 
 /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ProgressiveMediaSource.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ProgressiveMediaSource.java
@@ -157,7 +157,6 @@ public final class ProgressiveMediaSource extends BaseMediaSource
       this.drmSessionManagerProvider = drmSessionManagerProvider;
       this.loadErrorHandlingPolicy = loadErrorHandlingPolicy;
       this.continueLoadingCheckIntervalBytes = continueLoadingCheckIntervalBytes;
-      this.downloadExecutor = () -> null;
     }
 
     @CanIgnoreReturnValue
@@ -202,11 +201,10 @@ public final class ProgressiveMediaSource extends BaseMediaSource
     }
 
     /**
-     * Sets a supplier that can return an {@link Executor} that is used for loading the media. This
-     * is useful if the loading thread needs to be externally managed.
+     * Sets a supplier for an {@link Executor} that is used for loading the media.
      *
-     * @param downloadExecutor a {@link Supplier<Executor>} that provides an externally managed
-     *                         {@link Executor} for downloading and extraction.
+     * @param downloadExecutor A {@link Supplier<Executor>} that provides an externally managed
+     *     {@link Executor} for downloading and extraction.
      * @return This factory, for convenience.
      */
     @CanIgnoreReturnValue

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/chunk/ChunkSampleStream.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/chunk/ChunkSampleStream.java
@@ -50,7 +50,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/chunk/ChunkSampleStream.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/chunk/ChunkSampleStream.java
@@ -120,46 +120,8 @@ public class ChunkSampleStream<T extends ChunkSource>
    *     events.
    * @param canReportInitialDiscontinuity Whether the stream can report an initial discontinuity if
    *     the first chunk can't start at the beginning and needs to preroll data.
-
-   */
-  public ChunkSampleStream(
-      @C.TrackType int primaryTrackType,
-      @Nullable int[] embeddedTrackTypes,
-      @Nullable Format[] embeddedTrackFormats,
-      T chunkSource,
-      Callback<ChunkSampleStream<T>> callback,
-      Allocator allocator,
-      long positionUs,
-      DrmSessionManager drmSessionManager,
-      DrmSessionEventListener.EventDispatcher drmEventDispatcher,
-      LoadErrorHandlingPolicy loadErrorHandlingPolicy,
-      MediaSourceEventListener.EventDispatcher mediaSourceEventDispatcher,
-      boolean canReportInitialDiscontinuity) {
-    this(primaryTrackType, embeddedTrackTypes, embeddedTrackFormats, chunkSource, callback,
-        allocator, positionUs, drmSessionManager, drmEventDispatcher, loadErrorHandlingPolicy,
-        mediaSourceEventDispatcher, canReportInitialDiscontinuity, null);
-  }
-
-  /**
-   * Constructs an instance.
-   *
-   * @param primaryTrackType The {@link C.TrackType type} of the primary track.
-   * @param embeddedTrackTypes The types of any embedded tracks, or null.
-   * @param embeddedTrackFormats The formats of the embedded tracks, or null.
-   * @param chunkSource A {@link ChunkSource} from which chunks to load are obtained.
-   * @param callback An {@link Callback} for the stream.
-   * @param allocator An {@link Allocator} from which allocations can be obtained.
-   * @param positionUs The position from which to start loading media.
-   * @param drmSessionManager The {@link DrmSessionManager} to obtain {@link DrmSession DrmSessions}
-   *     from.
-   * @param drmEventDispatcher A dispatcher to notify of {@link DrmSessionEventListener} events.
-   * @param loadErrorHandlingPolicy The {@link LoadErrorHandlingPolicy}.
-   * @param mediaSourceEventDispatcher A dispatcher to notify of {@link MediaSourceEventListener}
-   *     events.
-   * @param canReportInitialDiscontinuity Whether the stream can report an initial discontinuity if
-   *     the first chunk can't start at the beginning and needs to preroll data.
-   * @param downloadExecutor An {@link Executor} for supplying the loader's thread. If null,
-   *                         a default single thread executor is used.
+   * @param downloadExecutor An optional externally provided {@link Executor} for loading and
+   *     extracting media.
    */
   public ChunkSampleStream(
       @C.TrackType int primaryTrackType,
@@ -183,8 +145,8 @@ public class ChunkSampleStream<T extends ChunkSource>
     this.mediaSourceEventDispatcher = mediaSourceEventDispatcher;
     this.loadErrorHandlingPolicy = loadErrorHandlingPolicy;
     this.canReportInitialDiscontinuity = canReportInitialDiscontinuity;
-    loader = downloadExecutor != null ?
-        new Loader(downloadExecutor) : new Loader("ChunkSampleStream");
+    loader =
+        downloadExecutor != null ? new Loader(downloadExecutor) : new Loader("ChunkSampleStream");
     nextChunkHolder = new ChunkHolder();
     mediaChunks = new ArrayList<>();
     readOnlyMediaChunks = Collections.unmodifiableList(mediaChunks);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/chunk/ChunkSampleStream.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/chunk/ChunkSampleStream.java
@@ -45,11 +45,11 @@ import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy;
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy.LoadErrorInfo;
 import androidx.media3.exoplayer.upstream.Loader;
 import androidx.media3.exoplayer.upstream.Loader.LoadErrorAction;
+import androidx.media3.exoplayer.util.ReleasableExecutor;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Executor;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /**
@@ -120,8 +120,8 @@ public class ChunkSampleStream<T extends ChunkSource>
    *     events.
    * @param canReportInitialDiscontinuity Whether the stream can report an initial discontinuity if
    *     the first chunk can't start at the beginning and needs to preroll data.
-   * @param downloadExecutor An optional externally provided {@link Executor} for loading and
-   *     extracting media.
+   * @param downloadExecutor An optional externally provided {@link ReleasableExecutor} for loading
+   *     and extracting media.
    */
   public ChunkSampleStream(
       @C.TrackType int primaryTrackType,
@@ -136,7 +136,7 @@ public class ChunkSampleStream<T extends ChunkSource>
       LoadErrorHandlingPolicy loadErrorHandlingPolicy,
       MediaSourceEventListener.EventDispatcher mediaSourceEventDispatcher,
       boolean canReportInitialDiscontinuity,
-      @Nullable Executor downloadExecutor) {
+      @Nullable ReleasableExecutor downloadExecutor) {
     this.primaryTrackType = primaryTrackType;
     this.embeddedTrackTypes = embeddedTrackTypes == null ? new int[0] : embeddedTrackTypes;
     this.embeddedTrackFormats = embeddedTrackFormats == null ? new Format[0] : embeddedTrackFormats;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/ReleasableExecutor.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/ReleasableExecutor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.exoplayer.util;
+
+import androidx.media3.common.util.Consumer;
+import androidx.media3.common.util.UnstableApi;
+import java.util.concurrent.Executor;
+
+/**
+ * An {@link Executor} with a dedicated {@link #release} method to signal when it is not longer
+ * needed.
+ */
+@UnstableApi
+public interface ReleasableExecutor extends Executor {
+
+  /**
+   * Releases the {@link Executor}, indicating that the caller no longer requires it for executing
+   * new commands.
+   *
+   * <p>When calling this method, there may still be pending commands that are currently executed.
+   */
+  void release();
+
+  /**
+   * Creates a {@link ReleasableExecutor} from an {@link Executor} and a release callback.
+   *
+   * @param executor The {@link Executor}
+   * @param releaseCallback The release callback, accepting the {@code executor} as an argument.
+   * @return The releasable executor.
+   * @param <T> The type of {@link Executor}.
+   */
+  static <T extends Executor> ReleasableExecutor from(T executor, Consumer<T> releaseCallback) {
+    return new ReleasableExecutor() {
+      @Override
+      public void execute(Runnable command) {
+        executor.execute(command);
+      }
+
+      @Override
+      public void release() {
+        releaseCallback.accept(executor);
+      }
+    };
+  }
+}

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/source/ProgressiveMediaPeriodTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/source/ProgressiveMediaPeriodTest.java
@@ -86,13 +86,12 @@ public final class ProgressiveMediaPeriodTest {
   private static void testExtractorsUpdatesSourceInfoBeforeOnPreparedCallback(
       ProgressiveMediaExtractor extractor, long imageDurationUs) throws TimeoutException {
     testExtractorsUpdatesSourceInfoBeforeOnPreparedCallback(
-        extractor, imageDurationUs, null);
+        extractor, imageDurationUs, /* executor= */ null);
   }
 
   private static void testExtractorsUpdatesSourceInfoBeforeOnPreparedCallback(
-      ProgressiveMediaExtractor extractor,
-      long imageDurationUs,
-      @Nullable Executor executor) throws TimeoutException {
+      ProgressiveMediaExtractor extractor, long imageDurationUs, @Nullable Executor executor)
+      throws TimeoutException {
     AtomicBoolean sourceInfoRefreshCalled = new AtomicBoolean(false);
     ProgressiveMediaPeriod.Listener sourceInfoRefreshListener =
         (durationUs, isSeekable, isLive) -> sourceInfoRefreshCalled.set(true);
@@ -137,7 +136,7 @@ public final class ProgressiveMediaPeriodTest {
     assertThat(sourceInfoRefreshCalledBeforeOnPrepared.get()).isTrue();
   }
 
-  private class ExecutionTrackingThread extends Thread {
+  private static final class ExecutionTrackingThread extends Thread {
     private final AtomicBoolean hasRun;
 
     public ExecutionTrackingThread(Runnable runnable, AtomicBoolean hasRun) {

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaPeriod.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaPeriod.java
@@ -837,7 +837,8 @@ import java.util.regex.Pattern;
             drmEventDispatcher,
             loadErrorHandlingPolicy,
             mediaSourceEventDispatcher,
-            canReportInitialDiscontinuity);
+            canReportInitialDiscontinuity,
+            /* downloadExecutor= */ null);
     synchronized (this) {
       // The map is also accessed on the loading thread so synchronize access.
       trackEmsgHandlerBySampleStream.put(stream, trackPlayerEmsgHandler);

--- a/libraries/exoplayer_smoothstreaming/src/main/java/androidx/media3/exoplayer/smoothstreaming/SsMediaPeriod.java
+++ b/libraries/exoplayer_smoothstreaming/src/main/java/androidx/media3/exoplayer/smoothstreaming/SsMediaPeriod.java
@@ -265,7 +265,8 @@ import java.util.List;
         drmEventDispatcher,
         loadErrorHandlingPolicy,
         mediaSourceEventDispatcher,
-        /* canReportInitialDiscontinuity= */ false);
+        /* canReportInitialDiscontinuity= */ false,
+        /* downloadExecutor= */ null);
   }
 
   private static TrackGroupArray buildTrackGroups(

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/FakeAdaptiveMediaPeriod.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/FakeAdaptiveMediaPeriod.java
@@ -188,7 +188,8 @@ public class FakeAdaptiveMediaPeriod
                 new DrmSessionEventListener.EventDispatcher(),
                 new DefaultLoadErrorHandlingPolicy(/* minimumLoadableRetryCount= */ 3),
                 mediaSourceEventDispatcher,
-                /* canReportInitialDiscontinuity= */ false);
+                /* canReportInitialDiscontinuity= */ false,
+                /* downloadExecutor= */ null);
         streams[i] = sampleStream;
         sampleStreams.add(sampleStream);
         streamResetFlags[i] = true;


### PR DESCRIPTION
This is enabled for ChunkSampleStream and ProgressiveMediaSource