### PR TITLE
Add implementation for `getPlaylistMetadata()` and `setPlaylistMetadata()` in `CastPlayer`

### DIFF
--- a/libraries/cast/src/main/java/androidx/media3/cast/CastPlayer.java
+++ b/libraries/cast/src/main/java/androidx/media3/cast/CastPlayer.java
@@ -16,6 +16,7 @@
 package androidx.media3.cast;
 
 import static androidx.media3.common.util.Assertions.checkArgument;
+import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Util.SDK_INT;
 import static androidx.media3.common.util.Util.castNonNull;
 import static java.lang.Math.min;
@@ -166,6 +167,7 @@ public final class CastPlayer extends BasePlayer {
   private long pendingSeekPositionMs;
   @Nullable private PositionInfo pendingMediaItemRemovalPosition;
   private MediaMetadata mediaMetadata;
+  private MediaMetadata playlistMetadata;
   private DeviceInfo deviceInfo;
 
   /**
@@ -268,6 +270,7 @@ public final class CastPlayer extends BasePlayer {
     playbackState = STATE_IDLE;
     currentTimeline = CastTimeline.EMPTY_CAST_TIMELINE;
     mediaMetadata = MediaMetadata.EMPTY;
+    playlistMetadata = MediaMetadata.EMPTY;
     currentTracks = Tracks.EMPTY;
     availableCommands = new Commands.Builder().addAll(PERMANENT_AVAILABLE_COMMANDS).build();
     pendingSeekWindowIndex = C.INDEX_UNSET;
@@ -656,14 +659,19 @@ public final class CastPlayer extends BasePlayer {
 
   @Override
   public MediaMetadata getPlaylistMetadata() {
-    // CastPlayer does not currently support metadata.
-    return MediaMetadata.EMPTY;
+    return playlistMetadata;
   }
 
-  /** This method is not supported and does nothing. */
   @Override
-  public void setPlaylistMetadata(MediaMetadata mediaMetadata) {
-    // CastPlayer does not currently support metadata.
+  public void setPlaylistMetadata(MediaMetadata playlistMetadata) {
+    checkNotNull(playlistMetadata);
+    if (playlistMetadata.equals(this.playlistMetadata)) {
+      return;
+    }
+    this.playlistMetadata = playlistMetadata;
+    listeners.sendEvent(
+        EVENT_PLAYLIST_METADATA_CHANGED,
+        listener -> listener.onPlaylistMetadataChanged(this.playlistMetadata));
   }
 
   @Override

--- a/libraries/cast/src/test/java/androidx/media3/cast/CastPlayerTest.java
+++ b/libraries/cast/src/test/java/androidx/media3/cast/CastPlayerTest.java
@@ -1800,7 +1800,7 @@ public class CastPlayerTest {
   }
 
   @Test
-  public void setMediaItems_doesNotifyOnMetadataChanged() {
+  public void setMediaItems_doesNotifyOnMediaMetadataChanged() {
     when(mockRemoteMediaClient.queueJumpToItem(anyInt(), anyLong(), eq(null)))
         .thenReturn(mockPendingResult);
     ArgumentCaptor<MediaMetadata> metadataCaptor = ArgumentCaptor.forClass(MediaMetadata.class);
@@ -1827,7 +1827,7 @@ public class CastPlayerTest {
                 .build());
     castPlayer.addListener(mockListener);
 
-    MediaMetadata intitalMetadata = castPlayer.getMediaMetadata();
+    MediaMetadata initialMetadata = castPlayer.getMediaMetadata();
     castPlayer.setMediaItems(firstPlaylist, /* startIndex= */ 0, /* startPositionMs= */ 2000L);
     updateTimeLine(firstPlaylist, /* mediaQueueItemIds= */ new int[] {1}, /* currentItemId= */ 1);
     MediaMetadata firstMetadata = castPlayer.getMediaMetadata();
@@ -1850,7 +1850,7 @@ public class CastPlayerTest {
             secondPlaylist.get(1).mediaMetadata,
             secondPlaylist.get(0).mediaMetadata)
         .inOrder();
-    assertThat(intitalMetadata).isEqualTo(MediaMetadata.EMPTY);
+    assertThat(initialMetadata).isEqualTo(MediaMetadata.EMPTY);
     assertThat(ImmutableList.of(firstMetadata, secondMetadata, thirdMetadata))
         .containsExactly(
             firstPlaylist.get(0).mediaMetadata,
@@ -1896,6 +1896,35 @@ public class CastPlayerTest {
 
     verify(mockListener, times(3)).onMediaItemTransition(any(), anyInt());
     verify(mockListener, never()).onMediaMetadataChanged(any());
+  }
+
+  @Test
+  public void setPlaylistMetadata_doesNotifyOnPlaylistMetadataChanged() {
+    castPlayer.addListener(mockListener);
+
+    MediaMetadata metadata = new MediaMetadata.Builder().setArtist("foo").build();
+
+    assertThat(castPlayer.getPlaylistMetadata()).isEqualTo(MediaMetadata.EMPTY);
+
+    castPlayer.setPlaylistMetadata(metadata);
+
+    assertThat(castPlayer.getPlaylistMetadata()).isEqualTo(metadata);
+
+    verify(mockListener).onPlaylistMetadataChanged(metadata);
+  }
+
+  @Test
+  public void setPlaylistMetadata_equalMetadata_doesNotNotifyOnPlaylistMetadataChanged() {
+    castPlayer.addListener(mockListener);
+
+    MediaMetadata metadata = new MediaMetadata.Builder().setArtist("foo").build();
+
+    castPlayer.setPlaylistMetadata(metadata);
+    castPlayer.setPlaylistMetadata(metadata);
+
+    assertThat(castPlayer.getPlaylistMetadata()).isEqualTo(metadata);
+
+    verify(mockListener, times(1)).onPlaylistMetadataChanged(metadata);
   }
 
   @Test


### PR DESCRIPTION
This commit implements the `getPlaylistMetadata()` and `setPlaylistMetadata()` methods in the `CastPlayer` class.
The new implementations are based on what is done in `ExoPlayerImpl`.