### PR TITLE
Use the existing `TAG` constant in `AudioManagerCompat`

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/audio/AudioManagerCompat.java
+++ b/libraries/common/src/main/java/androidx/media3/common/audio/AudioManagerCompat.java
@@ -220,10 +220,7 @@ public final class AudioManagerCompat {
     try {
       return audioManager.getStreamVolume(streamType);
     } catch (RuntimeException e) {
-      Log.w(
-          "AudioManagerCompat",
-          "Could not retrieve stream volume for stream type " + streamType,
-          e);
+      Log.w(TAG, "Could not retrieve stream volume for stream type " + streamType, e);
       return audioManager.getStreamMaxVolume(streamType);
     }
   }


### PR DESCRIPTION
https://github.com/androidx/media/blob/d5dcbf4a12bddbcf26e02fdfb29105f5c288ef5d/libraries/common/src/main/java/androidx/media3/common/audio/AudioManagerCompat.java#L43

This also addresses the `Private field 'TAG' is never used` warning.