### PR TITLE
Check out dumps with LF line endings, matches Dumper

### DIFF
--- a/libraries/test_data/.gitattributes
+++ b/libraries/test_data/.gitattributes
@@ -1,0 +1,1 @@
+*.dump text eol=lf


### PR DESCRIPTION
Fix for tests using dumps on Windows with Git set to use `core.autocrlf=true`. Tests are expecting LF, but the files after checkout are with CRLF.

This fix sets that the dumps will be checked out with LF.