### PR TITLE
Specify androidx.activity:activity-compose as 1.9.0

### DIFF
--- a/demos/effect/build.gradle
+++ b/demos/effect/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     def composeBom = platform('androidx.compose:compose-bom:2024.10.00')
     implementation composeBom
 
-    implementation 'androidx.activity:activity-compose'
+    implementation 'androidx.activity:activity-compose:1.9.0'
     implementation 'androidx.compose.foundation:foundation'
     implementation 'androidx.compose.material3:material3'
     implementation 'com.google.android.material:material:' + androidxMaterialVersion


### PR DESCRIPTION
The Compose BOM doesn't provide this.
https://developer.android.com/develop/ui/compose/bom/bom-mapping

```
Failed to resolve: androidx.activity:activity-compose
```