### PR TITLE
fix: prevent infinite loop causing stream freeze in DASH multi-period streams

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -26,6 +26,8 @@
 *   RTMP Extension:
 *   HLS Extension:
 *   DASH Extension:
+    *   Fix issue when calculating the update interval for ad insertion in multi-period live streams
+        ([#1698](https://github.com/androidx/media/issues/1698)).
 *   Smooth Streaming Extension:
 *   RTSP Extension:
 *   Decoder Extensions (FFmpeg, VP9, AV1, etc.):

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaSource.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaSource.java
@@ -1151,8 +1151,9 @@ public final class DashMediaSource extends BaseMediaSource {
                 + index.getNextSegmentAvailableTimeUs(periodDurationUs, nowUnixTimeUs);
         long requiredIntervalUs = nextSegmentShiftUnixTimeUs - nowUnixTimeUs;
         // Avoid multiple refreshes within a very small amount of time.
-        if (requiredIntervalUs < intervalUs - 100_000
-            || (requiredIntervalUs > intervalUs && requiredIntervalUs < intervalUs + 100_000)) {
+        if ((requiredIntervalUs < intervalUs - 100_000
+            || (requiredIntervalUs > intervalUs && requiredIntervalUs < intervalUs + 100_000) )
+            && requiredIntervalUs >0) {
           intervalUs = requiredIntervalUs;
         }
       }


### PR DESCRIPTION
- Added a condition to ensure `requiredIntervalUs > 0` in `DashMediaSource`.
- Resolves an issue where negative `requiredIntervalUs` triggered an infinite loop in `onPlaylistUpdateRequested()`, leading to application/stream freezes.

This fix restores smooth playback for multi-period DASH streams.

This fixes #1698.