### PR TITLE
Update PesReader -> canConsumeSynthesizedEmptyPusi metnod

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PesReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PesReader.java
@@ -171,9 +171,14 @@ public final class PesReader implements TsPayloadReader {
     // pes does not have a length field and body is being read, another exclusion
     // is due to H262 streams possibly having, in HLS mode, a pes across more than one segment
     // which would trigger committing an unfinished sample in the middle of the access unit
+
+    // Only call parseHeader if isModeHls is true and can parse header
+    // some hls may contains broken packages
+    boolean headerParsed = !isModeHls || parseHeader();
     return state == STATE_READING_BODY
         && payloadSize == C.LENGTH_UNSET
-        && !(isModeHls && reader instanceof H262Reader);
+        && !(isModeHls && reader instanceof H262Reader)
+        && headerParsed;
   }
 
   private void setState(int state) {


### PR DESCRIPTION
Hi developers
According to [#1189](https://github.com/androidx/media/pull/1189/) `PesReader` was updated. 
I noticed that some hls contains packages with incorrect PES headers which provide video friezes.
Was added additional check to `canConsumeSynthesizedEmptyPus`i method for hls.
Since our hls's work fine in `ExoPlayer` lib and after migtration to `Media3` lib our hls's work fine up to `1.1.1` version
But our hls's freeze on `1.2.0 - alpha01` version and above (was added [#419](https://github.com/androidx/media/pull/419))