### PR TITLE
Bug fix for Vobsub support

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/vobsub/VobsubParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/vobsub/VobsubParser.java
@@ -106,6 +106,9 @@ public final class VobsubParser implements SubtitleParser {
 
   private static final class CueBuilder {
 
+    private static final int CMD_FORCE_START = 0;
+    private static final int CMD_START = 1;
+    private static final int CMD_STOP = 2;
     private static final int CMD_COLORS = 3;
     private static final int CMD_ALPHA = 4;
     private static final int CMD_AREA = 5;
@@ -197,6 +200,11 @@ public final class VobsubParser implements SubtitleParser {
             if (!parseControlOffsets(buffer)) {
               return;
             }
+            break;
+          case CMD_FORCE_START:
+          case CMD_START:
+          case CMD_STOP:
+            // ignore unused commands without arguments
             break;
           case CMD_END:
           default:


### PR DESCRIPTION
This is a bug fix for the already accepted pull request https://github.com/androidx/media/pull/1979. When @icbaker and I were working on that pull request a `default` clause in the switch of `parseControl()` was added which makes subtitle parsing fail if unused SPU commands are not ignored. I only noticed this now, sorry for that.

The patch in this pull request fixes this by intentionally ignoring unused SPU commands without arguments (see the patch and the comment added by it).

Since the pull request mentioned above has already been accepted, this bug fix is actually quite important ;-)