### PR TITLE
expand format support for audio processors used by DefaultAudioSink

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,6 +11,8 @@
 *   Extractors:
 *   DataSource:
 *   Audio:
+    *   Add support for all linear PCM sample formats in
+        `ChannelMappingAudioProcessor` and `TrimmingAudioProcessor`.
 *   Video:
     *   Improve smooth video frame release at startup when audio samples don't
         start at exactly the requested position.
@@ -112,8 +114,6 @@ This release includes the following changes since [1.6.1](#161-2025-04-14):
     *   Fix bug that `AnalyticsListener.onAudioPositionAdvancing` was not
         reporting the time when the audio started advancing but the time of the
         first measurement.
-    *   Add support for all linear PCM sample formats in
-        `ChannelMappingAudioProcessor` and `TrimmingAudioProcessor`.
 *   Video:
     *   Add experimental `ExoPlayer` API to include the
         `MediaCodec.BUFFER_FLAG_DECODE_ONLY` flag when queuing decode-only input

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -112,6 +112,8 @@ This release includes the following changes since [1.6.1](#161-2025-04-14):
     *   Fix bug that `AnalyticsListener.onAudioPositionAdvancing` was not
         reporting the time when the audio started advancing but the time of the
         first measurement.
+    *   Add support for all linear PCM sample formats in
+        `ChannelMappingAudioProcessor` and `TrimmingAudioProcessor`.
 *   Video:
     *   Add experimental `ExoPlayer` API to include the
         `MediaCodec.BUFFER_FLAG_DECODE_ONLY` flag when queuing decode-only input

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -118,10 +118,8 @@ import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.ReadOnlyBufferException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -3462,21 +3460,16 @@ public final class Util {
   }
 
   /**
-   * Absolute <i>get</i> method for reading a sign-extended 24-bit integer value.
+   * Returns the sign-extended 24-bit integer value at {@code index}.
    *
-   * <p>Reads three bytes at the given index, composing them into a 24-bit integer value according
-   * to the current byte order.
-   *
-   * @param buf The buffer to operate on
-   * @param index The index from which the bytes will be read
-   * @return The 24-bit integer value at the given index
-   * @throws IndexOutOfBoundsException If {@code index} is negative or not smaller than the buffer's
-   *     limit, minus two
+   * @param buffer The buffer from which to read the 24-bit integer.
+   * @param index The index of the 24-bit integer.
    */
-  public static int getInt24(ByteBuffer buf, int index) {
-    byte component1 = buf.get(buf.order() == ByteOrder.BIG_ENDIAN ? index : index + 2);
-    byte component2 = buf.get(index + 1);
-    byte component3 = buf.get(buf.order() == ByteOrder.BIG_ENDIAN ? index + 2 : index);
+  @UnstableApi
+  public static int getInt24(ByteBuffer buffer, int index) {
+    byte component1 = buffer.get(buffer.order() == ByteOrder.BIG_ENDIAN ? index : index + 2);
+    byte component2 = buffer.get(index + 1);
+    byte component3 = buffer.get(buffer.order() == ByteOrder.BIG_ENDIAN ? index + 2 : index);
     return ((component1 << 24) & 0xff000000
             | (component2 << 16) & 0xff0000
             | (component3 << 8) & 0xff00)
@@ -3484,29 +3477,30 @@ public final class Util {
   }
 
   /**
-   * Relative <i>put</i> method for writing a 24-bit integer value.
+   * Writes a 24-bit integer value to a buffer at its current {@link ByteBuffer#position()}.
    *
-   * <p>Writes three bytes containing the given int value, in the current byte order, into this
-   * buffer at the current position, and then increments the position by three.
+   * <p>This is a relative operation that affects the buffer's position.
    *
-   * @param val The short value to be written
-   * @param buf The buffer to operate on
-   * @throws BufferOverflowException If there are fewer than two bytes remaining in this buffer
-   * @throws ReadOnlyBufferException If this buffer is read-only
-   * @throws IllegalArgumentException If the value is out of range for a 24-bit integer
+   * @param buffer The buffer on which to write the integer.
+   * @param value The integer value to write.
+   * @throws IllegalArgumentException If {@code value} is out of range for a 24-bit integer.
    */
-  public static void putInt24(ByteBuffer buf, int val) {
-    if ((val & ~0xffffff) != 0 && (val & ~0x7fffff) != 0xff800000) {
-      throw new IllegalArgumentException("value out of range: " + Integer.toHexString(val));
-    }
+  @UnstableApi
+  public static void putInt24(ByteBuffer buffer, int value) {
+    checkArgument(
+        (value & ~0xffffff) == 0 || (value & ~0x7fffff) == 0xff800000,
+        "Value out of range of 24-bit integer: " + Integer.toHexString(value));
+    checkArgument(buffer.remaining() >= 3);
     byte component1 =
-        buf.order() == ByteOrder.BIG_ENDIAN ? (byte) ((val & 0xFF0000) >> 16) : (byte) (val & 0xFF);
-    byte component2 = (byte) ((val & 0xFF00) >> 8);
+        buffer.order() == ByteOrder.BIG_ENDIAN
+            ? (byte) ((value & 0xFF0000) >> 16)
+            : (byte) (value & 0xFF);
+    byte component2 = (byte) ((value & 0xFF00) >> 8);
     byte component3 =
-        buf.order() == ByteOrder.BIG_ENDIAN ? (byte) (val & 0xFF) : (byte) ((val & 0xFF0000) >> 16);
-    buf.put(component1);
-    buf.put(component2);
-    buf.put(component3);
+        buffer.order() == ByteOrder.BIG_ENDIAN
+            ? (byte) (value & 0xFF)
+            : (byte) ((value & 0xFF0000) >> 16);
+    buffer.put(component1).put(component2).put(component3);
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ChannelMappingAudioProcessor.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ChannelMappingAudioProcessor.java
@@ -16,6 +16,9 @@
 package androidx.media3.exoplayer.audio;
 
 import static androidx.media3.common.util.Util.getByteDepth;
+import static androidx.media3.common.util.Util.getInt24;
+import static androidx.media3.common.util.Util.isEncodingLinearPcm;
+import static androidx.media3.common.util.Util.putInt24;
 
 import androidx.annotation.Nullable;
 import androidx.media3.common.C;
@@ -24,7 +27,6 @@ import androidx.media3.common.audio.AudioProcessor;
 import androidx.media3.common.audio.BaseAudioProcessor;
 import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -59,7 +61,7 @@ public final class ChannelMappingAudioProcessor extends BaseAudioProcessor {
       return AudioFormat.NOT_SET;
     }
 
-    if (!Util.isEncodingLinearPcm(inputAudioFormat.encoding)) {
+    if (!isEncodingLinearPcm(inputAudioFormat.encoding)) {
       throw new UnhandledAudioFormatException(inputAudioFormat);
     }
 
@@ -102,7 +104,7 @@ public final class ChannelMappingAudioProcessor extends BaseAudioProcessor {
             break;
           case C.ENCODING_PCM_24BIT:
           case C.ENCODING_PCM_24BIT_BIG_ENDIAN:
-            Util.putInt24(buffer, Util.getInt24(inputBuffer, inputIndex));
+            putInt24(buffer, getInt24(inputBuffer, inputIndex));
             break;
           case C.ENCODING_PCM_32BIT:
           case C.ENCODING_PCM_32BIT_BIG_ENDIAN:

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -540,6 +540,7 @@ public final class DefaultAudioSink implements AudioSink {
   private final TrimmingAudioProcessor trimmingAudioProcessor;
   private final ImmutableList<AudioProcessor> toIntPcmAvailableAudioProcessors;
   private final ImmutableList<AudioProcessor> toFloatPcmAvailableAudioProcessors;
+  private final ImmutableList<AudioProcessor> forPreProcessingAvailableAudioProcessors;
   private final AudioTrackPositionTracker audioTrackPositionTracker;
   private final ArrayDeque<MediaPositionParameters> mediaPositionParametersCheckpoints;
   private final boolean preferAudioTrackPlaybackParams;
@@ -620,12 +621,10 @@ public final class DefaultAudioSink implements AudioSink {
     audioTrackPositionTracker = new AudioTrackPositionTracker(new PositionTrackerListener());
     channelMappingAudioProcessor = new ChannelMappingAudioProcessor();
     trimmingAudioProcessor = new TrimmingAudioProcessor();
-    toIntPcmAvailableAudioProcessors =
-        ImmutableList.of(
-            new ToInt16PcmAudioProcessor(), channelMappingAudioProcessor, trimmingAudioProcessor);
-    toFloatPcmAvailableAudioProcessors =
-        ImmutableList.of(
-            new ToFloatPcmAudioProcessor(), channelMappingAudioProcessor, trimmingAudioProcessor);
+    toIntPcmAvailableAudioProcessors = ImmutableList.of(new ToInt16PcmAudioProcessor());
+    toFloatPcmAvailableAudioProcessors = ImmutableList.of(new ToFloatPcmAudioProcessor());
+    forPreProcessingAvailableAudioProcessors =
+        ImmutableList.of(trimmingAudioProcessor, channelMappingAudioProcessor);
     volume = 1f;
     audioSessionId = C.AUDIO_SESSION_ID_UNSET;
     auxEffectInfo = new AuxEffectInfo(AuxEffectInfo.NO_AUX_EFFECT_ID, 0f);
@@ -727,6 +726,7 @@ public final class DefaultAudioSink implements AudioSink {
       inputPcmFrameSize = Util.getPcmFrameSize(inputFormat.pcmEncoding, inputFormat.channelCount);
 
       ImmutableList.Builder<AudioProcessor> pipelineProcessors = new ImmutableList.Builder<>();
+      pipelineProcessors.addAll(forPreProcessingAvailableAudioProcessors);
       if (shouldUseFloatOutput(inputFormat.pcmEncoding)) {
         pipelineProcessors.addAll(toFloatPcmAvailableAudioProcessors);
       } else {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -538,9 +538,9 @@ public final class DefaultAudioSink implements AudioSink {
   private final boolean enableFloatOutput;
   private final ChannelMappingAudioProcessor channelMappingAudioProcessor;
   private final TrimmingAudioProcessor trimmingAudioProcessor;
-  private final ImmutableList<AudioProcessor> toIntPcmAvailableAudioProcessors;
-  private final ImmutableList<AudioProcessor> toFloatPcmAvailableAudioProcessors;
-  private final ImmutableList<AudioProcessor> forPreProcessingAvailableAudioProcessors;
+  private final ToInt16PcmAudioProcessor toInt16PcmAudioProcessor;
+  private final ToFloatPcmAudioProcessor toFloatPcmAudioProcessor;
+  private final ImmutableList<AudioProcessor> availableAudioProcessors;
   private final AudioTrackPositionTracker audioTrackPositionTracker;
   private final ArrayDeque<MediaPositionParameters> mediaPositionParametersCheckpoints;
   private final boolean preferAudioTrackPlaybackParams;
@@ -621,9 +621,9 @@ public final class DefaultAudioSink implements AudioSink {
     audioTrackPositionTracker = new AudioTrackPositionTracker(new PositionTrackerListener());
     channelMappingAudioProcessor = new ChannelMappingAudioProcessor();
     trimmingAudioProcessor = new TrimmingAudioProcessor();
-    toIntPcmAvailableAudioProcessors = ImmutableList.of(new ToInt16PcmAudioProcessor());
-    toFloatPcmAvailableAudioProcessors = ImmutableList.of(new ToFloatPcmAudioProcessor());
-    forPreProcessingAvailableAudioProcessors =
+    toInt16PcmAudioProcessor = new ToInt16PcmAudioProcessor();
+    toFloatPcmAudioProcessor = new ToFloatPcmAudioProcessor();
+    availableAudioProcessors =
         ImmutableList.of(trimmingAudioProcessor, channelMappingAudioProcessor);
     volume = 1f;
     audioSessionId = C.AUDIO_SESSION_ID_UNSET;
@@ -726,11 +726,11 @@ public final class DefaultAudioSink implements AudioSink {
       inputPcmFrameSize = Util.getPcmFrameSize(inputFormat.pcmEncoding, inputFormat.channelCount);
 
       ImmutableList.Builder<AudioProcessor> pipelineProcessors = new ImmutableList.Builder<>();
-      pipelineProcessors.addAll(forPreProcessingAvailableAudioProcessors);
+      pipelineProcessors.addAll(availableAudioProcessors);
       if (shouldUseFloatOutput(inputFormat.pcmEncoding)) {
-        pipelineProcessors.addAll(toFloatPcmAvailableAudioProcessors);
+        pipelineProcessors.add(toFloatPcmAudioProcessor);
       } else {
-        pipelineProcessors.addAll(toIntPcmAvailableAudioProcessors);
+        pipelineProcessors.add(toInt16PcmAudioProcessor);
         pipelineProcessors.add(audioProcessorChain.getAudioProcessors());
       }
       audioProcessingPipeline = new AudioProcessingPipeline(pipelineProcessors.build());
@@ -1619,12 +1619,12 @@ public final class DefaultAudioSink implements AudioSink {
   @Override
   public void reset() {
     flush();
-    for (AudioProcessor audioProcessor : toIntPcmAvailableAudioProcessors) {
+    for (AudioProcessor audioProcessor : availableAudioProcessors) {
       audioProcessor.reset();
     }
-    for (AudioProcessor audioProcessor : toFloatPcmAvailableAudioProcessors) {
-      audioProcessor.reset();
-    }
+    toInt16PcmAudioProcessor.reset();
+    toFloatPcmAudioProcessor.reset();
+
     if (audioProcessingPipeline != null) {
       audioProcessingPipeline.reset();
     }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/TrimmingAudioProcessor.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/TrimmingAudioProcessor.java
@@ -17,7 +17,6 @@ package androidx.media3.exoplayer.audio;
 
 import static java.lang.Math.min;
 
-import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.audio.BaseAudioProcessor;
 import androidx.media3.common.util.UnstableApi;
@@ -80,8 +79,7 @@ public final class TrimmingAudioProcessor extends BaseAudioProcessor {
   @Override
   public AudioFormat onConfigure(AudioFormat inputAudioFormat)
       throws UnhandledAudioFormatException {
-    if (inputAudioFormat.encoding != C.ENCODING_PCM_16BIT
-        && inputAudioFormat.encoding != C.ENCODING_PCM_FLOAT) {
+    if (!Util.isEncodingLinearPcm(inputAudioFormat.encoding)) {
       throw new UnhandledAudioFormatException(inputAudioFormat);
     }
     reconfigurationPending = true;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/TrimmingAudioProcessor.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/TrimmingAudioProcessor.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.audio;
 
+import static androidx.media3.common.util.Util.isEncodingLinearPcm;
 import static java.lang.Math.min;
 
 import androidx.media3.common.Format;
@@ -79,7 +80,7 @@ public final class TrimmingAudioProcessor extends BaseAudioProcessor {
   @Override
   public AudioFormat onConfigure(AudioFormat inputAudioFormat)
       throws UnhandledAudioFormatException {
-    if (!Util.isEncodingLinearPcm(inputAudioFormat.encoding)) {
+    if (!isEncodingLinearPcm(inputAudioFormat.encoding)) {
       throw new UnhandledAudioFormatException(inputAudioFormat);
     }
     reconfigurationPending = true;

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/ChannelMappingAudioProcessorTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/ChannelMappingAudioProcessorTest.java
@@ -92,7 +92,7 @@ public class ChannelMappingAudioProcessorTest {
 
     processor.queueInput(createInt24ByteBuffer(new int[] {0xff0001, 0x00ff02, 0x0300ff, 0x40ff00}));
     int[] output = createInt24Array(processor.getOutput());
-    assertThat(output).isEqualTo(new int[] {0x00ff02, 0xff0001, 0x40ff00, 0x0300ff});
+    assertThat(output).isEqualTo(new int[] {0x00ff02, 0xffff0001, 0x40ff00, 0x0300ff});
   }
 
   @Test

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/ChannelMappingAudioProcessorTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/ChannelMappingAudioProcessorTest.java
@@ -15,8 +15,12 @@
  */
 package androidx.media3.exoplayer.audio;
 
+import static androidx.media3.test.utils.TestUtil.createByteArray;
 import static androidx.media3.test.utils.TestUtil.createByteBuffer;
 import static androidx.media3.test.utils.TestUtil.createFloatArray;
+import static androidx.media3.test.utils.TestUtil.createInt24Array;
+import static androidx.media3.test.utils.TestUtil.createInt24ByteBuffer;
+import static androidx.media3.test.utils.TestUtil.createIntArray;
 import static androidx.media3.test.utils.TestUtil.createShortArray;
 import static com.google.common.truth.Truth.assertThat;
 
@@ -36,9 +40,21 @@ public class ChannelMappingAudioProcessorTest {
       new AudioFormat(
           /* sampleRate= */ 44100, /* channelCount= */ 3, /* encoding= */ C.ENCODING_PCM_FLOAT);
 
+  private static final AudioFormat PCM_32BIT_STEREO_FORMAT =
+      new AudioFormat(
+          /* sampleRate= */ 44100, /* channelCount= */ 2, /* encoding= */ C.ENCODING_PCM_32BIT);
+
+  private static final AudioFormat PCM_24BIT_STEREO_FORMAT =
+      new AudioFormat(
+          /* sampleRate= */ 44100, /* channelCount= */ 2, /* encoding= */ C.ENCODING_PCM_24BIT);
+
   private static final AudioFormat PCM_16BIT_STEREO_FORMAT =
       new AudioFormat(
           /* sampleRate= */ 44100, /* channelCount= */ 2, /* encoding= */ C.ENCODING_PCM_16BIT);
+
+  private static final AudioFormat PCM_8BIT_STEREO_FORMAT =
+      new AudioFormat(
+          /* sampleRate= */ 44100, /* channelCount= */ 2, /* encoding= */ C.ENCODING_PCM_8BIT);
 
   @Test
   public void channelMap_withPcmFloatSamples_mapsOutputCorrectly()
@@ -54,6 +70,32 @@ public class ChannelMappingAudioProcessorTest {
   }
 
   @Test
+  public void channelMap_withPcm32Samples_mapsOutputCorrectly()
+      throws AudioProcessor.UnhandledAudioFormatException {
+    ChannelMappingAudioProcessor processor = new ChannelMappingAudioProcessor();
+    processor.setChannelMap(new int[] {1, 0});
+    processor.configure(PCM_32BIT_STEREO_FORMAT);
+    processor.flush();
+
+    processor.queueInput(createByteBuffer(new int[] {1, 2, 3, 4, 5, 6}));
+    int[] output = createIntArray(processor.getOutput());
+    assertThat(output).isEqualTo(new int[] {2, 1, 4, 3, 6, 5});
+  }
+
+  @Test
+  public void channelMap_withPcm24Samples_mapsOutputCorrectly()
+      throws AudioProcessor.UnhandledAudioFormatException {
+    ChannelMappingAudioProcessor processor = new ChannelMappingAudioProcessor();
+    processor.setChannelMap(new int[] {1, 0});
+    processor.configure(PCM_24BIT_STEREO_FORMAT);
+    processor.flush();
+
+    processor.queueInput(createInt24ByteBuffer(new int[] {0xff0001, 0x00ff02, 0x0300ff, 0x40ff00}));
+    int[] output = createInt24Array(processor.getOutput());
+    assertThat(output).isEqualTo(new int[] {0x00ff02, 0xff0001, 0x40ff00, 0x0300ff});
+  }
+
+  @Test
   public void channelMap_withPcm16Samples_mapsOutputCorrectly()
       throws AudioProcessor.UnhandledAudioFormatException {
     ChannelMappingAudioProcessor processor = new ChannelMappingAudioProcessor();
@@ -64,6 +106,19 @@ public class ChannelMappingAudioProcessorTest {
     processor.queueInput(createByteBuffer(new short[] {1, 2, 3, 4, 5, 6}));
     short[] output = createShortArray(processor.getOutput());
     assertThat(output).isEqualTo(new short[] {2, 1, 4, 3, 6, 5});
+  }
+
+  @Test
+  public void channelMap_withPcm8Samples_mapsOutputCorrectly()
+      throws AudioProcessor.UnhandledAudioFormatException {
+    ChannelMappingAudioProcessor processor = new ChannelMappingAudioProcessor();
+    processor.setChannelMap(new int[] {1, 0});
+    processor.configure(PCM_8BIT_STEREO_FORMAT);
+    processor.flush();
+
+    processor.queueInput(createByteBuffer(new byte[] {1, 2, 3, 4, 5, 6}));
+    byte[] output = createByteArray(processor.getOutput());
+    assertThat(output).isEqualTo(new byte[] {2, 1, 4, 3, 6, 5});
   }
 
   @Test

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestUtil.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestUtil.java
@@ -82,6 +82,7 @@ import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -182,11 +183,35 @@ public class TestUtil {
     return content;
   }
 
+  /** Gets the underlying data of the {@link ByteBuffer} as a {@code int[]}. */
+  public static int[] createIntArray(ByteBuffer byteBuffer) {
+    IntBuffer buffer = byteBuffer.asIntBuffer();
+    int[] content = new int[buffer.remaining()];
+    buffer.get(content);
+    return content;
+  }
+
+  /** Gets the underlying data of the {@link ByteBuffer} as int24 values in {@code int[]}. */
+  public static int[] createInt24Array(ByteBuffer byteBuffer) {
+    int[] content = new int[byteBuffer.remaining() / 3];
+    for (int i = 0; i < content.length; i++) {
+      content[i] = Util.getInt24(byteBuffer, byteBuffer.position() + i * 3) & 0xffffff;
+    }
+    return content;
+  }
+
   /** Gets the underlying data of the {@link ByteBuffer} as a {@code short[]}. */
   public static short[] createShortArray(ByteBuffer byteBuffer) {
     ShortBuffer buffer = byteBuffer.asShortBuffer();
     short[] content = new short[buffer.remaining()];
     buffer.get(content);
+    return content;
+  }
+
+  /** Gets the underlying data of the {@link ByteBuffer} as a {@code byte[]}. */
+  public static byte[] createByteArray(ByteBuffer byteBuffer) {
+    byte[] content = new byte[byteBuffer.remaining()];
+    byteBuffer.get(content);
     return content;
   }
 
@@ -199,9 +224,34 @@ public class TestUtil {
   }
 
   /** Creates a {@link ByteBuffer} containing the {@code data}. */
+  public static ByteBuffer createByteBuffer(int[] data) {
+    ByteBuffer buffer = ByteBuffer.allocateDirect(data.length * 4).order(ByteOrder.nativeOrder());
+    buffer.asIntBuffer().put(data);
+    return buffer;
+  }
+
+  /** Creates a {@link ByteBuffer} containing the {@code data}. */
+  public static ByteBuffer createInt24ByteBuffer(int[] data) {
+    ByteBuffer buffer = ByteBuffer.allocateDirect(data.length * 3).order(ByteOrder.nativeOrder());
+    for (int i : data) {
+      Util.putInt24(buffer, i);
+    }
+    buffer.rewind();
+    return buffer;
+  }
+
+  /** Creates a {@link ByteBuffer} containing the {@code data}. */
   public static ByteBuffer createByteBuffer(short[] data) {
     ByteBuffer buffer = ByteBuffer.allocateDirect(data.length * 2).order(ByteOrder.nativeOrder());
     buffer.asShortBuffer().put(data);
+    return buffer;
+  }
+
+  /** Creates a {@link ByteBuffer} containing the {@code data}. */
+  public static ByteBuffer createByteBuffer(byte[] data) {
+    ByteBuffer buffer = ByteBuffer.allocateDirect(data.length).order(ByteOrder.nativeOrder());
+    buffer.put(data);
+    buffer.rewind();
     return buffer;
   }
 

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestUtil.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestUtil.java
@@ -18,6 +18,7 @@ package androidx.media3.test.utils;
 import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
+import static androidx.media3.common.util.Util.putInt24;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -175,6 +176,13 @@ public class TestUtil {
     return array;
   }
 
+  /** Gets the underlying data of the {@link ByteBuffer} as a {@code byte[]}. */
+  public static byte[] createByteArray(ByteBuffer byteBuffer) {
+    byte[] content = new byte[byteBuffer.remaining()];
+    byteBuffer.get(content);
+    return content;
+  }
+
   /** Gets the underlying data of the {@link ByteBuffer} as a {@code float[]}. */
   public static float[] createFloatArray(ByteBuffer byteBuffer) {
     FloatBuffer buffer = byteBuffer.asFloatBuffer();
@@ -191,11 +199,13 @@ public class TestUtil {
     return content;
   }
 
-  /** Gets the underlying data of the {@link ByteBuffer} as int24 values in {@code int[]}. */
+  /**
+   * Gets the underlying data of the {@link ByteBuffer} as 24-bit integer values in {@code int[]}.
+   */
   public static int[] createInt24Array(ByteBuffer byteBuffer) {
     int[] content = new int[byteBuffer.remaining() / 3];
     for (int i = 0; i < content.length; i++) {
-      content[i] = Util.getInt24(byteBuffer, byteBuffer.position() + i * 3) & 0xffffff;
+      content[i] = Util.getInt24(byteBuffer, byteBuffer.position() + i * 3);
     }
     return content;
   }
@@ -205,13 +215,6 @@ public class TestUtil {
     ShortBuffer buffer = byteBuffer.asShortBuffer();
     short[] content = new short[buffer.remaining()];
     buffer.get(content);
-    return content;
-  }
-
-  /** Gets the underlying data of the {@link ByteBuffer} as a {@code byte[]}. */
-  public static byte[] createByteArray(ByteBuffer byteBuffer) {
-    byte[] content = new byte[byteBuffer.remaining()];
-    byteBuffer.get(content);
     return content;
   }
 
@@ -231,16 +234,6 @@ public class TestUtil {
   }
 
   /** Creates a {@link ByteBuffer} containing the {@code data}. */
-  public static ByteBuffer createInt24ByteBuffer(int[] data) {
-    ByteBuffer buffer = ByteBuffer.allocateDirect(data.length * 3).order(ByteOrder.nativeOrder());
-    for (int i : data) {
-      Util.putInt24(buffer, i);
-    }
-    buffer.rewind();
-    return buffer;
-  }
-
-  /** Creates a {@link ByteBuffer} containing the {@code data}. */
   public static ByteBuffer createByteBuffer(short[] data) {
     ByteBuffer buffer = ByteBuffer.allocateDirect(data.length * 2).order(ByteOrder.nativeOrder());
     buffer.asShortBuffer().put(data);
@@ -251,6 +244,16 @@ public class TestUtil {
   public static ByteBuffer createByteBuffer(byte[] data) {
     ByteBuffer buffer = ByteBuffer.allocateDirect(data.length).order(ByteOrder.nativeOrder());
     buffer.put(data);
+    buffer.rewind();
+    return buffer;
+  }
+
+  /** Creates a {@link ByteBuffer} with the contents of {@code data} as 24-bit integers. */
+  public static ByteBuffer createInt24ByteBuffer(int[] data) {
+    ByteBuffer buffer = ByteBuffer.allocateDirect(data.length * 3).order(ByteOrder.nativeOrder());
+    for (int i : data) {
+      putInt24(buffer, i);
+    }
     buffer.rewind();
     return buffer;
   }


### PR DESCRIPTION
This allows future extensions such as direct 24 bit / 32 bit (int) playback in DefaultAudioSink, and is a step towards Issue: #1931

Run audio processors possibly discarding data first to avoid wasting CPU on data that'll be discarded anyway.