### PR TITLE
Fix ALPHA_8 format support for bitmap in Cue.

### DIFF
--- a/libraries/common/src/androidTest/java/androidx/media3/common/text/CueTest.java
+++ b/libraries/common/src/androidTest/java/androidx/media3/common/text/CueTest.java
@@ -1,0 +1,31 @@
+package androidx.media3.common.text;
+
+import static com.google.common.truth.Truth.assertThat;
+import android.graphics.Bitmap;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Tests for {@link Cue}. */
+@RunWith(AndroidJUnit4.class)
+public class CueTest {
+
+   @Test
+   public void roundTripViaSerializableBundle_withBitmapAlpha8_yieldsEqualInstance() {
+      Bitmap bitmap = Bitmap.createBitmap(8, 8, Bitmap.Config.ALPHA_8);
+      byte[] bytes = new byte[bitmap.getWidth() * bitmap.getHeight()];
+      for (byte i = 0; i < bytes.length; i++) {
+         bytes[i] = i;
+      }
+      Buffer buffer = ByteBuffer.wrap(bytes);
+      bitmap.copyPixelsFromBuffer(buffer);
+      Cue cue =
+          new Cue.Builder().setBitmap(bitmap).build();
+      Cue modifiedCue = Cue.fromBundle(cue.toSerializableBundle());
+
+      assertThat(modifiedCue).isEqualTo(cue);
+   }
+
+}


### PR DESCRIPTION
Bitmap.compress not support ALPHA_8 format, so we just copy the pixel buffer.

This should fix #2054 