### PR TITLE
Add MediaCodecInfo to MediaCodecRenderer::onReadyToInitializeCodec

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -30,6 +30,9 @@
     *   Enable sending `CmcdData` for manifest requests in adaptive streaming
         formats DASH, HLS, and SmoothStreaming
         ([#1951](https://github.com/androidx/media/issues/1951)).
+    *   Provide `MediaCodecInfo` of the codec that will be initialized in
+        `MediaCodecRenderer.onReadyToInitializeCodec`
+        ([#1963](https://github.com/androidx/media/pull/1963)).
 *   Transformer:
     *   Update parameters of `VideoFrameProcessor.registerInputStream` and
         `VideoFrameProcessor.Listener.onInputStreamRegistered` to use `Format`.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -1495,7 +1495,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
    *
    * <p>The default implementation is a no-op.
    *
-   * @param codecInfo The {@link MediaCodecInfo} the codec which is being configured.
+   * @param codecInfo The {@link MediaCodecInfo} of the codec which will be initialized.
    * @param format The {@link Format} for which the codec is being configured.
    * @throws ExoPlaybackException If an error occurs preparing for initializing the codec.
    */

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -1216,7 +1216,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     if (codecOperatingRate <= assumedMinimumCodecOperatingRate) {
       codecOperatingRate = CODEC_OPERATING_RATE_UNSET;
     }
-    onReadyToInitializeCodec(inputFormat);
+    onReadyToInitializeCodec(codecInfo, inputFormat);
     codecInitializingTimestamp = getClock().elapsedRealtime();
     MediaCodecAdapter.Configuration configuration =
         getMediaCodecConfiguration(codecInfo, inputFormat, crypto, codecOperatingRate);
@@ -1495,10 +1495,11 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
    *
    * <p>The default implementation is a no-op.
    *
+   * @param codecInfo The {@link MediaCodecInfo} the codec which is being configured.
    * @param format The {@link Format} for which the codec is being configured.
    * @throws ExoPlaybackException If an error occurs preparing for initializing the codec.
    */
-  protected void onReadyToInitializeCodec(Format format) throws ExoPlaybackException {
+  protected void onReadyToInitializeCodec(MediaCodecInfo codecInfo, Format format) throws ExoPlaybackException {
     // Do nothing.
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -1499,7 +1499,8 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
    * @param format The {@link Format} for which the codec is being configured.
    * @throws ExoPlaybackException If an error occurs preparing for initializing the codec.
    */
-  protected void onReadyToInitializeCodec(MediaCodecInfo codecInfo, Format format) throws ExoPlaybackException {
+  protected void onReadyToInitializeCodec(MediaCodecInfo codecInfo, Format format)
+      throws ExoPlaybackException {
     // Do nothing.
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1214,7 +1214,8 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
 
   @CallSuper
   @Override
-  protected void onReadyToInitializeCodec(MediaCodecInfo codecInfo, Format format) throws ExoPlaybackException {
+  protected void onReadyToInitializeCodec(MediaCodecInfo codecInfo, Format format)
+      throws ExoPlaybackException {
     if (videoSink != null && !videoSink.isInitialized()) {
       try {
         videoSink.initialize(format);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1214,7 +1214,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
 
   @CallSuper
   @Override
-  protected void onReadyToInitializeCodec(Format format) throws ExoPlaybackException {
+  protected void onReadyToInitializeCodec(MediaCodecInfo codecInfo, Format format) throws ExoPlaybackException {
     if (videoSink != null && !videoSink.isInitialized()) {
       try {
         videoSink.initialize(format);

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/ExperimentalFrameExtractor.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/ExperimentalFrameExtractor.java
@@ -78,6 +78,7 @@ import androidx.media3.exoplayer.Renderer;
 import androidx.media3.exoplayer.SeekParameters;
 import androidx.media3.exoplayer.analytics.AnalyticsListener;
 import androidx.media3.exoplayer.mediacodec.MediaCodecAdapter;
+import androidx.media3.exoplayer.mediacodec.MediaCodecInfo;
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector;
 import androidx.media3.exoplayer.source.MediaSource;
 import androidx.media3.exoplayer.video.MediaCodecVideoRenderer;
@@ -662,12 +663,12 @@ public final class ExperimentalFrameExtractor {
 
     @CallSuper
     @Override
-    protected void onReadyToInitializeCodec(Format format) throws ExoPlaybackException {
+    protected void onReadyToInitializeCodec(MediaCodecInfo codecInfo, Format format) throws ExoPlaybackException {
       if (isTransferHdr(format.colorInfo) && toneMapHdrToSdr) {
         // Setting the VideoSink format to SDR_BT709_LIMITED tone maps to SDR.
         format = format.buildUpon().setColorInfo(SDR_BT709_LIMITED).build();
       }
-      super.onReadyToInitializeCodec(format);
+      super.onReadyToInitializeCodec(codecInfo, format);
     }
 
     @Override

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/ExperimentalFrameExtractor.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/ExperimentalFrameExtractor.java
@@ -663,7 +663,8 @@ public final class ExperimentalFrameExtractor {
 
     @CallSuper
     @Override
-    protected void onReadyToInitializeCodec(MediaCodecInfo codecInfo, Format format) throws ExoPlaybackException {
+    protected void onReadyToInitializeCodec(MediaCodecInfo codecInfo, Format format)
+        throws ExoPlaybackException {
       if (isTransferHdr(format.colorInfo) && toneMapHdrToSdr) {
         // Setting the VideoSink format to SDR_BT709_LIMITED tone maps to SDR.
         format = format.buildUpon().setColorInfo(SDR_BT709_LIMITED).build();


### PR DESCRIPTION
This adds the MediaCodecInfo to the `onReadyToInitializeCodec` to allow for renderers to know which codec is being initialize, not only which format the codec will be initialized for. With multiple codecs supporting a format, knowing which one is being used would be helpful.