### PR TITLE
fmtp parser: checks parameterPair.length before accessing parameterPair[1]

### DIFF
--- a/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/MediaDescription.java
+++ b/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/MediaDescription.java
@@ -392,7 +392,9 @@ import java.util.Objects;
     for (String parameter : parameters) {
       // The parameter values can bear equal signs, so splitAtFirst must be used.
       String[] parameterPair = Util.splitAtFirst(parameter, "=");
-      formatParametersBuilder.put(parameterPair[0], parameterPair[1]);
+      if (parameterPair.length == 2) {
+        formatParametersBuilder.put(parameterPair[0].trim(), parameterPair[1].trim());
+      }
     }
     return formatParametersBuilder.buildOrThrow();
   }

--- a/libraries/exoplayer_rtsp/src/test/java/androidx/media3/exoplayer/rtsp/FmtpParserTest.java
+++ b/libraries/exoplayer_rtsp/src/test/java/androidx/media3/exoplayer/rtsp/FmtpParserTest.java
@@ -1,0 +1,104 @@
+package androidx.media3.exoplayer.rtsp;
+
+import static androidx.media3.exoplayer.rtsp.MediaDescription.MEDIA_TYPE_VIDEO;
+import static androidx.media3.exoplayer.rtsp.MediaDescription.RTP_AVP_PROFILE;
+import static androidx.media3.exoplayer.rtsp.SessionDescription.ATTR_CONTROL;
+import static androidx.media3.exoplayer.rtsp.SessionDescription.ATTR_FMTP;
+import static androidx.media3.exoplayer.rtsp.SessionDescription.ATTR_RTPMAP;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+public class FmtpParserTest {
+
+  private MediaDescription createMediaDescription(String fmtpValue) {
+    return new MediaDescription.Builder(
+        MEDIA_TYPE_VIDEO, /* port= */ 0, RTP_AVP_PROFILE, /* payloadType= */ 96)
+        .addAttribute(ATTR_RTPMAP, "96 H264/90000")
+        .addAttribute(ATTR_FMTP, fmtpValue)
+        .build();
+  }
+
+  @Test
+  public void testValidFmtpParameters() {
+    MediaDescription mediaDescription = createMediaDescription(
+        "96 packetization-mode=1;profile-level-id=4D4028;sprop-parameter-sets=Z01AKJ2oHgCJ+WEAAAMAAQAAAwAehA==,aO48gA=="
+    );
+
+    ImmutableMap<String, String> fmtpMap = mediaDescription.getFmtpParametersAsMap();
+
+    assertThat(fmtpMap).containsExactly(
+        "packetization-mode", "1",
+        "profile-level-id", "4D4028",
+        "sprop-parameter-sets", "Z01AKJ2oHgCJ+WEAAAMAAQAAAwAehA==,aO48gA=="
+    );
+  }
+
+  @Test
+  public void testEmptyFmtpAttribute() {
+    try {
+      MediaDescription mediaDescription = createMediaDescription("");
+
+      ImmutableMap<String, String> fmtpMap = mediaDescription.getFmtpParametersAsMap();
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Test
+  public void testNullFmtpAttribute() {
+    try {
+      MediaDescription mediaDescription = createMediaDescription(null);
+      ImmutableMap<String, String> fmtpMap = mediaDescription.getFmtpParametersAsMap();
+      assertThat(fmtpMap).isEmpty();
+    } catch (NullPointerException e) {
+      assertThat(e).isInstanceOf(NullPointerException.class);
+    }
+  }
+
+  @Test
+  public void testInvalidFormat_NoEqualSigns() {
+    MediaDescription mediaDescription = createMediaDescription("96 invalid-format");
+
+    ImmutableMap<String, String> fmtpMap = mediaDescription.getFmtpParametersAsMap();
+
+    assertThat(fmtpMap).isEmpty();
+  }
+
+  @Test
+  public void testTrailingSemicolon() {
+    MediaDescription mediaDescription = createMediaDescription(
+        "96 packetization-mode=1;profile-level-id=4D4028;");
+
+    ImmutableMap<String, String> fmtpMap = mediaDescription.getFmtpParametersAsMap();
+
+    assertThat(fmtpMap).containsExactly(
+        "packetization-mode", "1",
+        "profile-level-id", "4D4028"
+    );
+  }
+
+  @Test
+  public void testMultipleEqualsInValue() {
+    MediaDescription mediaDescription = createMediaDescription(
+        "96 complex-param=abc=xyz;another-param=value");
+
+    ImmutableMap<String, String> fmtpMap = mediaDescription.getFmtpParametersAsMap();
+
+    assertThat(fmtpMap).containsExactly(
+        "complex-param", "abc=xyz",
+        "another-param", "value"
+    );
+  }
+
+  @Test
+  public void testIncorrectFmtpFormat() {
+    // Modified input to have a space but still invalid
+    MediaDescription mediaDescription = createMediaDescription("96 profile-level-id");
+
+    ImmutableMap<String, String> fmtpMap = mediaDescription.getFmtpParametersAsMap();
+
+    assertThat(fmtpMap).isEmpty();
+  }
+}


### PR DESCRIPTION
MediaDescription.getFmtpParametersAsMap() can throw an `ArrayIndexOutOfBoundsException` with RTSP feeds.


Error thrown
 ```java
 java.lang.ArrayIndexOutOfBoundsException: length=1; index=1          
 at androidx.media3.exoplayer.rtsp.MediaDescription.getFmtpParametersAsMap(MediaDescription.java:394) 
 ```
 attributes sent as follows:
 ```
 96 packetization-mode=1;profile-level-id=4D4028;sprop-parameter-sets=Z01AKJ2oHgCJ+WEAAAMAAQAAAwAehA==,aO48gA==
 ```
 then 
 
 ```java
 0 PCMA/8000
 ```
passes 
 ```java
checkArgument(fmtpComponents.length == 2, fmtpAttributeValue);
 ```
 but would fail 
 ```java
 formatParametersBuilder.put(parameterPair[0], parameterPair[1]);
 ```
 as `parameterPair[1]` does not exist.
 This code checks parameterPair.length before accessing parameterPair[1]
 
 Catching this issue enables the RTSP stream to play with no issue.