### PR TITLE
Minor Util.postOrRun refactor: fix skipped reuse of variable created …

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -795,7 +795,7 @@ public final class Util {
     if (!looper.getThread().isAlive()) {
       return false;
     }
-    if (handler.getLooper() == Looper.myLooper()) {
+    if (looper == Looper.myLooper()) {
       runnable.run();
       return true;
     } else {


### PR DESCRIPTION
…for reuse

It looks like a variable got created to only obtain the Looper once (the Looper is stored in a `final` field), but then it's not actually being reused. A minor nit I tripped over during code review.