### PR TITLE
notify ShuffleOrder when media item(s) are moved

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -13,6 +13,8 @@
     *   Throw `IllegalStateException` when `PreloadMediaSource` is played by an
         `ExoPlayer` with a playback thread that is different than the preload
         thread ([#2495](https://github.com/androidx/media/issues/2495)).
+    *   Add `cloneAndMove` to `ShuffleMode` with a default implementation
+        ([#2226](https://github.com/androidx/media/pull/2226)).
 *   Transformer:
     *   Add `CodecDbLite` that enables chipset specific optimizations of video
         encoding settings.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
@@ -703,7 +703,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
     }
     Timeline oldTimeline = getCurrentTimeline();
     pendingOperationAcks++;
-    Util.moveItems(mediaSourceHolderSnapshots, fromIndex, toIndex, newFromIndex);
+    moveMediaSourceHolders(fromIndex, toIndex, newFromIndex);
     Timeline newTimeline = createMaskingTimeline();
     PlaybackInfo newPlaybackInfo =
         maskTimelineAndPosition(
@@ -723,6 +723,11 @@ import java.util.concurrent.CopyOnWriteArraySet;
         /* ignored */ C.TIME_UNSET,
         /* ignored */ C.INDEX_UNSET,
         /* repeatCurrentMediaItem= */ false);
+  }
+
+  private void moveMediaSourceHolders(int fromIndex, int toIndex, int newFromIndex) {
+    Util.moveItems(mediaSourceHolderSnapshots, fromIndex, toIndex, newFromIndex);
+    shuffleOrder = shuffleOrder.cloneAndMove(fromIndex, toIndex, newFromIndex);
   }
 
   @Override

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
@@ -703,7 +703,8 @@ import java.util.concurrent.CopyOnWriteArraySet;
     }
     Timeline oldTimeline = getCurrentTimeline();
     pendingOperationAcks++;
-    moveMediaSourceHolders(fromIndex, toIndex, newFromIndex);
+    Util.moveItems(mediaSourceHolderSnapshots, fromIndex, toIndex, newFromIndex);
+    shuffleOrder = shuffleOrder.cloneAndMove(fromIndex, toIndex, newFromIndex);
     Timeline newTimeline = createMaskingTimeline();
     PlaybackInfo newPlaybackInfo =
         maskTimelineAndPosition(
@@ -723,11 +724,6 @@ import java.util.concurrent.CopyOnWriteArraySet;
         /* ignored */ C.TIME_UNSET,
         /* ignored */ C.INDEX_UNSET,
         /* repeatCurrentMediaItem= */ false);
-  }
-
-  private void moveMediaSourceHolders(int fromIndex, int toIndex, int newFromIndex) {
-    Util.moveItems(mediaSourceHolderSnapshots, fromIndex, toIndex, newFromIndex);
-    shuffleOrder = shuffleOrder.cloneAndMove(fromIndex, toIndex, newFromIndex);
   }
 
   @Override

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ShuffleOrder.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ShuffleOrder.java
@@ -267,7 +267,10 @@ public interface ShuffleOrder {
   ShuffleOrder cloneAndInsert(int insertionIndex, int insertionCount);
 
   /**
-   * Returns a copy of the shuffle order with a range of elements moved.
+   * Returns a copy of the shuffle order to be used after a move.
+   *
+   * <p>The default implementation is a no-op. Custom implementation can choose to re-shuffle when
+   * items are moved.
    *
    * @param indexFrom The starting index in the unshuffled order of the range to move, from before
    *     the move occurs.
@@ -278,8 +281,7 @@ public interface ShuffleOrder {
    * @return A copy of this {@link ShuffleOrder} with the elements moved.
    */
   default ShuffleOrder cloneAndMove(int indexFrom, int indexToExclusive, int newIndexFrom) {
-    return cloneAndRemove(indexFrom, indexToExclusive)
-        .cloneAndInsert(newIndexFrom, indexToExclusive - indexFrom);
+    return this;
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ShuffleOrder.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ShuffleOrder.java
@@ -267,6 +267,22 @@ public interface ShuffleOrder {
   ShuffleOrder cloneAndInsert(int insertionIndex, int insertionCount);
 
   /**
+   * Returns a copy of the shuffle order with a range of elements moved.
+   *
+   * @param indexFrom The starting index in the unshuffled order of the range to move, from before
+   *     the move occurs.
+   * @param indexToExclusive The smallest index (must be greater or equal to {@code indexFrom}) that
+   *     is not included in the range of elements moved, from before the move occurs.
+   * @param newIndexFrom The starting index in the unshuffled order of the range to move, from after
+   *     the move occurs.
+   * @return A copy of this {@link ShuffleOrder} with the elements moved.
+   */
+  default ShuffleOrder cloneAndMove(int indexFrom, int indexToExclusive, int newIndexFrom) {
+    return cloneAndRemove(indexFrom, indexToExclusive)
+        .cloneAndInsert(newIndexFrom, indexToExclusive - indexFrom);
+  }
+
+  /**
    * Returns a copy of the shuffle order with a range of elements removed.
    *
    * @param indexFrom The starting index in the unshuffled order of the range to remove.


### PR DESCRIPTION
Issue: #1932
Issue: #1381

--

(Extracting a seperate method `moveMediaSourceHolders` was done to align with insert/remove code. A new `default` method instead of just implementing that in `DefaultShuffleOrder` was done because I believe the move detection is not required by simpler shuffle order implementations, and this makes upgrades easier as devs don't have to implement a new function.)