### PR TITLE
Update LegacyConversions.java

### DIFF
--- a/libraries/session/src/main/java/androidx/media3/session/LegacyConversions.java
+++ b/libraries/session/src/main/java/androidx/media3/session/LegacyConversions.java
@@ -846,8 +846,8 @@ import java.util.concurrent.TimeoutException;
     CharSequence title;
     CharSequence subtitle;
     CharSequence description;
-    if (metadata.displayTitle != null) {
-      title = metadata.displayTitle;
+    if (metadata.title != null) {
+      title = metadata.title;
       subtitle = metadata.subtitle;
       description = metadata.description;
       if (extras == null) {


### PR DESCRIPTION
I have fixed a possible bug when mixing displayTitle with title which causes displayTitle to appear when displayTitle should appear in legacy MediaControllers.