### PR TITLE
Allow CmcdConfiguration.Factory to return null to disable CMCD

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/CmcdConfiguration.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/CmcdConfiguration.java
@@ -127,8 +127,9 @@ public final class CmcdConfiguration {
      * Creates a {@link CmcdConfiguration} based on the provided {@link MediaItem}.
      *
      * @param mediaItem The {@link MediaItem} from which to create the CMCD configuration.
-     * @return A {@link CmcdConfiguration} instance.
+     * @return A {@link CmcdConfiguration} instance, or {@code null} to disable CMCD.
      */
+    @Nullable
     CmcdConfiguration createCmcdConfiguration(MediaItem mediaItem);
 
     /**

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaSource.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaSource.java
@@ -112,7 +112,7 @@ public final class DashMediaSource extends BaseMediaSource {
     private final DashChunkSource.Factory chunkSourceFactory;
     @Nullable private final DataSource.Factory manifestDataSourceFactory;
 
-    private CmcdConfiguration.Factory cmcdConfigurationFactory;
+    @Nullable private CmcdConfiguration.Factory cmcdConfigurationFactory;
     private DrmSessionManagerProvider drmSessionManagerProvider;
     private CompositeSequenceableLoaderFactory compositeSequenceableLoaderFactory;
     private LoadErrorHandlingPolicy loadErrorHandlingPolicy;


### PR DESCRIPTION
We would like to enable or disable CMCD selectively for specific media items. This already works today by simply returning `null` from `CmcdConfiguration.Factory.createCmcdConfiguration()`, however this behavior is not specified anywhere.

This PR updates the return type to be `@Nullable`, so this behavior is properly specified and better supported for Kotlin users.