### PR TITLE
session: fix IllegalStateException when calling setSessionExtras()

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -21,6 +21,10 @@
 *   Muxers:
 *   IMA extension:
 *   Session:
+    *   Fix bug where calling `setSessionExtras` from the main thread when
+        running the player from a different application thread then the main
+        thread caused an `IllegalStateException`
+        ([#2265](https://github.com/androidx/media/pull/2265)).
 *   UI:
 *   Downloads:
 *   OkHttp extension:

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
@@ -1135,7 +1135,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       PlayerWrapper playerWrapper = sessionImpl.getPlayerWrapper();
       playerWrapper.setLegacyExtras(sessionExtras);
       sessionCompat.setExtras(playerWrapper.getLegacyExtras());
-      sessionCompat.setPlaybackState(sessionImpl.getPlayerWrapper().createPlaybackStateCompat());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
 
     @Override


### PR DESCRIPTION
...from thread which isn't application thread. This change makes the demo app work with player using a non-main application thread.

(There is no related issue, I believe.)