### PR TITLE
Make MediaCodecVideoRenderer::shouldUsePlaceholderSurface protected.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,6 +11,10 @@
 *   Audio:
     *   Make `androidx.media3.common.audio.SonicAudioProcessor` final.
 *   Video:
+    *   Change `MediaCodecVideoRenderer.shouldUsePlaceholderSurface` to
+        protected so that applications can override to block usage of
+        placeholder surfaces
+        ([#1905](https://github.com/androidx/media/pull/1905)).
 *   Text:
 *   Metadata:
 *   Image:

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1882,7 +1882,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     return Util.SDK_INT >= 35 && codecInfo.detachedSurfaceSupported;
   }
 
-  private boolean shouldUsePlaceholderSurface(MediaCodecInfo codecInfo) {
+  protected boolean shouldUsePlaceholderSurface(MediaCodecInfo codecInfo) {
     return Util.SDK_INT >= 23
         && !tunneling
         && !codecNeedsSetOutputSurfaceWorkaround(codecInfo.name)


### PR DESCRIPTION
This enables a derived renderer to disable the placeholder surface.

Not having a placeholder surface allows to delay instantiating the codecs until we have a surface. This allows to have more players ready without having their decoders loaded.

This follows the mode that `shouldUseDetachedSurface` is protected and overridable by a derived class.

Since `getSurfaceForCodec` must call `hasSurfaceForCodec`, the check for the placeholder surface in `getSurfaceForCodec` should not trigger if we disable the placeholder surface as `hasSurfaceForCodec` would have returned false.