### PR TITLE
Fixed break presence of the next segment for hls

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/TsExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/TsExtractor.java
@@ -449,12 +449,14 @@ public final class TsExtractor implements Extractor {
 
     if (!fillBufferWithAtLeastOnePacket(input)) {
       // Send a synthesized empty pusi to allow for packetFinished to be triggered on the last unit.
-      for (int i = 0; i < tsPayloadReaders.size(); i++) {
-        TsPayloadReader payloadReader = tsPayloadReaders.valueAt(i);
-        if (payloadReader instanceof PesReader) {
-          PesReader pesReader = (PesReader) payloadReader;
-          if (pesReader.canConsumeSynthesizedEmptyPusi(isModeHls)) {
-            pesReader.consume(new ParsableByteArray(), FLAG_PAYLOAD_UNIT_START_INDICATOR);
+      if (mode != MODE_HLS) { // see https://github.com/androidx/media/pull/419 PR
+        for (int i = 0; i < tsPayloadReaders.size(); i++) {
+          TsPayloadReader payloadReader = tsPayloadReaders.valueAt(i);
+          if (payloadReader instanceof PesReader) {
+            PesReader pesReader = (PesReader) payloadReader;
+            if (pesReader.canConsumeSynthesizedEmptyPusi(isModeHls)) {
+              pesReader.consume(new ParsableByteArray(), FLAG_PAYLOAD_UNIT_START_INDICATOR);
+            }
           }
         }
       }


### PR DESCRIPTION
Hi developers
in  [PR](https://github.com/androidx/media/pull/419) discused some context about why it's correct to only do this if `mode != MODE_HLS`
The autor [PR]( https://github.com/androidx/media/pull/419) could not defend his opinion about HLS check in `TsExtractor ->  read()` method

![for_pul](https://github.com/user-attachments/assets/23b993c1-f089-4247-9250-4839038209de)

please approve our PR,  since our hls's work fine in `ExoPlayer` lib and after migtration to `Media3` lib our hls's work fine up to `1.1.1` version
But our hls's freeze on `1.2.0 - alpha01` version and above (was added [PR]( https://github.com/androidx/media/pull/419))
in our PR we added only HLS check in` TsExtractor ->  read()` method


Without of our check`mode != MODE_HLS` would break HLS mode, because of the presence of the next segment.