### PR TITLE
Fix: Update the Default value for the keep alive session.

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSessionManager.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSessionManager.java
@@ -297,7 +297,7 @@ public class DefaultDrmSessionManager implements DrmSessionManager {
   public static final int INITIAL_DRM_REQUEST_RETRY_COUNT = 3;
 
   /** Default value for {@link Builder#setSessionKeepaliveMs(long)}. */
-  public static final long DEFAULT_SESSION_KEEPALIVE_MS = 5 * 60 * C.MILLIS_PER_SECOND;
+  public static final long DEFAULT_SESSION_KEEPALIVE_MS = 8 * 60 * C.MILLIS_PER_SECOND;
 
   private static final String TAG = "DefaultDrmSessionMgr";
 


### PR DESCRIPTION
We saw that period can be more then 5 minutes resulting in a deletion of the session 
By default we should have a bigger value to avoid to delete it
