### PR TITLE
Deprecate `Util.DEVICE`, `Util.MANUFACTURER` and `Util.MODEL`

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/GlUtil.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/GlUtil.java
@@ -33,6 +33,7 @@ import android.opengl.GLES20;
 import android.opengl.GLES30;
 import android.opengl.GLUtils;
 import android.opengl.Matrix;
+import android.os.Build;
 import androidx.annotation.IntRange;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -170,7 +171,8 @@ public final class GlUtil {
     if (Util.SDK_INT < 24) {
       return false;
     }
-    if (Util.SDK_INT < 26 && ("samsung".equals(Util.MANUFACTURER) || "XT1650".equals(Util.MODEL))) {
+    if (Util.SDK_INT < 26
+        && ("samsung".equals(Build.MANUFACTURER) || "XT1650".equals(Util.MODEL))) {
       // Samsung devices running Nougat are known to be broken. See
       // https://github.com/google/ExoPlayer/issues/3373 and [Internal: b/37197802].
       // Moto Z XT1650 is also affected. See

--- a/libraries/common/src/main/java/androidx/media3/common/util/GlUtil.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/GlUtil.java
@@ -172,7 +172,7 @@ public final class GlUtil {
       return false;
     }
     if (Util.SDK_INT < 26
-        && ("samsung".equals(Build.MANUFACTURER) || "XT1650".equals(Util.MODEL))) {
+        && ("samsung".equals(Build.MANUFACTURER) || "XT1650".equals(Build.MODEL))) {
       // Samsung devices running Nougat are known to be broken. See
       // https://github.com/google/ExoPlayer/issues/3373 and [Internal: b/37197802].
       // Moto Z XT1650 is also affected. See

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -170,17 +170,14 @@ public final class Util {
   @UnstableApi @Deprecated public static final String MANUFACTURER = Build.MANUFACTURER;
 
   /**
-   * Like {@link Build#MODEL}, but in a place where it can be conveniently overridden for local
-   * testing.
+   * @deprecated Use {@link Build#MODEL} instead.
    */
-  // TODO: b/384699964 - Deprecate this and migrate usages to Build.MODEL which works better with
-  //  Robolectric's ShadowBuild.setModel().
-  @UnstableApi public static final String MODEL = Build.MODEL;
+  @UnstableApi @Deprecated public static final String MODEL = Build.MODEL;
 
   /** A concise description of the device that it can be useful to log for debugging purposes. */
   @UnstableApi
   public static final String DEVICE_DEBUG_INFO =
-      Build.DEVICE + ", " + MODEL + ", " + Build.MANUFACTURER + ", " + SDK_INT;
+      Build.DEVICE + ", " + Build.MODEL + ", " + Build.MANUFACTURER + ", " + SDK_INT;
 
   /** An empty byte array. */
   @UnstableApi public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
@@ -3240,7 +3237,7 @@ public final class Util {
 
       // Sony Android TVs advertise support for 4k output via a system feature.
       if ("Sony".equals(Build.MANUFACTURER)
-          && MODEL.startsWith("BRAVIA")
+          && Build.MODEL.startsWith("BRAVIA")
           && context.getPackageManager().hasSystemFeature("com.sony.dtv.hardware.panel.qfhd")) {
         return new Point(3840, 2160);
       }
@@ -3489,9 +3486,9 @@ public final class Util {
     return SDK_INT < 29
         || context.getApplicationInfo().targetSdkVersion < 29
         || ((SDK_INT == 30
-                && (Ascii.equalsIgnoreCase(MODEL, "moto g(20)")
-                    || Ascii.equalsIgnoreCase(MODEL, "rmx3231")))
-            || (SDK_INT == 34 && Ascii.equalsIgnoreCase(MODEL, "sm-x200")));
+                && (Ascii.equalsIgnoreCase(Build.MODEL, "moto g(20)")
+                    || Ascii.equalsIgnoreCase(Build.MODEL, "rmx3231")))
+            || (SDK_INT == 34 && Ascii.equalsIgnoreCase(Build.MODEL, "sm-x200")));
   }
 
   /**

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -165,12 +165,9 @@ public final class Util {
   @UnstableApi @Deprecated public static final String DEVICE = Build.DEVICE;
 
   /**
-   * Like {@link Build#MANUFACTURER}, but in a place where it can be conveniently overridden for
-   * local testing.
+   * @deprecated Use {@link Build#MANUFACTURER} instead.
    */
-  // TODO: b/384699964 - Deprecate this and migrate usages to Build.MANUFACTURER which works better
-  //  with Robolectric's ShadowBuild.setManufacturer().
-  @UnstableApi public static final String MANUFACTURER = Build.MANUFACTURER;
+  @UnstableApi @Deprecated public static final String MANUFACTURER = Build.MANUFACTURER;
 
   /**
    * Like {@link Build#MODEL}, but in a place where it can be conveniently overridden for local
@@ -183,7 +180,7 @@ public final class Util {
   /** A concise description of the device that it can be useful to log for debugging purposes. */
   @UnstableApi
   public static final String DEVICE_DEBUG_INFO =
-      Build.DEVICE + ", " + MODEL + ", " + MANUFACTURER + ", " + SDK_INT;
+      Build.DEVICE + ", " + MODEL + ", " + Build.MANUFACTURER + ", " + SDK_INT;
 
   /** An empty byte array. */
   @UnstableApi public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
@@ -3242,7 +3239,7 @@ public final class Util {
       }
 
       // Sony Android TVs advertise support for 4k output via a system feature.
-      if ("Sony".equals(MANUFACTURER)
+      if ("Sony".equals(Build.MANUFACTURER)
           && MODEL.startsWith("BRAVIA")
           && context.getPackageManager().hasSystemFeature("com.sony.dtv.hardware.panel.qfhd")) {
         return new Point(3840, 2160);

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -160,12 +160,9 @@ public final class Util {
   @UnstableApi public static final int SDK_INT = Build.VERSION.SDK_INT;
 
   /**
-   * Like {@link Build#DEVICE}, but in a place where it can be conveniently overridden for local
-   * testing.
+   * @deprecated Use {@link Build#DEVICE} instead.
    */
-  // TODO: b/384699964 - Deprecate this and migrate usages to Build.DEVICE which works better with
-  //  Robolectric's ShadowBuild.setDevice().
-  @UnstableApi public static final String DEVICE = Build.DEVICE;
+  @UnstableApi @Deprecated public static final String DEVICE = Build.DEVICE;
 
   /**
    * Like {@link Build#MANUFACTURER}, but in a place where it can be conveniently overridden for
@@ -186,7 +183,7 @@ public final class Util {
   /** A concise description of the device that it can be useful to log for debugging purposes. */
   @UnstableApi
   public static final String DEVICE_DEBUG_INFO =
-      DEVICE + ", " + MODEL + ", " + MANUFACTURER + ", " + SDK_INT;
+      Build.DEVICE + ", " + MODEL + ", " + MANUFACTURER + ", " + SDK_INT;
 
   /** An empty byte array. */
   @UnstableApi public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
@@ -482,7 +479,7 @@ public final class Util {
   /** Returns true if the code path is currently running on an emulator. */
   @UnstableApi
   public static boolean isRunningOnEmulator() {
-    String deviceName = Ascii.toLowerCase(Util.DEVICE);
+    String deviceName = Ascii.toLowerCase(Build.DEVICE);
     return deviceName.contains("emulator")
         || deviceName.contains("emu64a")
         || deviceName.contains("emu64x")

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -387,7 +387,7 @@ public final class AudioCapabilities {
 
     // Workaround for Nexus Player not reporting support for mono passthrough. See
     // [Internal: b/34268671].
-    if (Util.SDK_INT <= 26 && "fugu".equals(Util.DEVICE) && channelCount == 1) {
+    if (Util.SDK_INT <= 26 && "fugu".equals(Build.DEVICE) && channelCount == 1) {
       channelCount = 2;
     }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
@@ -1059,7 +1059,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
    */
   private static boolean deviceDoesntSupportOperatingRate() {
     return Util.SDK_INT == 23
-        && ("ZTE B2017G".equals(Util.MODEL) || "AXON 7 mini".equals(Util.MODEL));
+        && ("ZTE B2017G".equals(Build.MODEL) || "AXON 7 mini".equals(Build.MODEL));
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
@@ -1072,7 +1072,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
     // The workaround applies to Samsung Galaxy S6 and Samsung Galaxy S7.
     return Util.SDK_INT < 24
         && "OMX.SEC.aac.dec".equals(codecName)
-        && "samsung".equals(Util.MANUFACTURER)
+        && "samsung".equals(Build.MANUFACTURER)
         && (Build.DEVICE.startsWith("zeroflte")
             || Build.DEVICE.startsWith("herolte")
             || Build.DEVICE.startsWith("heroqlte"));

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
@@ -28,6 +28,7 @@ import android.media.AudioFormat;
 import android.media.MediaCodec;
 import android.media.MediaCrypto;
 import android.media.MediaFormat;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import androidx.annotation.CallSuper;
@@ -1072,9 +1073,9 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
     return Util.SDK_INT < 24
         && "OMX.SEC.aac.dec".equals(codecName)
         && "samsung".equals(Util.MANUFACTURER)
-        && (Util.DEVICE.startsWith("zeroflte")
-            || Util.DEVICE.startsWith("herolte")
-            || Util.DEVICE.startsWith("heroqlte"));
+        && (Build.DEVICE.startsWith("zeroflte")
+            || Build.DEVICE.startsWith("herolte")
+            || Build.DEVICE.startsWith("heroqlte"));
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkCryptoConfig.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkCryptoConfig.java
@@ -17,6 +17,7 @@ package androidx.media3.exoplayer.drm;
 
 import android.media.MediaCodec;
 import android.media.MediaCrypto;
+import android.os.Build;
 import androidx.media3.common.C;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
@@ -36,7 +37,7 @@ public final class FrameworkCryptoConfig implements CryptoConfig {
    * configuration.
    */
   public static final boolean WORKAROUND_DEVICE_NEEDS_KEYS_TO_CONFIGURE_CODEC =
-      "Amazon".equals(Util.MANUFACTURER)
+      "Amazon".equals(Build.MANUFACTURER)
           && ("AFTM".equals(Util.MODEL) // Fire TV Stick Gen 1
               || "AFTB".equals(Util.MODEL)); // Fire TV Gen 1
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkCryptoConfig.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkCryptoConfig.java
@@ -20,7 +20,6 @@ import android.media.MediaCrypto;
 import android.os.Build;
 import androidx.media3.common.C;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.decoder.CryptoConfig;
 import java.util.UUID;
 
@@ -38,8 +37,8 @@ public final class FrameworkCryptoConfig implements CryptoConfig {
    */
   public static final boolean WORKAROUND_DEVICE_NEEDS_KEYS_TO_CONFIGURE_CODEC =
       "Amazon".equals(Build.MANUFACTURER)
-          && ("AFTM".equals(Util.MODEL) // Fire TV Stick Gen 1
-              || "AFTB".equals(Util.MODEL)); // Fire TV Gen 1
+          && ("AFTM".equals(Build.MODEL) // Fire TV Stick Gen 1
+              || "AFTB".equals(Build.MODEL)); // Fire TV Gen 1
 
   /** The DRM scheme UUID. */
   public final UUID uuid;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
@@ -501,10 +501,10 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
     if ((Util.SDK_INT < 23 && C.WIDEVINE_UUID.equals(uuid))
         || (C.PLAYREADY_UUID.equals(uuid)
             && "Amazon".equals(Build.MANUFACTURER)
-            && ("AFTB".equals(Util.MODEL) // Fire TV Gen 1
-                || "AFTS".equals(Util.MODEL) // Fire TV Gen 2
-                || "AFTM".equals(Util.MODEL) // Fire TV Stick Gen 1
-                || "AFTT".equals(Util.MODEL)))) { // Fire TV Stick Gen 2
+            && ("AFTB".equals(Build.MODEL) // Fire TV Gen 1
+                || "AFTS".equals(Build.MODEL) // Fire TV Gen 2
+                || "AFTM".equals(Build.MODEL) // Fire TV Stick Gen 1
+                || "AFTT".equals(Build.MODEL)))) { // Fire TV Stick Gen 2
       byte[] psshData = PsshAtomUtil.parseSchemeSpecificData(initData, uuid);
       if (psshData != null) {
         // Extraction succeeded, so return the extracted data.
@@ -541,7 +541,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
    * <p>See <a href="https://github.com/google/ExoPlayer/issues/4413">GitHub issue #4413</a>.
    */
   private static boolean needsForceWidevineL3Workaround() {
-    return "ASUS_Z00AD".equals(Util.MODEL);
+    return "ASUS_Z00AD".equals(Build.MODEL);
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
@@ -26,6 +26,7 @@ import android.media.MediaDrmException;
 import android.media.NotProvisionedException;
 import android.media.UnsupportedSchemeException;
 import android.media.metrics.LogSessionId;
+import android.os.Build;
 import android.os.PersistableBundle;
 import android.text.TextUtils;
 import androidx.annotation.Nullable;
@@ -499,7 +500,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
     // Some Amazon devices also require data to be extracted from the PSSH atom for PlayReady.
     if ((Util.SDK_INT < 23 && C.WIDEVINE_UUID.equals(uuid))
         || (C.PLAYREADY_UUID.equals(uuid)
-            && "Amazon".equals(Util.MANUFACTURER)
+            && "Amazon".equals(Build.MANUFACTURER)
             && ("AFTB".equals(Util.MODEL) // Fire TV Gen 1
                 || "AFTS".equals(Util.MODEL) // Fire TV Gen 2
                 || "AFTM".equals(Util.MODEL) // Fire TV Stick Gen 1

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
@@ -37,6 +37,7 @@ import android.media.MediaCodecInfo.AudioCapabilities;
 import android.media.MediaCodecInfo.CodecCapabilities;
 import android.media.MediaCodecInfo.CodecProfileLevel;
 import android.media.MediaCodecInfo.VideoCapabilities;
+import android.os.Build;
 import android.util.Pair;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -831,7 +832,7 @@ public final class MediaCodecInfo {
    * @return Whether to enable the workaround.
    */
   private static boolean needsRotatedVerticalResolutionWorkaround(String name) {
-    if ("OMX.MTK.VIDEO.DECODER.HEVC".equals(name) && "mcv5a".equals(Util.DEVICE)) {
+    if ("OMX.MTK.VIDEO.DECODER.HEVC".equals(name) && "mcv5a".equals(Build.DEVICE)) {
       // See https://github.com/google/ExoPlayer/issues/6612.
       return false;
     }
@@ -846,6 +847,6 @@ public final class MediaCodecInfo {
     // See https://github.com/google/ExoPlayer/issues/3537
     return MimeTypes.VIDEO_H265.equals(mimeType)
         && CodecProfileLevel.HEVCProfileMain10 == profile
-        && ("sailfish".equals(Util.DEVICE) || "marlin".equals(Util.DEVICE));
+        && ("sailfish".equals(Build.DEVICE) || "marlin".equals(Build.DEVICE));
   }
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
@@ -791,7 +791,7 @@ public final class MediaCodecInfo {
    */
   private static boolean needsDisableAdaptationWorkaround(String name) {
     return Util.SDK_INT <= 22
-        && ("ODROID-XU3".equals(Util.MODEL) || "Nexus 10".equals(Util.MODEL))
+        && ("ODROID-XU3".equals(Build.MODEL) || "Nexus 10".equals(Build.MODEL))
         && ("OMX.Exynos.AVC.Decoder".equals(name) || "OMX.Exynos.AVC.Decoder.secure".equals(name));
   }
 
@@ -804,7 +804,7 @@ public final class MediaCodecInfo {
    *     new format's configuration data.
    */
   private static boolean needsAdaptationReconfigureWorkaround(String name) {
-    return Util.MODEL.startsWith("SM-T230") && "OMX.MARVELL.VIDEO.HW.CODA7542DECODER".equals(name);
+    return Build.MODEL.startsWith("SM-T230") && "OMX.MARVELL.VIDEO.HW.CODA7542DECODER".equals(name);
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -2617,7 +2617,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
                 || "OMX.bcm.vdec.avc.tunnel.secure".equals(name)
                 || "OMX.bcm.vdec.hevc.tunnel".equals(name)
                 || "OMX.bcm.vdec.hevc.tunnel.secure".equals(name)))
-        || ("Amazon".equals(Util.MANUFACTURER) && "AFTS".equals(Util.MODEL) && codecInfo.secure);
+        || ("Amazon".equals(Build.MANUFACTURER) && "AFTS".equals(Util.MODEL) && codecInfo.secure);
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -2561,10 +2561,10 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   private @AdaptationWorkaroundMode int codecAdaptationWorkaroundMode(String name) {
     if (Util.SDK_INT <= 25
         && "OMX.Exynos.avc.dec.secure".equals(name)
-        && (Util.MODEL.startsWith("SM-T585")
-            || Util.MODEL.startsWith("SM-A510")
-            || Util.MODEL.startsWith("SM-A520")
-            || Util.MODEL.startsWith("SM-J700"))) {
+        && (Build.MODEL.startsWith("SM-T585")
+            || Build.MODEL.startsWith("SM-A510")
+            || Build.MODEL.startsWith("SM-A520")
+            || Build.MODEL.startsWith("SM-J700"))) {
       return ADAPTATION_WORKAROUND_MODE_ALWAYS;
     } else if (Util.SDK_INT < 24
         && ("OMX.Nvidia.h264.decode".equals(name) || "OMX.Nvidia.h264.decode.secure".equals(name))
@@ -2617,7 +2617,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
                 || "OMX.bcm.vdec.avc.tunnel.secure".equals(name)
                 || "OMX.bcm.vdec.hevc.tunnel".equals(name)
                 || "OMX.bcm.vdec.hevc.tunnel.secure".equals(name)))
-        || ("Amazon".equals(Build.MANUFACTURER) && "AFTS".equals(Util.MODEL) && codecInfo.secure);
+        || ("Amazon".equals(Build.MANUFACTURER) && "AFTS".equals(Build.MODEL) && codecInfo.secure);
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -39,6 +39,7 @@ import android.media.MediaCrypto;
 import android.media.MediaCryptoException;
 import android.media.MediaFormat;
 import android.media.metrics.LogSessionId;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
 import androidx.annotation.CallSuper;
@@ -2567,10 +2568,10 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       return ADAPTATION_WORKAROUND_MODE_ALWAYS;
     } else if (Util.SDK_INT < 24
         && ("OMX.Nvidia.h264.decode".equals(name) || "OMX.Nvidia.h264.decode.secure".equals(name))
-        && ("flounder".equals(Util.DEVICE)
-            || "flounder_lte".equals(Util.DEVICE)
-            || "grouper".equals(Util.DEVICE)
-            || "tilapia".equals(Util.DEVICE))) {
+        && ("flounder".equals(Build.DEVICE)
+            || "flounder_lte".equals(Build.DEVICE)
+            || "grouper".equals(Build.DEVICE)
+            || "tilapia".equals(Build.DEVICE))) {
       return ADAPTATION_WORKAROUND_MODE_SAME_RESOLUTION;
     } else {
       return ADAPTATION_WORKAROUND_MODE_NEVER;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
@@ -559,7 +559,7 @@ public final class MediaCodecUtil {
     // Work around https://github.com/google/ExoPlayer/issues/3249.
     if (Util.SDK_INT < 24
         && ("OMX.SEC.aac.dec".equals(name) || "OMX.Exynos.AAC.Decoder".equals(name))
-        && "samsung".equals(Util.MANUFACTURER)
+        && "samsung".equals(Build.MANUFACTURER)
         && (Build.DEVICE.startsWith("zeroflte") // Galaxy S6
             || Build.DEVICE.startsWith("zerolte") // Galaxy S6 Edge
             || Build.DEVICE.startsWith("zenlte") // Galaxy S6 Edge+

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
@@ -22,6 +22,7 @@ import android.annotation.SuppressLint;
 import android.media.MediaCodecInfo.CodecCapabilities;
 import android.media.MediaCodecInfo.CodecProfileLevel;
 import android.media.MediaCodecList;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.Pair;
 import androidx.annotation.CheckResult;
@@ -559,14 +560,14 @@ public final class MediaCodecUtil {
     if (Util.SDK_INT < 24
         && ("OMX.SEC.aac.dec".equals(name) || "OMX.Exynos.AAC.Decoder".equals(name))
         && "samsung".equals(Util.MANUFACTURER)
-        && (Util.DEVICE.startsWith("zeroflte") // Galaxy S6
-            || Util.DEVICE.startsWith("zerolte") // Galaxy S6 Edge
-            || Util.DEVICE.startsWith("zenlte") // Galaxy S6 Edge+
-            || "SC-05G".equals(Util.DEVICE) // Galaxy S6
-            || "marinelteatt".equals(Util.DEVICE) // Galaxy S6 Active
-            || "404SC".equals(Util.DEVICE) // Galaxy S6 Edge
-            || "SC-04G".equals(Util.DEVICE)
-            || "SCV31".equals(Util.DEVICE))) {
+        && (Build.DEVICE.startsWith("zeroflte") // Galaxy S6
+            || Build.DEVICE.startsWith("zerolte") // Galaxy S6 Edge
+            || Build.DEVICE.startsWith("zenlte") // Galaxy S6 Edge+
+            || "SC-05G".equals(Build.DEVICE) // Galaxy S6
+            || "marinelteatt".equals(Build.DEVICE) // Galaxy S6 Active
+            || "404SC".equals(Build.DEVICE) // Galaxy S6 Edge
+            || "SC-04G".equals(Build.DEVICE)
+            || "SCV31".equals(Build.DEVICE))) {
       return false;
     }
 
@@ -590,7 +591,7 @@ public final class MediaCodecUtil {
   private static void applyWorkarounds(String mimeType, List<MediaCodecInfo> decoderInfos) {
     if (MimeTypes.AUDIO_RAW.equals(mimeType)) {
       if (Util.SDK_INT < 26
-          && Util.DEVICE.equals("R9")
+          && Build.DEVICE.equals("R9")
           && decoderInfos.size() == 1
           && decoderInfos.get(0).name.equals("OMX.MTK.AUDIO.DECODER.RAW")) {
         // This device does not list a generic raw audio decoder, yet it can be instantiated by

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -36,6 +36,7 @@ import android.media.MediaCodecInfo.CodecCapabilities;
 import android.media.MediaCodecInfo.CodecProfileLevel;
 import android.media.MediaCrypto;
 import android.media.MediaFormat;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -2371,7 +2372,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       // https://github.com/google/ExoPlayer/issues/8014.
       // https://github.com/google/ExoPlayer/issues/8329.
       // https://github.com/google/ExoPlayer/issues/9710.
-      switch (Util.DEVICE) {
+      switch (Build.DEVICE) {
         case "aquaman":
         case "dangal":
         case "dangalUHD":
@@ -2385,7 +2386,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
           break; // Do nothing.
       }
     }
-    if (Util.SDK_INT <= 27 && "HWEML".equals(Util.DEVICE)) {
+    if (Util.SDK_INT <= 27 && "HWEML".equals(Build.DEVICE)) {
       // Workaround for Huawei P20:
       // https://github.com/google/ExoPlayer/issues/4468#issuecomment-459291645.
       return true;
@@ -2425,7 +2426,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       // https://github.com/google/ExoPlayer/issues/6503.
       // https://github.com/google/ExoPlayer/issues/8014,
       // https://github.com/google/ExoPlayer/pull/8030.
-      switch (Util.DEVICE) {
+      switch (Build.DEVICE) {
         case "1601":
         case "1713":
         case "1714":

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1264,10 +1264,10 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
             HEVC_MAX_INPUT_SIZE_THRESHOLD,
             getMaxSampleSize(/* pixelCount= */ width * height, /* minCompressionRatio= */ 2));
       case MimeTypes.VIDEO_H264:
-        if ("BRAVIA 4K 2015".equals(Util.MODEL) // Sony Bravia 4K
+        if ("BRAVIA 4K 2015".equals(Build.MODEL) // Sony Bravia 4K
             || ("Amazon".equals(Build.MANUFACTURER)
-                && ("KFSOWI".equals(Util.MODEL) // Kindle Soho
-                    || ("AFTS".equals(Util.MODEL) && codecInfo.secure)))) { // Fire TV Gen 2
+                && ("KFSOWI".equals(Build.MODEL) // Kindle Soho
+                    || ("AFTS".equals(Build.MODEL) && codecInfo.secure)))) { // Fire TV Gen 2
           // Use the default value for cases where platform limitations may prevent buffers of the
           // calculated maximum input size from being allocated.
           return Format.NO_VALUE;
@@ -2391,7 +2391,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       // https://github.com/google/ExoPlayer/issues/4468#issuecomment-459291645.
       return true;
     }
-    switch (Util.MODEL) {
+    switch (Build.MODEL) {
       // Workaround for some Fire OS devices.
       case "AFTA":
       case "AFTN":
@@ -2571,7 +2571,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
         default:
           break; // Do nothing.
       }
-      switch (Util.MODEL) {
+      switch (Build.MODEL) {
         case "JSN-L21":
           return true;
         default:

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -1265,7 +1265,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
             getMaxSampleSize(/* pixelCount= */ width * height, /* minCompressionRatio= */ 2));
       case MimeTypes.VIDEO_H264:
         if ("BRAVIA 4K 2015".equals(Util.MODEL) // Sony Bravia 4K
-            || ("Amazon".equals(Util.MANUFACTURER)
+            || ("Amazon".equals(Build.MANUFACTURER)
                 && ("KFSOWI".equals(Util.MODEL) // Kindle Soho
                     || ("AFTS".equals(Util.MODEL) && codecInfo.secure)))) { // Fire TV Gen 2
           // Use the default value for cases where platform limitations may prevent buffers of the
@@ -2294,7 +2294,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     // also lose sync [Internal: b/26453592]. Even after M, the devices may apply post processing
     // operations that can modify frame output timestamps, which is incompatible with ExoPlayer's
     // logic for skipping decode-only frames.
-    return "NVIDIA".equals(Util.MANUFACTURER);
+    return "NVIDIA".equals(Build.MANUFACTURER);
   }
 
   /*

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/BitmapPixelTestUtil.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/BitmapPixelTestUtil.java
@@ -34,12 +34,12 @@ import android.graphics.PixelFormat;
 import android.media.Image;
 import android.opengl.GLES20;
 import android.opengl.GLES30;
+import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.media3.common.util.GlUtil;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -92,7 +92,7 @@ public class BitmapPixelTestUtil {
    */
   // TODO: b/279154364 - Stop allowing 15f threshold after bug is fixed.
   public static final float MAXIMUM_AVERAGE_PIXEL_ABSOLUTE_DIFFERENCE_DIFFERENT_DEVICE =
-      !Util.MODEL.equals("H8266") && !Util.MODEL.equals("H8416") ? 5f : 15f;
+      !Build.MODEL.equals("H8266") && !Build.MODEL.equals("H8416") ? 5f : 15f;
 
   /**
    * Maximum allowed average pixel difference between bitmaps generated.

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/AndroidTestUtil.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/AndroidTestUtil.java
@@ -37,6 +37,7 @@ import android.media.Image;
 import android.media.MediaCodecInfo;
 import android.opengl.EGLContext;
 import android.opengl.EGLDisplay;
+import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.media3.common.ColorInfo;
@@ -1121,7 +1122,7 @@ public final class AndroidTestUtil {
       throws IOException, InterruptedException {
     // b/298599172 - runUntilComparisonFrameOrEnded fails on this device because reading decoder
     //  output as a bitmap doesn't work.
-    assumeFalse(Util.SDK_INT == 21 && Ascii.toLowerCase(Util.MODEL).contains("nexus"));
+    assumeFalse(Util.SDK_INT == 21 && Ascii.toLowerCase(Build.MODEL).contains("nexus"));
     ImmutableList.Builder<Bitmap> bitmaps = new ImmutableList.Builder<>();
     try (VideoDecodingWrapper decodingWrapper =
         new VideoDecodingWrapper(
@@ -1430,8 +1431,8 @@ public final class AndroidTestUtil {
         && format.height >= 4320
         && format.sampleMimeType != null
         && format.sampleMimeType.equals(MimeTypes.VIDEO_H265)
-        && (Ascii.equalsIgnoreCase(Util.MODEL, "SM-F711U1")
-            || Ascii.equalsIgnoreCase(Util.MODEL, "SM-F926U1"));
+        && (Ascii.equalsIgnoreCase(Build.MODEL, "SM-F711U1")
+            || Ascii.equalsIgnoreCase(Build.MODEL, "SM-F926U1"));
   }
 
   private static boolean canEncode(Format format, boolean isPortraitEncodingEnabled) {

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/SequenceEffectTestUtil.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/SequenceEffectTestUtil.java
@@ -26,6 +26,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.media3.common.Effect;
 import androidx.media3.common.MediaItem;
@@ -177,9 +178,9 @@ public final class SequenceEffectTestUtil {
    */
   public static boolean decoderProducesWashedOutColours(MediaCodecInfo mediaCodecInfo) {
     return mediaCodecInfo.name.equals("OMX.google.h264.decoder")
-        && (Util.MODEL.equals("ANE-LX1")
-            || Util.MODEL.equals("MHA-L29")
-            || Util.MODEL.equals("COR-L29"));
+        && (Build.MODEL.equals("ANE-LX1")
+            || Build.MODEL.equals("MHA-L29")
+            || Build.MODEL.equals("COR-L29"));
   }
 
   /**

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerAndroidTestRunner.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerAndroidTestRunner.java
@@ -25,6 +25,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
 import android.net.Uri;
+import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.media3.common.MediaItem;
@@ -465,7 +466,7 @@ public class TransformerAndroidTestRunner {
       // ExportTestResult.
       throw interruptedException;
     } catch (Throwable analysisFailure) {
-      if (Util.SDK_INT == 21 && Ascii.toLowerCase(Util.MODEL).contains("nexus")) {
+      if (Util.SDK_INT == 21 && Ascii.toLowerCase(Build.MODEL).contains("nexus")) {
         // b/233584640, b/230093713
         Log.i(TAG, testId + ": Skipping SSIM calculation due to known device-specific issue");
       } else {

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerPauseResumeTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerPauseResumeTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assume.assumeFalse;
 
 import android.content.Context;
 import android.media.MediaCodec.BufferInfo;
+import android.os.Build;
 import androidx.media3.common.C;
 import androidx.media3.common.Effect;
 import androidx.media3.common.Format;
@@ -412,9 +413,9 @@ public class TransformerPauseResumeTest {
     // expected.
     // On vivo 1820 and vivo 1906, the process crashes unexpectedly (see b/310566201).
     return (Util.SDK_INT == 26 && Util.isRunningOnEmulator())
-        || (Util.SDK_INT == 27 && Ascii.equalsIgnoreCase(Util.MODEL, "vivo 1820"))
-        || (Util.SDK_INT == 28 && Ascii.equalsIgnoreCase(Util.MODEL, "vivo 1901"))
-        || (Util.SDK_INT == 28 && Ascii.equalsIgnoreCase(Util.MODEL, "vivo 1906"));
+        || (Util.SDK_INT == 27 && Ascii.equalsIgnoreCase(Build.MODEL, "vivo 1820"))
+        || (Util.SDK_INT == 28 && Ascii.equalsIgnoreCase(Build.MODEL, "vivo 1901"))
+        || (Util.SDK_INT == 28 && Ascii.equalsIgnoreCase(Build.MODEL, "vivo 1906"));
   }
 
   private static final class FrameBlockingMuxerFactory implements Muxer.Factory {

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerSequenceEffectTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerSequenceEffectTest.java
@@ -46,12 +46,12 @@ import static androidx.media3.transformer.SequenceEffectTestUtil.tryToExportComp
 import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
+import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.media3.common.Effect;
 import androidx.media3.common.Format;
 import androidx.media3.common.MediaItem;
-import androidx.media3.common.util.Util;
 import androidx.media3.effect.BitmapOverlay;
 import androidx.media3.effect.DebugTraceUtil;
 import androidx.media3.effect.DefaultVideoFrameProcessor;
@@ -361,13 +361,13 @@ public final class TransformerSequenceEffectTest {
                 .build());
     // Some devices need a very high bitrate to avoid encoding artifacts.
     int bitrate = 30_000_000;
-    if (Ascii.equalsIgnoreCase(Util.MODEL, "mi a2 lite")
-        || Ascii.equalsIgnoreCase(Util.MODEL, "redmi 8")
-        || Ascii.equalsIgnoreCase(Util.MODEL, "sm-f711u1")
-        || Ascii.equalsIgnoreCase(Util.MODEL, "sm-f916u1")
-        || Ascii.equalsIgnoreCase(Util.MODEL, "sm-f926u1")
-        || Ascii.equalsIgnoreCase(Util.MODEL, "sm-g981u1")
-        || Ascii.equalsIgnoreCase(Util.MODEL, "tb-q706")) {
+    if (Ascii.equalsIgnoreCase(Build.MODEL, "mi a2 lite")
+        || Ascii.equalsIgnoreCase(Build.MODEL, "redmi 8")
+        || Ascii.equalsIgnoreCase(Build.MODEL, "sm-f711u1")
+        || Ascii.equalsIgnoreCase(Build.MODEL, "sm-f916u1")
+        || Ascii.equalsIgnoreCase(Build.MODEL, "sm-f926u1")
+        || Ascii.equalsIgnoreCase(Build.MODEL, "sm-g981u1")
+        || Ascii.equalsIgnoreCase(Build.MODEL, "tb-q706")) {
       // And some devices need a lower bitrate because VideoDecodingWrapper fails to decode high
       // bitrate output, or FrameworkMuxer fails to mux.
       bitrate = 10_000_000;

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/ExportTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/ExportTest.java
@@ -381,7 +381,7 @@ public class ExportTest {
   public void exportTranscodeBt2020Sdr() throws Exception {
     Context context = ApplicationProvider.getApplicationContext();
     // Reference: b/262732842#comment51
-    if (SDK_INT <= 27 && Util.MANUFACTURER.equals("samsung")) {
+    if (SDK_INT <= 27 && Build.MANUFACTURER.equals("samsung")) {
       String reason = "Some older Samsung encoders report a non-specified error code";
       recordTestSkipped(context, testId, reason);
       throw new AssumptionViolatedException(reason);

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/ExportTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/ExportTest.java
@@ -171,11 +171,11 @@ public class ExportTest {
     // Reference: b/262710361
     assumeFalse(
         "Skip due to over-reported encoder capabilities",
-        Util.SDK_INT == 29 && Ascii.equalsIgnoreCase(Util.MODEL, "pixel 3"));
+        Util.SDK_INT == 29 && Ascii.equalsIgnoreCase(Build.MODEL, "pixel 3"));
     // Reference: b/347635026
     assumeFalse(
         "Skip due to decoder failing to queue input frames",
-        Util.SDK_INT == 29 && Ascii.equalsIgnoreCase(Util.MODEL, "pixel 3a"));
+        Util.SDK_INT == 29 && Ascii.equalsIgnoreCase(Build.MODEL, "pixel 3a"));
     Transformer transformer =
         new Transformer.Builder(context)
             .setEncoderFactory(new ForceEncodeEncoderFactory(context))
@@ -198,11 +198,11 @@ public class ExportTest {
     // Reference: b/244711282#comment5
     assumeFalse(
         "Some devices are capable of instantiating only either one 8K decoder or one 8K encoder",
-        Ascii.equalsIgnoreCase(Util.MODEL, "tb-q706")
-            || Ascii.equalsIgnoreCase(Util.MODEL, "sm-f916u1")
-            || Ascii.equalsIgnoreCase(Util.MODEL, "sm-g981u1")
-            || Ascii.equalsIgnoreCase(Util.MODEL, "le2121")
-            || Ascii.equalsIgnoreCase(Util.MODEL, "seahawk"));
+        Ascii.equalsIgnoreCase(Build.MODEL, "tb-q706")
+            || Ascii.equalsIgnoreCase(Build.MODEL, "sm-f916u1")
+            || Ascii.equalsIgnoreCase(Build.MODEL, "sm-g981u1")
+            || Ascii.equalsIgnoreCase(Build.MODEL, "le2121")
+            || Ascii.equalsIgnoreCase(Build.MODEL, "seahawk"));
     Context context = ApplicationProvider.getApplicationContext();
     assumeFormatsSupported(
         context, testId, /* inputFormat= */ MP4_ASSET_8K24.videoFormat, /* outputFormat= */ null);
@@ -212,7 +212,7 @@ public class ExportTest {
             .build();
     MediaItem mediaItem = MediaItem.fromUri(Uri.parse(MP4_ASSET_8K24.uri));
     // TODO: b/281824052 - have requestCalculateSsim always be true after linked bug is fixed.
-    boolean requestCalculateSsim = !Util.MODEL.equals("SM-G991B");
+    boolean requestCalculateSsim = !Build.MODEL.equals("SM-G991B");
 
     ExportTestResult result =
         new TransformerAndroidTestRunner.Builder(context, transformer)
@@ -394,7 +394,7 @@ public class ExportTest {
     // Reference: b/391362064
     assumeFalse(
         "Skip due to over-reported decoder capabilities",
-        SDK_INT == 33 && Ascii.equalsIgnoreCase(Util.MODEL, "sm-a325f"));
+        SDK_INT == 33 && Ascii.equalsIgnoreCase(Build.MODEL, "sm-a325f"));
     Transformer transformer = new Transformer.Builder(context).build();
     MediaItem mediaItem = MediaItem.fromUri(Uri.parse(MP4_ASSET_BT2020_SDR.uri));
     EditedMediaItem editedMediaItem =
@@ -414,12 +414,12 @@ public class ExportTest {
     Context context = ApplicationProvider.getApplicationContext();
     // Devices with Tensor G2 & G3 chipsets should work, but Pixel 7a is flaky.
     assumeTrue(
-        Ascii.toLowerCase(Util.MODEL).contains("pixel")
-            && (Ascii.toLowerCase(Util.MODEL).contains("7")
-                || Ascii.toLowerCase(Util.MODEL).contains("8")
-                || Ascii.toLowerCase(Util.MODEL).contains("fold")
-                || Ascii.toLowerCase(Util.MODEL).contains("tablet")));
-    assumeFalse(Ascii.toLowerCase(Util.MODEL).contains("7a"));
+        Ascii.toLowerCase(Build.MODEL).contains("pixel")
+            && (Ascii.toLowerCase(Build.MODEL).contains("7")
+                || Ascii.toLowerCase(Build.MODEL).contains("8")
+                || Ascii.toLowerCase(Build.MODEL).contains("fold")
+                || Ascii.toLowerCase(Build.MODEL).contains("tablet")));
+    assumeFalse(Ascii.toLowerCase(Build.MODEL).contains("7a"));
     Transformer transformer =
         new Transformer.Builder(context).experimentalSetTrimOptimizationEnabled(true).build();
     MediaItem mediaItem =

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/ExportTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/ExportTest.java
@@ -42,6 +42,7 @@ import static org.junit.Assume.assumeTrue;
 import android.content.Context;
 import android.media.MediaFormat;
 import android.net.Uri;
+import android.os.Build;
 import android.util.Pair;
 import androidx.media3.common.Effect;
 import androidx.media3.common.Format;
@@ -180,7 +181,7 @@ public class ExportTest {
             .setEncoderFactory(new ForceEncodeEncoderFactory(context))
             .build();
     MediaItem mediaItem = MediaItem.fromUri(Uri.parse(MP4_ASSET_4K60_PORTRAIT.uri));
-    boolean skipCalculateSsim = Util.SDK_INT < 30 && Util.DEVICE.equals("joyeuse");
+    boolean skipCalculateSsim = Util.SDK_INT < 30 && Build.DEVICE.equals("joyeuse");
 
     ExportTestResult result =
         new TransformerAndroidTestRunner.Builder(context, transformer)

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/ToneMapHdrToSdrUsingOpenGlPixelTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/ToneMapHdrToSdrUsingOpenGlPixelTest.java
@@ -24,11 +24,11 @@ import static androidx.media3.transformer.mh.UnoptimizedGlEffect.NO_OP_EFFECT;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.graphics.Bitmap;
+import android.os.Build;
 import android.util.Log;
 import androidx.media3.common.C;
 import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
-import androidx.media3.common.util.Util;
 import androidx.media3.effect.DefaultVideoFrameProcessor;
 import androidx.media3.test.utils.VideoFrameProcessorTestRunner;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -60,7 +60,8 @@ public final class ToneMapHdrToSdrUsingOpenGlPixelTest {
    * substantial distortions introduced by changes in tested components will cause the test to fail.
    */
   private static final float MAXIMUM_DEVICE_AVERAGE_PIXEL_ABSOLUTE_DIFFERENCE =
-      !Ascii.equalsIgnoreCase(Util.MODEL, "dn2103") && !Ascii.equalsIgnoreCase(Util.MODEL, "v2059")
+      !Ascii.equalsIgnoreCase(Build.MODEL, "dn2103")
+              && !Ascii.equalsIgnoreCase(Build.MODEL, "v2059")
           ? 6f
           : 7f;
 

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TranscodeForegroundSpeedTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TranscodeForegroundSpeedTest.java
@@ -22,13 +22,13 @@ import static org.junit.Assume.assumeTrue;
 
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.audio.ChannelMixingAudioProcessor;
 import androidx.media3.common.audio.ChannelMixingMatrix;
 import androidx.media3.common.audio.SonicAudioProcessor;
 import androidx.media3.common.util.Clock;
-import androidx.media3.common.util.Util;
 import androidx.media3.effect.Presentation;
 import androidx.media3.transformer.AndroidTestUtil;
 import androidx.media3.transformer.AssetLoader;
@@ -77,10 +77,10 @@ public class TranscodeForegroundSpeedTest {
       export1080pWithAudioTo720p_onMediumPerformanceDeviceWithDynamicScheduling_completesWithAtLeast140Fps()
           throws Exception {
     assumeTrue(
-        Ascii.toLowerCase(Util.MODEL).contains("pixel 2")
-            || Ascii.toLowerCase(Util.MODEL).contains("dn2103")
-            || Ascii.toLowerCase(Util.MODEL).contains("sm-g960f")
-            || Ascii.toLowerCase(Util.MODEL).contains("g8441"));
+        Ascii.toLowerCase(Build.MODEL).contains("pixel 2")
+            || Ascii.toLowerCase(Build.MODEL).contains("dn2103")
+            || Ascii.toLowerCase(Build.MODEL).contains("sm-g960f")
+            || Ascii.toLowerCase(Build.MODEL).contains("g8441"));
     assumeFormatsSupported(
         context,
         testId,
@@ -102,13 +102,13 @@ public class TranscodeForegroundSpeedTest {
       export1080pWithAudioTo720p_onLowerPerformanceDevicesWithDynamicScheduling_completesWithAtLeast60Fps()
           throws Exception {
     assumeTrue(
-        (Ascii.toLowerCase(Util.MODEL).contains("f-01l")
-            || Ascii.toLowerCase(Util.MODEL).contains("asus_x00td")
-            || Ascii.toLowerCase(Util.MODEL).contains("redmi note 5")
-            || Ascii.toLowerCase(Util.MODEL).contains("mha-l29")
-            || Ascii.toLowerCase(Util.MODEL).contains("oneplus a6013")
-            || Ascii.toLowerCase(Util.MODEL).contains("cph1803")
-            || Ascii.toLowerCase(Util.MODEL).contains("mi a2 lite")));
+        (Ascii.toLowerCase(Build.MODEL).contains("f-01l")
+            || Ascii.toLowerCase(Build.MODEL).contains("asus_x00td")
+            || Ascii.toLowerCase(Build.MODEL).contains("redmi note 5")
+            || Ascii.toLowerCase(Build.MODEL).contains("mha-l29")
+            || Ascii.toLowerCase(Build.MODEL).contains("oneplus a6013")
+            || Ascii.toLowerCase(Build.MODEL).contains("cph1803")
+            || Ascii.toLowerCase(Build.MODEL).contains("mi a2 lite")));
     assumeFormatsSupported(
         context,
         testId,

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TranscodeQualityTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TranscodeQualityTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assume.assumeFalse;
 
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Util;
@@ -64,10 +65,10 @@ public final class TranscodeQualityTest {
         /* outputFormat= */ AndroidTestUtil.MP4_ASSET_WITH_INCREASING_TIMESTAMPS.videoFormat);
     // Skip on specific pre-API 34 devices where calculating SSIM fails.
     assumeFalse(
-        (Util.SDK_INT < 33 && (Util.MODEL.equals("SM-F711U1") || Util.MODEL.equals("SM-F926U1")))
-            || (Util.SDK_INT == 33 && Util.MODEL.equals("LE2121")));
+        (Util.SDK_INT < 33 && (Build.MODEL.equals("SM-F711U1") || Build.MODEL.equals("SM-F926U1")))
+            || (Util.SDK_INT == 33 && Build.MODEL.equals("LE2121")));
     // Skip on specific API 21 devices that aren't able to decode and encode at this resolution.
-    assumeFalse(Util.SDK_INT == 21 && Util.MODEL.equals("Nexus 7"));
+    assumeFalse(Util.SDK_INT == 21 && Build.MODEL.equals("Nexus 7"));
     Transformer transformer =
         new Transformer.Builder(context)
             .setVideoMimeType(MimeTypes.VIDEO_H264)
@@ -109,8 +110,8 @@ public final class TranscodeQualityTest {
             .setSampleMimeType(MimeTypes.VIDEO_H265)
             .build());
     assumeFalse(
-        (Util.SDK_INT < 33 && (Util.MODEL.equals("SM-F711U1") || Util.MODEL.equals("SM-F926U1")))
-            || (Util.SDK_INT == 33 && Util.MODEL.equals("LE2121")));
+        (Util.SDK_INT < 33 && (Build.MODEL.equals("SM-F711U1") || Build.MODEL.equals("SM-F926U1")))
+            || (Util.SDK_INT == 33 && Build.MODEL.equals("LE2121")));
     Transformer transformer =
         new Transformer.Builder(context).setVideoMimeType(MimeTypes.VIDEO_H265).build();
     MediaItem mediaItem =

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TranscodeSpeedTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TranscodeSpeedTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assume.assumeTrue;
 
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
 import androidx.media3.common.Format;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MimeTypes;
@@ -115,13 +116,13 @@ public class TranscodeSpeedTest {
     Transformer transformer =
         new Transformer.Builder(context).setVideoMimeType(MimeTypes.VIDEO_H264).build();
     boolean isHighPerformance =
-        Ascii.toLowerCase(Util.MODEL).contains("pixel")
-            && (Ascii.toLowerCase(Util.MODEL).contains("6")
-                || Ascii.toLowerCase(Util.MODEL).contains("7")
-                || Ascii.toLowerCase(Util.MODEL).contains("8")
-                || Ascii.toLowerCase(Util.MODEL).contains("fold")
-                || Ascii.toLowerCase(Util.MODEL).contains("tablet"));
-    if (Util.SDK_INT == 33 && Ascii.toLowerCase(Util.MODEL).contains("pixel 6")) {
+        Ascii.toLowerCase(Build.MODEL).contains("pixel")
+            && (Ascii.toLowerCase(Build.MODEL).contains("6")
+                || Ascii.toLowerCase(Build.MODEL).contains("7")
+                || Ascii.toLowerCase(Build.MODEL).contains("8")
+                || Ascii.toLowerCase(Build.MODEL).contains("fold")
+                || Ascii.toLowerCase(Build.MODEL).contains("tablet"));
+    if (Util.SDK_INT == 33 && Ascii.toLowerCase(Build.MODEL).contains("pixel 6")) {
       // Pixel 6 is usually quick, unless it's on API 33. See b/358519058.
       isHighPerformance = false;
     }
@@ -159,14 +160,14 @@ public class TranscodeSpeedTest {
       analyzeVideo_onHighPerformanceDevice_withConfiguredOperatingRate_completesWithHighThroughput()
           throws Exception {
     assumeTrue(
-        Ascii.toLowerCase(Util.MODEL).contains("pixel")
-            && (Ascii.toLowerCase(Util.MODEL).contains("6")
-                || Ascii.toLowerCase(Util.MODEL).contains("7")
-                || Ascii.toLowerCase(Util.MODEL).contains("8")
-                || Ascii.toLowerCase(Util.MODEL).contains("fold")
-                || Ascii.toLowerCase(Util.MODEL).contains("tablet")));
+        Ascii.toLowerCase(Build.MODEL).contains("pixel")
+            && (Ascii.toLowerCase(Build.MODEL).contains("6")
+                || Ascii.toLowerCase(Build.MODEL).contains("7")
+                || Ascii.toLowerCase(Build.MODEL).contains("8")
+                || Ascii.toLowerCase(Build.MODEL).contains("fold")
+                || Ascii.toLowerCase(Build.MODEL).contains("tablet")));
     // Pixel 6 is usually quick, unless it's on API 33. See b/358519058.
-    assumeFalse(Util.SDK_INT == 33 && Ascii.toLowerCase(Util.MODEL).contains("pixel 6"));
+    assumeFalse(Util.SDK_INT == 33 && Ascii.toLowerCase(Build.MODEL).contains("pixel 6"));
     AtomicInteger videoFramesSeen = new AtomicInteger(/* initialValue= */ 0);
     MediaItem mediaItem =
         MediaItem.fromUri(Uri.parse(MP4_LONG_ASSET_WITH_INCREASING_TIMESTAMPS.uri))

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultDecoderFactory.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultDecoderFactory.java
@@ -427,7 +427,7 @@ public final class DefaultDecoderFactory implements Codec.DecoderFactory {
 
   private static boolean deviceNeedsDisableToneMappingWorkaround(
       @C.ColorTransfer int colorTransfer) {
-    if (Util.MANUFACTURER.equals("Google") && Build.ID.startsWith("TP1A")) {
+    if (Build.MANUFACTURER.equals("Google") && Build.ID.startsWith("TP1A")) {
       // Some Pixel 6 builds report support for tone mapping but the feature doesn't work
       // (see b/249297370#comment8).
       return true;

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultDecoderFactory.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultDecoderFactory.java
@@ -37,7 +37,6 @@ import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.MediaFormatUtil;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.mediacodec.MediaCodecInfo;
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector;
 import androidx.media3.exoplayer.mediacodec.MediaCodecUtil;
@@ -422,7 +421,7 @@ public final class DefaultDecoderFactory implements Codec.DecoderFactory {
         && format.height >= 4320
         && format.sampleMimeType != null
         && format.sampleMimeType.equals(MimeTypes.VIDEO_H265)
-        && (Util.MODEL.equals("SM-F711U1") || Util.MODEL.equals("SM-F926U1"));
+        && (Build.MODEL.equals("SM-F711U1") || Build.MODEL.equals("SM-F926U1"));
   }
 
   private static boolean deviceNeedsDisableToneMappingWorkaround(
@@ -433,17 +432,17 @@ public final class DefaultDecoderFactory implements Codec.DecoderFactory {
       return true;
     }
     if (colorTransfer == C.COLOR_TRANSFER_HLG
-        && (Util.MODEL.startsWith("SM-F936")
-            || Util.MODEL.startsWith("SM-F916")
-            || Util.MODEL.startsWith("SM-F721")
-            || Util.MODEL.equals("SM-X900"))) {
+        && (Build.MODEL.startsWith("SM-F936")
+            || Build.MODEL.startsWith("SM-F916")
+            || Build.MODEL.startsWith("SM-F721")
+            || Build.MODEL.equals("SM-X900"))) {
       // Some Samsung Galaxy Z Fold devices report support for HLG tone mapping but the feature only
       // works on PQ (see b/282791751#comment7).
       return true;
     }
     if (SDK_INT < 34
         && colorTransfer == C.COLOR_TRANSFER_ST2084
-        && Util.MODEL.startsWith("SM-F936")) {
+        && Build.MODEL.startsWith("SM-F936")) {
       // The Samsung Fold 4 HDR10 codec plugin for tonemapping sets incorrect crop values, so block
       // using it (see b/290725189).
       return true;
@@ -470,9 +469,9 @@ public final class DefaultDecoderFactory implements Codec.DecoderFactory {
     // hardware decoder + software encoder (17 fps).
     // Due to b/267740292 using hardware to software encoder fallback is risky.
     return format.width * format.height >= 1920 * 1080
-        && (Ascii.equalsIgnoreCase(Util.MODEL, "vivo 1906")
-            || Ascii.equalsIgnoreCase(Util.MODEL, "redmi 7a")
-            || Ascii.equalsIgnoreCase(Util.MODEL, "redmi 8"));
+        && (Ascii.equalsIgnoreCase(Build.MODEL, "vivo 1906")
+            || Ascii.equalsIgnoreCase(Build.MODEL, "redmi 7a")
+            || Ascii.equalsIgnoreCase(Build.MODEL, "redmi 8"));
   }
 
   private static ExportException createExportException(Format format, String reason) {

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultDecoderFactory.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultDecoderFactory.java
@@ -453,7 +453,7 @@ public final class DefaultDecoderFactory implements Codec.DecoderFactory {
 
   private static boolean deviceNeedsNoFrameRateWorkaround() {
     // Redmi Note 9 Pro fails if KEY_FRAME_RATE is set too high (see b/278076311).
-    return SDK_INT < 30 && Util.DEVICE.equals("joyeuse");
+    return SDK_INT < 30 && Build.DEVICE.equals("joyeuse");
   }
 
   private static boolean decoderSupportsKeyAllowFrameDrop(Context context) {

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultEncoderFactory.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultEncoderFactory.java
@@ -847,13 +847,14 @@ public final class DefaultEncoderFactory implements Codec.EncoderFactory {
 
   private static boolean deviceNeedsDefaultFrameRateWorkaround() {
     // Redmi Note 9 Pro fails if KEY_FRAME_RATE is set too high (see b/278076311).
-    return SDK_INT < 30 && Util.DEVICE.equals("joyeuse");
+    return SDK_INT < 30 && Build.DEVICE.equals("joyeuse");
   }
 
   private static boolean deviceNeedsNoH264HighProfileWorkaround() {
     // The H.264/AVC encoder produces B-frames when high profile is chosen despite configuration to
     // turn them off, so force not using high profile on these devices (see b/306617392).
     // TODO(b/229420356): Remove once the in-app muxer is the default and B-frames are supported.
-    return Util.SDK_INT == 27 && (Util.DEVICE.equals("ASUS_X00T_3") || Util.DEVICE.equals("TC77"));
+    return Util.SDK_INT == 27
+        && (Build.DEVICE.equals("ASUS_X00T_3") || Build.DEVICE.equals("TC77"));
   }
 }


### PR DESCRIPTION
This PR deprecates `Util.DEVICE`, `Util.MANUFACTURER` and `Util.MODEL` and replaces them with `Build.DEVICE`, `Build.MANUFACTURER` and `Build.MODEL`, respectively.

This addresses the corresponding TODOs in the project and [issue 384699964](http://issuetracker.google.com/issues/384699964) (I hope, since it is not public).

**Note:** I've submitted all three replacements in a single PR, since they are part of the same ticket, but I've used one commit for each of them. If you prefer multiple PRs, let me know.