### PR TITLE
Add support for TTML origin and extent attributes defined in style instead of region

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/ttml/TtmlNode.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/ttml/TtmlNode.java
@@ -53,6 +53,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
   public static final String ANONYMOUS_REGION_ID = "";
   public static final String ATTR_ID = "id";
+  public static final String ATTR_STYLE = "style";
   public static final String ATTR_TTS_ORIGIN = "origin";
   public static final String ATTR_TTS_EXTENT = "extent";
   public static final String ATTR_TTS_DISPLAY_ALIGN = "displayAlign";

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/ttml/TtmlParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/ttml/TtmlParser.java
@@ -315,7 +315,7 @@ public final class TtmlParser implements SubtitleParser {
           globalStyles.put(styleId, style);
         }
       } else if (XmlPullParserUtil.isStartTag(xmlParser, TtmlNode.TAG_REGION)) {
-        @Nullable TtmlRegion ttmlRegion = parseRegionAttributes(xmlParser, cellRows, ttsExtent);
+        @Nullable TtmlRegion ttmlRegion = parseRegionAttributes(xmlParser, cellRows, ttsExtent, globalStyles);
         if (ttmlRegion != null) {
           globalRegions.put(ttmlRegion.id, ttmlRegion);
         }
@@ -350,7 +350,8 @@ public final class TtmlParser implements SubtitleParser {
    */
   @Nullable
   private static TtmlRegion parseRegionAttributes(
-      XmlPullParser xmlParser, int cellRows, @Nullable TtsExtent ttsExtent) {
+      XmlPullParser xmlParser, int cellRows, @Nullable TtsExtent ttsExtent,
+      Map<String, TtmlStyle> globalStyles) {
     @Nullable String regionId = XmlPullParserUtil.getAttributeValue(xmlParser, TtmlNode.ATTR_ID);
     if (regionId == null) {
       return null;
@@ -361,6 +362,15 @@ public final class TtmlParser implements SubtitleParser {
 
     @Nullable
     String regionOrigin = XmlPullParserUtil.getAttributeValue(xmlParser, TtmlNode.ATTR_TTS_ORIGIN);
+    if (regionOrigin == null) {
+      String styleId = XmlPullParserUtil.getAttributeValue(xmlParser, TtmlNode.ATTR_STYLE);
+      if (styleId != null) {
+        TtmlStyle style = globalStyles.get(styleId);
+        if (style != null) {
+          regionOrigin = style.getOrigin();
+        }
+      }
+    }
     if (regionOrigin != null) {
       Matcher originPercentageMatcher = PERCENTAGE_COORDINATES.matcher(regionOrigin);
       Matcher originPixelMatcher = PIXEL_COORDINATES.matcher(regionOrigin);
@@ -406,6 +416,15 @@ public final class TtmlParser implements SubtitleParser {
     float height;
     @Nullable
     String regionExtent = XmlPullParserUtil.getAttributeValue(xmlParser, TtmlNode.ATTR_TTS_EXTENT);
+    if (regionExtent == null) {
+      String styleId = XmlPullParserUtil.getAttributeValue(xmlParser, TtmlNode.ATTR_STYLE);
+      if (styleId != null) {
+        TtmlStyle style = globalStyles.get(styleId);
+        if (style != null) {
+          regionExtent = style.getExtent();
+        }
+      }
+    }
     if (regionExtent != null) {
       Matcher extentPercentageMatcher = PERCENTAGE_COORDINATES.matcher(regionExtent);
       Matcher extentPixelMatcher = PIXEL_COORDINATES.matcher(regionExtent);
@@ -625,6 +644,12 @@ public final class TtmlParser implements SubtitleParser {
           break;
         case TtmlNode.ATTR_TTS_SHEAR:
           style = createIfNull(style).setShearPercentage(parseShear(attributeValue));
+          break;
+        case TtmlNode.ATTR_TTS_ORIGIN:
+          style = createIfNull(style).setOrigin(attributeValue);
+          break;
+        case TtmlNode.ATTR_TTS_EXTENT:
+          style = createIfNull(style).setExtent(attributeValue);
           break;
         default:
           // ignore

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/ttml/TtmlStyle.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/ttml/TtmlStyle.java
@@ -96,6 +96,8 @@ import java.lang.annotation.Target;
   private @OptionalBoolean int textCombine;
   @Nullable private TextEmphasis textEmphasis;
   private float shearPercentage;
+  @Nullable private String origin;
+  @Nullable private String extent;
 
   public TtmlStyle() {
     linethrough = UNSPECIFIED;
@@ -277,6 +279,12 @@ import java.lang.annotation.Target;
       if (shearPercentage == UNSPECIFIED_SHEAR) {
         shearPercentage = ancestor.shearPercentage;
       }
+      if (origin == null) {
+        origin = ancestor.origin;
+      }
+      if (extent == null) {
+        extent = ancestor.extent;
+      }
       // attributes not inherited as of http://www.w3.org/TR/ttml1/
       if (chaining && !hasBackgroundColor && ancestor.hasBackgroundColor) {
         setBackgroundColor(ancestor.backgroundColor);
@@ -381,5 +389,27 @@ import java.lang.annotation.Target;
 
   public float getFontSize() {
     return fontSize;
+  }
+
+  @CanIgnoreReturnValue
+  public TtmlStyle setOrigin(@Nullable String origin) {
+    this.origin = origin;
+    return this;
+  }
+
+  @Nullable
+  public String getOrigin() {
+    return origin;
+  }
+
+  @CanIgnoreReturnValue
+  public TtmlStyle setExtent(@Nullable String extent) {
+    this.extent = extent;
+    return this;
+  }
+
+  @Nullable
+  public String getExtent() {
+    return extent;
   }
 }


### PR DESCRIPTION
Hello,

This adds support for  `tts:origin` and/or `tts:extent` attributes  defined in `style` instead of `region`. This issue has been quoted long time ago by @ojw28 in https://github.com/google/ExoPlayer/issues/2953#issuecomment-308792801

Here is an example of a sequence of 3 TTML subtitles which change the position of origin and extent, resulting on a jump of subtitles when the 2nd subtitle in on screen:

1. origin & extent are defined in region
```xml
<tt
	xmlns="http://www.w3.org/ns/ttml"
	xmlns:tts="http://www.w3.org/ns/ttml#styling" xml:lang="">
	<head>
		<styling>
			<style xml:id="speakerStyle" tts:fontFamily="proportionalSansSerif" tts:fontSize="0.68c" tts:backgroundColor="transparent" tts:displayAlign="after" tts:color="white" tts:textOutline="black 2px" />
		</styling>
		<layout>
			<region xml:id="speaker_1" tts:origin="10% 60%" tts:extent="80% 35%" tts:textAlign="center" style="speakerStyle" tts:zIndex="1" />
			<region xml:id="speaker_2" tts:origin="12% 80%" tts:extent="75% 16%" tts:textAlign="center" style="speakerStyle" tts:zIndex="1" />
		</layout>
	</head>
	<body>
		<div>
			<p begin="87327:40:41.026" end="87327:40:41.186" region="speaker_1"></p>
			<p begin="87327:40:41.186" end="87327:40:43.026" region="speaker_2">
				<span tts:color="cyan" tts:fontStyle="normal" tts:fontWeight="normal" tts:textDecoration="none">C&apos;est un réservoir d&apos;eau douce,</span>
				<br />
				<span tts:color="cyan" tts:fontStyle="normal" tts:fontWeight="normal" tts:textDecoration="none">bien utile pour les Inuits.</span>
			</p>
		</div>
	</body>
</tt>
```

2. origin & extent are defined in style
```xml
<?xml version="1.0" encoding="utf-8"?>
<tt
	xmlns="http://www.w3.org/ns/ttml"
	xmlns:tts="http://www.w3.org/ns/ttml#styling" xml:lang="">
	<head>
		<styling>
			<style xml:id="speakerStyle" tts:fontFamily="proportionalSansSerif" tts:fontSize="0.68c" tts:origin="12% 80%" tts:extent="75% 16%" tts:textAlign="center" tts:backgroundColor="transparent" tts:displayAlign="after" tts:color="white" tts:textOutline="black 2px" />
		</styling>
		<layout>
			<region xml:id="speaker" style="speakerStyle" tts:zIndex="1" />
		</layout>
	</head>
	<body>
		<div>
			<p begin="87327:40:43.026" end="87327:40:45.026" region="speaker">
				<span tts:color="cyan" tts:fontStyle="normal" tts:fontWeight="normal" tts:textDecoration="none">C&apos;est un réservoir d&apos;eau douce,</span>
				<br />
				<span tts:color="cyan" tts:fontStyle="normal" tts:fontWeight="normal" tts:textDecoration="none">bien utile pour les Inuits.</span>
			</p>
		</div>
	</body>
</tt>
```

3. origin & extent are defined again in region
```xml
<?xml version="1.0" encoding="utf-8"?>
<tt
	xmlns="http://www.w3.org/ns/ttml"
	xmlns:tts="http://www.w3.org/ns/ttml#styling" xml:lang="">
	<head>
		<styling>
			<style xml:id="speakerStyle" tts:fontFamily="proportionalSansSerif" tts:fontSize="0.68c" tts:backgroundColor="transparent" tts:displayAlign="after" tts:color="white" tts:textOutline="black 2px" />
		</styling>
		<layout>
			<region xml:id="speaker_1" tts:origin="12% 80%" tts:extent="75% 16%" tts:textAlign="center" style="speakerStyle" tts:zIndex="1" />
			<region xml:id="speaker_2" tts:origin="10% 60%" tts:extent="80% 35%" tts:textAlign="center" style="speakerStyle" tts:zIndex="1" />
			<region xml:id="speaker_3" tts:origin="9% 80%" tts:extent="80% 16%" tts:textAlign="center" style="speakerStyle" tts:zIndex="1" />
		</layout>
	</head>
	<body>
		<div>
			<p begin="87327:40:45.026" end="87327:40:45.706" region="speaker_1">
				<span tts:color="cyan" tts:fontStyle="normal" tts:fontWeight="normal" tts:textDecoration="none">C&apos;est un réservoir d&apos;eau douce,</span>
				<br />
				<span tts:color="cyan" tts:fontStyle="normal" tts:fontWeight="normal" tts:textDecoration="none">bien utile pour les Inuits.</span>
			</p>
			<p begin="87327:40:45.706" end="87327:40:46.066" region="speaker_2"></p>
			<p begin="87327:40:46.066" end="87327:40:47.026" region="speaker_3">
				<span tts:color="green" tts:fontStyle="normal" tts:fontWeight="normal" tts:textDecoration="none">-On va enlever la 1re couche.</span>
				<br />
				<span tts:color="green" tts:fontStyle="normal" tts:fontWeight="normal" tts:textDecoration="none">La glace sera meilleure, dessous.</span>
			</p>
		</div>
	</body>
</tt>
```

Note that this fix works only if styles are defined before regions.