### PR TITLE
DrmSession Caching Proposal

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DrmSessionManager.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DrmSessionManager.java
@@ -95,6 +95,14 @@ public interface DrmSessionManager {
   void setPlayer(Looper playbackLooper, PlayerId playerId);
 
   /**
+   * Releases all the aquired resources if default is set to preserve keepAlive on {@link
+   * #release()}. This is called from the Activity's onStop()
+   */
+  default void releaseAllSessions() {
+    // Do nothing.
+  }
+
+  /**
    * Pre-acquires a DRM session for the specified {@link Format}.
    *
    * <p>This notifies the manager that a subsequent call to {@link #acquireSession(


### PR DESCRIPTION
This series of commits implements extending the functionality of the `DefaultDrmSessionManagersetSessionKeepaliveMs()` to allow keeping open `MediaDrm` sessions beyond the live time of any one `MediaSource`

Our fork of ExoPlayer is using this implementation to support a large live channel lineup while reducing the tune load on the DRM License Server significantly (we see hit ratios over 50% on AmLogic hardware).

The related issue Is #2048 

One improvement would be to add a "player release listener" API to ExoPlayer to allow automatically calling the `releaseAllSessions()` method on `DefaultDrmSessionManager` rather than requiring the application to do this manually.
