### PR TITLE
Deprecate `Util.SDK_INT` in favor of `Build.VERSION.SDK_INT`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,6 +3,7 @@
 ### Unreleased changes
 
 *   Common Library:
+    *   Deprecate `Util.SDK_INT`. Use `Build.VERSION.SDK_INT` instead.
 *   ExoPlayer:
     *   Add `ExoPlayer.setScrubbingModeEnabled(boolean)` method. This optimizes
         the player for many frequent seeks (for example, from a user dragging a

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,7 +3,6 @@
 ### Unreleased changes
 
 *   Common Library:
-    *   Deprecate `Util.SDK_INT`. Use `Build.VERSION.SDK_INT` instead.
 *   ExoPlayer:
     *   Add `ExoPlayer.setScrubbingModeEnabled(boolean)` method. This optimizes
         the player for many frequent seeks (for example, from a user dragging a

--- a/demos/composition/src/main/java/androidx/media3/demo/composition/CompositionPreviewActivity.java
+++ b/demos/composition/src/main/java/androidx/media3/demo/composition/CompositionPreviewActivity.java
@@ -16,7 +16,7 @@
 package androidx.media3.demo.composition;
 
 import static android.content.pm.ActivityInfo.COLOR_MODE_HDR;
-import static androidx.media3.common.util.Util.SDK_INT;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.transformer.Composition.HDR_MODE_EXPERIMENTAL_FORCE_INTERPRET_HDR_AS_SDR;
 import static androidx.media3.transformer.Composition.HDR_MODE_KEEP_HDR;
 import static androidx.media3.transformer.Composition.HDR_MODE_TONE_MAP_HDR_TO_SDR_USING_MEDIACODEC;

--- a/demos/effect/src/main/java/androidx/media3/demo/effect/EffectActivity.kt
+++ b/demos/effect/src/main/java/androidx/media3/demo/effect/EffectActivity.kt
@@ -17,6 +17,7 @@ package androidx.media3.demo.effect
 
 import android.Manifest
 import android.net.Uri
+import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableString
@@ -81,7 +82,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.Effect
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.common.util.Util.SDK_INT
 import androidx.media3.effect.Contrast
 import androidx.media3.effect.OverlayEffect
 import androidx.media3.effect.StaticOverlaySettings

--- a/demos/gl/src/main/java/androidx/media3/demo/gl/MainActivity.java
+++ b/demos/gl/src/main/java/androidx/media3/demo/gl/MainActivity.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.demo.gl;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.app.Activity;
@@ -94,7 +95,7 @@ public final class MainActivity extends Activity {
   @Override
   public void onStart() {
     super.onStart();
-    if (Util.SDK_INT > 23) {
+    if (SDK_INT > 23) {
       initializePlayer();
       if (playerView != null) {
         playerView.onResume();
@@ -105,7 +106,7 @@ public final class MainActivity extends Activity {
   @Override
   public void onResume() {
     super.onResume();
-    if (Util.SDK_INT <= 23 || player == null) {
+    if (SDK_INT <= 23 || player == null) {
       initializePlayer();
       if (playerView != null) {
         playerView.onResume();
@@ -116,7 +117,7 @@ public final class MainActivity extends Activity {
   @Override
   public void onPause() {
     super.onPause();
-    if (Util.SDK_INT <= 23) {
+    if (SDK_INT <= 23) {
       if (playerView != null) {
         playerView.onPause();
       }
@@ -127,7 +128,7 @@ public final class MainActivity extends Activity {
   @Override
   public void onStop() {
     super.onStop();
-    if (Util.SDK_INT > 23) {
+    if (SDK_INT > 23) {
       if (playerView != null) {
         playerView.onPause();
       }

--- a/demos/transformer/src/main/java/androidx/media3/demo/transformer/ConfigurationActivity.java
+++ b/demos/transformer/src/main/java/androidx/media3/demo/transformer/ConfigurationActivity.java
@@ -17,8 +17,8 @@ package androidx.media3.demo.transformer;
 
 import static android.Manifest.permission.READ_EXTERNAL_STORAGE;
 import static android.Manifest.permission.READ_MEDIA_VIDEO;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkState;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static androidx.media3.transformer.Composition.HDR_MODE_EXPERIMENTAL_FORCE_INTERPRET_HDR_AS_SDR;
 import static androidx.media3.transformer.Composition.HDR_MODE_KEEP_HDR;
 import static androidx.media3.transformer.Composition.HDR_MODE_TONE_MAP_HDR_TO_SDR_USING_MEDIACODEC;

--- a/demos/transformer/src/main/java/androidx/media3/demo/transformer/TransformerActivity.java
+++ b/demos/transformer/src/main/java/androidx/media3/demo/transformer/TransformerActivity.java
@@ -16,6 +16,7 @@
 package androidx.media3.demo.transformer;
 
 import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.exoplayer.DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS;
@@ -985,14 +986,14 @@ public final class TransformerActivity extends AppCompatActivity {
                 .setOngoing(true)
                 .setSmallIcon(R.drawable.exo_icon_play)
                 .build();
-        if (Util.SDK_INT >= 26) {
+        if (SDK_INT >= 26) {
           NotificationChannel channel =
               new NotificationChannel(
                   CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_HIGH);
           NotificationManager manager = getSystemService(NotificationManager.class);
           manager.createNotificationChannel(channel);
         }
-        if (Util.SDK_INT >= 29) {
+        if (SDK_INT >= 29) {
           startForeground(NOTIFICATION_ID, notification, FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION);
         } else {
           startForeground(NOTIFICATION_ID, notification);

--- a/libraries/cast/src/main/java/androidx/media3/cast/CastPlayer.java
+++ b/libraries/cast/src/main/java/androidx/media3/cast/CastPlayer.java
@@ -15,9 +15,9 @@
  */
 package androidx.media3.cast;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static androidx.media3.common.util.Util.castNonNull;
 import static java.lang.Math.min;
 

--- a/libraries/common/src/main/java/androidx/media3/common/AudioAttributes.java
+++ b/libraries/common/src/main/java/androidx/media3/common/AudioAttributes.java
@@ -15,6 +15,8 @@
  */
 package androidx.media3.common;
 
+import static android.os.Build.VERSION.SDK_INT;
+
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -45,10 +47,10 @@ public final class AudioAttributes {
               .setContentType(audioAttributes.contentType)
               .setFlags(audioAttributes.flags)
               .setUsage(audioAttributes.usage);
-      if (Util.SDK_INT >= 29) {
+      if (SDK_INT >= 29) {
         Api29.setAllowedCapturePolicy(builder, audioAttributes.allowedCapturePolicy);
       }
-      if (Util.SDK_INT >= 32) {
+      if (SDK_INT >= 32) {
         Api32.setSpatializationBehavior(builder, audioAttributes.spatializationBehavior);
       }
       this.audioAttributes = builder.build();

--- a/libraries/common/src/main/java/androidx/media3/common/BundleListRetriever.java
+++ b/libraries/common/src/main/java/androidx/media3/common/BundleListRetriever.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.common;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.os.Binder;
@@ -25,7 +26,6 @@ import android.os.RemoteException;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
@@ -56,7 +56,7 @@ public final class BundleListRetriever extends Binder {
 
   // Soft limit of an IPC buffer size
   private static final int SUGGESTED_MAX_IPC_SIZE =
-      Util.SDK_INT >= 30 ? IBinder.getSuggestedMaxIpcSizeBytes() : 64 * 1024;
+      SDK_INT >= 30 ? IBinder.getSuggestedMaxIpcSizeBytes() : 64 * 1024;
 
   private static final int REPLY_END_OF_LIST = 0;
   private static final int REPLY_CONTINUE = 1;

--- a/libraries/common/src/main/java/androidx/media3/common/FlagSet.java
+++ b/libraries/common/src/main/java/androidx/media3/common/FlagSet.java
@@ -15,13 +15,13 @@
  */
 package androidx.media3.common;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkIndex;
 import static androidx.media3.common.util.Assertions.checkState;
 
 import android.util.SparseBooleanArray;
 import androidx.annotation.Nullable;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 /**
@@ -222,7 +222,7 @@ public final class FlagSet {
       return false;
     }
     FlagSet that = (FlagSet) o;
-    if (Util.SDK_INT < 24) {
+    if (SDK_INT < 24) {
       // SparseBooleanArray.equals() is not implemented on API levels below 24.
       if (size() != that.size()) {
         return false;
@@ -240,7 +240,7 @@ public final class FlagSet {
 
   @Override
   public int hashCode() {
-    if (Util.SDK_INT < 24) {
+    if (SDK_INT < 24) {
       // SparseBooleanArray.hashCode() is not implemented on API levels below 24.
       int hashCode = size();
       for (int i = 0; i < size(); i++) {

--- a/libraries/common/src/main/java/androidx/media3/common/audio/AudioFocusRequestCompat.java
+++ b/libraries/common/src/main/java/androidx/media3/common/audio/AudioFocusRequestCompat.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.common.audio;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
@@ -55,7 +56,7 @@ public final class AudioFocusRequestCompat {
     this.audioAttributes = audioFocusRequestCompat;
     this.pauseOnDuck = pauseOnDuck;
 
-    if (Util.SDK_INT < 26) {
+    if (SDK_INT < 26) {
       this.onAudioFocusChangeListener =
           new OnAudioFocusChangeListenerHandlerCompat(
               onAudioFocusChangeListener, focusChangeHandler);
@@ -63,7 +64,7 @@ public final class AudioFocusRequestCompat {
       this.onAudioFocusChangeListener = onAudioFocusChangeListener;
     }
 
-    if (Util.SDK_INT >= 26) {
+    if (SDK_INT >= 26) {
       this.frameworkAudioFocusRequest =
           new AudioFocusRequest.Builder(focusGain)
               .setAudioAttributes(audioAttributes.getAudioAttributesV21().audioAttributes)

--- a/libraries/common/src/main/java/androidx/media3/common/audio/AudioManagerCompat.java
+++ b/libraries/common/src/main/java/androidx/media3/common/audio/AudioManagerCompat.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.common.audio;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static java.lang.annotation.ElementType.TYPE_USE;
 
@@ -29,7 +30,6 @@ import androidx.media3.common.util.BackgroundExecutor;
 import androidx.media3.common.util.ConditionVariable;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -154,7 +154,7 @@ public final class AudioManagerCompat {
   @SuppressWarnings("deprecation")
   public static int requestAudioFocus(
       AudioManager audioManager, AudioFocusRequestCompat focusRequest) {
-    if (Util.SDK_INT >= 26) {
+    if (SDK_INT >= 26) {
       return audioManager.requestAudioFocus(focusRequest.getAudioFocusRequest());
     } else {
       return audioManager.requestAudioFocus(
@@ -176,7 +176,7 @@ public final class AudioManagerCompat {
   @SuppressWarnings("deprecation")
   public static int abandonAudioFocusRequest(
       AudioManager audioManager, AudioFocusRequestCompat focusRequest) {
-    if (Util.SDK_INT >= 26) {
+    if (SDK_INT >= 26) {
       return audioManager.abandonAudioFocusRequest(focusRequest.getAudioFocusRequest());
     } else {
       return audioManager.abandonAudioFocus(focusRequest.getOnAudioFocusChangeListener());
@@ -204,7 +204,7 @@ public final class AudioManagerCompat {
    */
   @IntRange(from = 0)
   public static int getStreamMinVolume(AudioManager audioManager, @C.StreamType int streamType) {
-    return Util.SDK_INT >= 28 ? audioManager.getStreamMinVolume(streamType) : 0;
+    return SDK_INT >= 28 ? audioManager.getStreamMinVolume(streamType) : 0;
   }
 
   /**
@@ -233,7 +233,7 @@ public final class AudioManagerCompat {
    * @return Whether the stream is muted.
    */
   public static boolean isStreamMute(AudioManager audioManager, @C.StreamType int streamType) {
-    if (Util.SDK_INT >= 23) {
+    if (SDK_INT >= 23) {
       return audioManager.isStreamMute(streamType);
     } else {
       return getStreamVolume(audioManager, streamType) == 0;

--- a/libraries/common/src/main/java/androidx/media3/common/util/GlUtil.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/GlUtil.java
@@ -17,6 +17,7 @@ package androidx.media3.common.util;
 
 import static android.opengl.EGL14.EGL_CONTEXT_CLIENT_VERSION;
 import static android.opengl.GLU.gluErrorString;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkState;
 
@@ -169,18 +170,17 @@ public final class GlUtil {
    * <p>If {@code true}, the device supports a protected output path for DRM content when using GL.
    */
   public static boolean isProtectedContentExtensionSupported(Context context) {
-    if (Util.SDK_INT < 24) {
+    if (SDK_INT < 24) {
       return false;
     }
-    if (Util.SDK_INT < 26
-        && ("samsung".equals(Build.MANUFACTURER) || "XT1650".equals(Build.MODEL))) {
+    if (SDK_INT < 26 && ("samsung".equals(Build.MANUFACTURER) || "XT1650".equals(Build.MODEL))) {
       // Samsung devices running Nougat are known to be broken. See
       // https://github.com/google/ExoPlayer/issues/3373 and [Internal: b/37197802].
       // Moto Z XT1650 is also affected. See
       // https://github.com/google/ExoPlayer/issues/3215.
       return false;
     }
-    if (Util.SDK_INT < 26
+    if (SDK_INT < 26
         && !context
             .getPackageManager()
             .hasSystemFeature(PackageManager.FEATURE_VR_MODE_HIGH_PERFORMANCE)) {
@@ -242,7 +242,7 @@ public final class GlUtil {
   public static boolean isBt2020PqExtensionSupported() {
     // On API<33, the system cannot display PQ content correctly regardless of whether BT2020 PQ
     // GL extension is supported. Context: http://b/252537203#comment5.
-    return Util.SDK_INT >= 33 && isExtensionSupported(EXTENSION_COLORSPACE_BT2020_PQ);
+    return SDK_INT >= 33 && isExtensionSupported(EXTENSION_COLORSPACE_BT2020_PQ);
   }
 
   /** Returns whether {@link #EXTENSION_COLORSPACE_BT2020_HLG} is supported. */

--- a/libraries/common/src/main/java/androidx/media3/common/util/MediaFormatUtil.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/MediaFormatUtil.java
@@ -15,7 +15,7 @@
  */
 package androidx.media3.common.util;
 
-import static androidx.media3.common.util.Util.SDK_INT;
+import static android.os.Build.VERSION.SDK_INT;
 
 import android.annotation.SuppressLint;
 import android.media.AudioFormat;

--- a/libraries/common/src/main/java/androidx/media3/common/util/NetworkTypeObserver.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/NetworkTypeObserver.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.common.util;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.annotation.SuppressLint;
@@ -159,7 +160,7 @@ public final class NetworkTypeObserver {
 
   private void handleConnectivityActionBroadcast(Context context) {
     @C.NetworkType int networkType = getNetworkTypeFromConnectivityManager(context);
-    if (Util.SDK_INT >= 31 && networkType == C.NETWORK_TYPE_4G) {
+    if (SDK_INT >= 31 && networkType == C.NETWORK_TYPE_4G) {
       // Delay update of the network type to check whether this is actually 5G-NSA.
       Api31.disambiguate4gAnd5gNsa(context, /* instance= */ NetworkTypeObserver.this);
     } else {
@@ -239,7 +240,7 @@ public final class NetworkTypeObserver {
       case TelephonyManager.NETWORK_TYPE_LTE:
         return C.NETWORK_TYPE_4G;
       case TelephonyManager.NETWORK_TYPE_NR:
-        return Util.SDK_INT >= 29 ? C.NETWORK_TYPE_5G_SA : C.NETWORK_TYPE_UNKNOWN;
+        return SDK_INT >= 29 ? C.NETWORK_TYPE_5G_SA : C.NETWORK_TYPE_UNKNOWN;
       case TelephonyManager.NETWORK_TYPE_IWLAN:
         return C.NETWORK_TYPE_WIFI;
       case TelephonyManager.NETWORK_TYPE_GSM:

--- a/libraries/common/src/main/java/androidx/media3/common/util/NotificationUtil.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/NotificationUtil.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.common.util;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static java.lang.annotation.ElementType.TYPE_USE;
 
@@ -113,7 +114,7 @@ public final class NotificationUtil {
       @StringRes int nameResourceId,
       @StringRes int descriptionResourceId,
       @Importance int importance) {
-    if (Util.SDK_INT >= 26) {
+    if (SDK_INT >= 26) {
       NotificationManager notificationManager =
           checkNotNull(
               (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE));

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -155,10 +155,9 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
 public final class Util {
 
   /**
-   * Like {@link Build.VERSION#SDK_INT}, but in a place where it can be conveniently overridden for
-   * local testing.
+   * @deprecated Use {@link Build.VERSION#SDK_INT} instead.
    */
-  @UnstableApi public static final int SDK_INT = Build.VERSION.SDK_INT;
+  @UnstableApi @Deprecated public static final int SDK_INT = Build.VERSION.SDK_INT;
 
   /**
    * @deprecated Use {@link Build#DEVICE} instead.
@@ -178,7 +177,7 @@ public final class Util {
   /** A concise description of the device that it can be useful to log for debugging purposes. */
   @UnstableApi
   public static final String DEVICE_DEBUG_INFO =
-      Build.DEVICE + ", " + Build.MODEL + ", " + Build.MANUFACTURER + ", " + SDK_INT;
+      Build.DEVICE + ", " + Build.MODEL + ", " + Build.MANUFACTURER + ", " + Build.VERSION.SDK_INT;
 
   /** An empty byte array. */
   @UnstableApi public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
@@ -249,7 +248,7 @@ public final class Util {
   /**
    * Registers a {@link BroadcastReceiver} that's not intended to receive broadcasts from other
    * apps. This will be enforced by specifying {@link Context#RECEIVER_NOT_EXPORTED} if {@link
-   * #SDK_INT} is 33 or above.
+   * Build.VERSION#SDK_INT} is 33 or above.
    *
    * <p>Do not use this method if registering a receiver for a <a
    * href="https://android.googlesource.com/platform/frameworks/base/+/master/core/res/AndroidManifest.xml">protected
@@ -264,7 +263,7 @@ public final class Util {
   @Nullable
   public static Intent registerReceiverNotExported(
       Context context, @Nullable BroadcastReceiver receiver, IntentFilter filter) {
-    if (SDK_INT < 33) {
+    if (Build.VERSION.SDK_INT < 33) {
       return context.registerReceiver(receiver, filter);
     } else {
       return context.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED);
@@ -272,8 +271,8 @@ public final class Util {
   }
 
   /**
-   * Calls {@link Context#startForegroundService(Intent)} if {@link #SDK_INT} is 26 or higher, or
-   * {@link Context#startService(Intent)} otherwise.
+   * Calls {@link Context#startForegroundService(Intent)} if {@link Build.VERSION#SDK_INT} is 26 or
+   * higher, or {@link Context#startService(Intent)} otherwise.
    *
    * @param context The context to call.
    * @param intent The intent to pass to the called method.
@@ -282,7 +281,7 @@ public final class Util {
   @UnstableApi
   @Nullable
   public static ComponentName startForegroundService(Context context, Intent intent) {
-    if (SDK_INT >= 26) {
+    if (Build.VERSION.SDK_INT >= 26) {
       return context.startForegroundService(intent);
     } else {
       return context.startService(intent);
@@ -307,7 +306,7 @@ public final class Util {
       Notification notification,
       int foregroundServiceType,
       String foregroundServiceManifestType) {
-    if (Util.SDK_INT >= 29) {
+    if (Build.VERSION.SDK_INT >= 29) {
       Api29.startForeground(
           service,
           notificationId,
@@ -352,7 +351,7 @@ public final class Util {
    */
   public static boolean maybeRequestReadStoragePermission(
       Activity activity, MediaItem... mediaItems) {
-    if (SDK_INT < 23) {
+    if (Build.VERSION.SDK_INT < 23) {
       return false;
     }
     for (MediaItem mediaItem : mediaItems) {
@@ -377,7 +376,7 @@ public final class Util {
     if (!isReadStoragePermissionRequestNeeded(activity, uri)) {
       return false;
     }
-    if (SDK_INT < 33) {
+    if (Build.VERSION.SDK_INT < 33) {
       return requestExternalStoragePermission(activity);
     } else {
       return requestReadMediaPermissions(activity);
@@ -386,7 +385,7 @@ public final class Util {
 
   @ChecksSdkIntAtLeast(api = 23)
   private static boolean isReadStoragePermissionRequestNeeded(Activity activity, Uri uri) {
-    if (SDK_INT < 23) {
+    if (Build.VERSION.SDK_INT < 23) {
       // Permission automatically granted via manifest below API 23.
       return false;
     }
@@ -440,7 +439,7 @@ public final class Util {
    * @return Whether it may be possible to load the URIs of the given media items.
    */
   public static boolean checkCleartextTrafficPermitted(MediaItem... mediaItems) {
-    if (SDK_INT < 24) {
+    if (Build.VERSION.SDK_INT < 24) {
       // We assume cleartext traffic is permitted.
       return true;
     }
@@ -511,7 +510,7 @@ public final class Util {
       return false;
     }
 
-    if (Util.SDK_INT >= 31) {
+    if (Build.VERSION.SDK_INT >= 31) {
       return sparseArray1.contentEquals(sparseArray2);
     }
 
@@ -540,7 +539,7 @@ public final class Util {
    */
   @UnstableApi
   public static <T> int contentHashCode(SparseArray<T> sparseArray) {
-    if (Util.SDK_INT >= 31) {
+    if (Build.VERSION.SDK_INT >= 31) {
       return sparseArray.contentHashCode();
     }
     int hash = 17;
@@ -2296,7 +2295,7 @@ public final class Util {
       case 8:
         return AudioFormat.CHANNEL_OUT_7POINT1_SURROUND;
       case 10:
-        if (Util.SDK_INT >= 32) {
+        if (Build.VERSION.SDK_INT >= 32) {
           return AudioFormat.CHANNEL_OUT_5POINT1POINT4;
         } else {
           // Before API 32, height channel masks are not available. For those 10-channel streams
@@ -2306,7 +2305,7 @@ public final class Util {
       case 12:
         return AudioFormat.CHANNEL_OUT_7POINT1POINT4;
       case 24:
-        if (Util.SDK_INT >= 32) {
+        if (Build.VERSION.SDK_INT >= 32) {
           return AudioFormat.CHANNEL_OUT_7POINT1POINT4
               | AudioFormat.CHANNEL_OUT_FRONT_LEFT_OF_CENTER
               | AudioFormat.CHANNEL_OUT_FRONT_RIGHT_OF_CENTER
@@ -3070,7 +3069,9 @@ public final class Util {
   /** Returns the default {@link Locale.Category#DISPLAY DISPLAY} {@link Locale}. */
   @UnstableApi
   public static Locale getDefaultDisplayLocale() {
-    return SDK_INT >= 24 ? Locale.getDefault(Locale.Category.DISPLAY) : Locale.getDefault();
+    return Build.VERSION.SDK_INT >= 24
+        ? Locale.getDefault(Locale.Category.DISPLAY)
+        : Locale.getDefault();
   }
 
   /**
@@ -3165,7 +3166,7 @@ public final class Util {
    */
   @UnstableApi
   public static boolean isAutomotive(Context context) {
-    return SDK_INT >= 23
+    return Build.VERSION.SDK_INT >= 23
         && context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE);
   }
 
@@ -3241,7 +3242,7 @@ public final class Util {
       // vendor.display-size instead.
       @Nullable
       String displaySize =
-          SDK_INT < 28
+          Build.VERSION.SDK_INT < 28
               ? getSystemProperty("sys.display-size")
               : getSystemProperty("vendor.display-size");
       // If we managed to read the display size, attempt to parse it.
@@ -3270,7 +3271,7 @@ public final class Util {
     }
 
     Point displaySize = new Point();
-    if (SDK_INT >= 23) {
+    if (Build.VERSION.SDK_INT >= 23) {
       getDisplaySizeV23(display, displaySize);
     } else {
       display.getRealSize(displaySize);
@@ -3324,9 +3325,9 @@ public final class Util {
         return true;
       case MimeTypes.IMAGE_HEIF:
       case MimeTypes.IMAGE_HEIC:
-        return Util.SDK_INT >= 26;
+        return Build.VERSION.SDK_INT >= 26;
       case MimeTypes.IMAGE_AVIF:
-        return Util.SDK_INT >= 34;
+        return Build.VERSION.SDK_INT >= 34;
       default:
         return false;
     }
@@ -3526,12 +3527,12 @@ public final class Util {
     // full.
     // Some devices might drop frames despite setting {@link
     // MediaFormat#KEY_ALLOW_FRAME_DROP} to 0. See b/307518793, b/289983935 and b/353487886.
-    return SDK_INT < 29
+    return Build.VERSION.SDK_INT < 29
         || context.getApplicationInfo().targetSdkVersion < 29
-        || ((SDK_INT == 30
+        || ((Build.VERSION.SDK_INT == 30
                 && (Ascii.equalsIgnoreCase(Build.MODEL, "moto g(20)")
                     || Ascii.equalsIgnoreCase(Build.MODEL, "rmx3231")))
-            || (SDK_INT == 34 && Ascii.equalsIgnoreCase(Build.MODEL, "sm-x200")));
+            || (Build.VERSION.SDK_INT == 34 && Ascii.equalsIgnoreCase(Build.MODEL, "sm-x200")));
   }
 
   /**
@@ -3818,7 +3819,7 @@ public final class Util {
 
   private static String[] getSystemLocales() {
     Configuration config = Resources.getSystem().getConfiguration();
-    return SDK_INT >= 24
+    return Build.VERSION.SDK_INT >= 24
         ? getSystemLocalesV24(config)
         : new String[] {getLocaleLanguageTag(config.locale)};
   }

--- a/libraries/common/src/test/java/androidx/media3/common/util/NetworkTypeObserverTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/util/NetworkTypeObserverTest.java
@@ -17,6 +17,7 @@ package androidx.media3.common.util;
 
 import static android.net.NetworkInfo.State.CONNECTED;
 import static android.net.NetworkInfo.State.DISCONNECTED;
+import static android.os.Build.VERSION.SDK_INT;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static org.mockito.Mockito.mock;
@@ -238,7 +239,7 @@ public class NetworkTypeObserverTest {
     ConnectivityManager connectivityManager =
         (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
     Shadows.shadowOf(connectivityManager).setActiveNetworkInfo(networkInfo);
-    if (Util.SDK_INT >= 31) {
+    if (SDK_INT >= 31) {
       TelephonyManager telephonyManager =
           (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
       Object displayInfo =

--- a/libraries/decoder/src/main/java/androidx/media3/decoder/CryptoInfo.java
+++ b/libraries/decoder/src/main/java/androidx/media3/decoder/CryptoInfo.java
@@ -15,12 +15,13 @@
  */
 package androidx.media3.decoder;
 
+import static android.os.Build.VERSION.SDK_INT;
+
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.media3.common.C;
 import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 
 /**
  * Metadata describing the structure of an encrypted input sample.
@@ -90,7 +91,7 @@ public final class CryptoInfo {
 
   public CryptoInfo() {
     frameworkCryptoInfo = new android.media.MediaCodec.CryptoInfo();
-    patternHolder = Util.SDK_INT >= 24 ? new PatternHolderV24(frameworkCryptoInfo) : null;
+    patternHolder = SDK_INT >= 24 ? new PatternHolderV24(frameworkCryptoInfo) : null;
   }
 
   /**
@@ -121,7 +122,7 @@ public final class CryptoInfo {
     frameworkCryptoInfo.key = key;
     frameworkCryptoInfo.iv = iv;
     frameworkCryptoInfo.mode = mode;
-    if (Util.SDK_INT >= 24) {
+    if (SDK_INT >= 24) {
       Assertions.checkNotNull(patternHolder).set(encryptedBlocks, clearBlocks);
     }
   }

--- a/libraries/decoder_iamf/src/androidTest/java/androidx/media3/decoder/iamf/IamfPlaybackTest.java
+++ b/libraries/decoder_iamf/src/androidTest/java/androidx/media3/decoder/iamf/IamfPlaybackTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.decoder.iamf;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import android.content.Context;
@@ -28,7 +29,6 @@ import androidx.media3.common.AudioAttributes;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.PlaybackException;
 import androidx.media3.common.Player;
-import androidx.media3.common.util.Util;
 import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.Renderer;
@@ -99,7 +99,7 @@ public class IamfPlaybackTest {
     @Override
     public void run() {
       Looper.prepare();
-      if (Util.SDK_INT >= 32) { // Spatializer is only available on API 32 and above.
+      if (SDK_INT >= 32) { // Spatializer is only available on API 32 and above.
         AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         // Lint can't follow the indirection from AudioFormat.ENCODING_PCM_16BIT to
         // IamfDecoder.OUTPUT_PCM_ENCODING.

--- a/libraries/decoder_iamf/src/main/java/androidx/media3/decoder/iamf/LibiamfAudioRenderer.java
+++ b/libraries/decoder_iamf/src/main/java/androidx/media3/decoder/iamf/LibiamfAudioRenderer.java
@@ -15,6 +15,8 @@
  */
 package androidx.media3.decoder.iamf;
 
+import static android.os.Build.VERSION.SDK_INT;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.media.AudioFormat;
@@ -92,7 +94,7 @@ public class LibiamfAudioRenderer extends DecoderAudioRenderer<IamfDecoder> {
   @SuppressLint("WrongConstant")
   private boolean isSpatializationSupported() {
     // Spatializer is only available on API 32 and above.
-    if (Util.SDK_INT < 32) {
+    if (SDK_INT < 32) {
       return false;
     }
 

--- a/libraries/effect/src/main/java/androidx/media3/effect/BitmapTextureManager.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/BitmapTextureManager.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.effect;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
@@ -32,7 +33,6 @@ import androidx.media3.common.GlTextureInfo;
 import androidx.media3.common.VideoFrameProcessingException;
 import androidx.media3.common.util.GlUtil;
 import androidx.media3.common.util.TimestampIterator;
-import androidx.media3.common.util.Util;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -218,7 +218,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
               /* rboId= */ C.INDEX_UNSET,
               frameInfo.format.width,
               frameInfo.format.height);
-      if (Util.SDK_INT >= 34 && bitmap.hasGainmap()) {
+      if (SDK_INT >= 34 && bitmap.hasGainmap()) {
         checkNotNull(repeatingGainmapShaderProgram).setGainmap(checkNotNull(bitmap.getGainmap()));
       }
       if (signalRepeatingSequence) {

--- a/libraries/effect/src/main/java/androidx/media3/effect/ByteBufferConcurrentEffect.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/ByteBufferConcurrentEffect.java
@@ -15,9 +15,9 @@
  */
 package androidx.media3.effect;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 
 import android.opengl.GLES20;

--- a/libraries/effect/src/main/java/androidx/media3/effect/DebugViewShaderProgram.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/DebugViewShaderProgram.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.effect;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.GlUtil.getDefaultEglDisplay;
 import static androidx.media3.effect.DefaultVideoFrameProcessor.WORKING_COLOR_SPACE_DEFAULT;
@@ -41,7 +42,6 @@ import androidx.media3.common.VideoFrameProcessingException;
 import androidx.media3.common.util.GlUtil;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import com.google.common.collect.ImmutableList;
 import java.util.Objects;
 import java.util.concurrent.Executor;
@@ -221,7 +221,7 @@ public final class DebugViewShaderProgram implements GlShaderProgram {
       // Therefore, convert HLG to PQ below API 34, so that HLG input can be displayed properly on
       // API 33.
       this.outputColorTransfer =
-          outputColorTransfer == C.COLOR_TRANSFER_HLG && Util.SDK_INT < 34
+          outputColorTransfer == C.COLOR_TRANSFER_HLG && SDK_INT < 34
               ? C.COLOR_TRANSFER_ST2084
               : outputColorTransfer;
       surfaceView.getHolder().addCallback(this);

--- a/libraries/effect/src/main/java/androidx/media3/effect/DefaultShaderProgram.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/DefaultShaderProgram.java
@@ -17,6 +17,7 @@ package androidx.media3.effect;
 
 import static android.opengl.GLES20.GL_FALSE;
 import static android.opengl.GLES20.GL_TRUE;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.VideoFrameProcessor.INPUT_TYPE_BITMAP;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkState;
@@ -36,7 +37,6 @@ import androidx.media3.common.util.GlProgram;
 import androidx.media3.common.util.GlUtil;
 import androidx.media3.common.util.GlUtil.GlException;
 import androidx.media3.common.util.Size;
-import androidx.media3.common.util.Util;
 import androidx.media3.effect.DefaultVideoFrameProcessor.WorkingColorSpace;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -733,7 +733,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     if (lastGainmap == null) {
       return;
     }
-    if (Util.SDK_INT < 34) {
+    if (SDK_INT < 34) {
       throw new IllegalStateException("Gainmaps not supported under API 34.");
     }
     glProgram.setSamplerTexIdUniform("uGainmapTexSampler", gainmapTexId, /* texUnitIndex= */ 1);

--- a/libraries/effect/src/main/java/androidx/media3/effect/DefaultVideoFrameProcessor.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/DefaultVideoFrameProcessor.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.effect;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
@@ -619,7 +620,7 @@ public final class DefaultVideoFrameProcessor implements VideoFrameProcessor {
     }
     if (ColorInfo.isTransferHdr(outputColorInfo)) {
       checkArgument(
-          Util.SDK_INT >= 34 && inputBitmap.hasGainmap(),
+          SDK_INT >= 34 && inputBitmap.hasGainmap(),
           "VideoFrameProcessor configured for HDR output, but either received SDR input, or is on"
               + " an API level that doesn't support gainmaps. SDR to HDR tonemapping is not"
               + " supported.");

--- a/libraries/effect/src/main/java/androidx/media3/effect/OverlayShaderProgram.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/OverlayShaderProgram.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.effect;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
@@ -36,7 +37,6 @@ import androidx.media3.common.VideoFrameProcessingException;
 import androidx.media3.common.util.GlProgram;
 import androidx.media3.common.util.GlUtil;
 import androidx.media3.common.util.Size;
-import androidx.media3.common.util.Util;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 
@@ -212,7 +212,7 @@ import java.io.IOException;
         hdrTypes[i] = HDR_TYPE_TEXT;
         overlaySamplersAvailable -= 1;
       } else if (overlay instanceof BitmapOverlay) {
-        checkState(Util.SDK_INT >= 34);
+        checkState(SDK_INT >= 34);
         hdrTypes[i] = HDR_TYPE_ULTRA_HDR;
         // Each UltraHDR overlay uses an extra texture to apply the gainmap to the base in the
         // shader.

--- a/libraries/effect/src/main/java/androidx/media3/effect/TextOverlay.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/TextOverlay.java
@@ -15,8 +15,8 @@
  */
 package androidx.media3.effect;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static java.lang.Math.ceil;
 
 import android.annotation.SuppressLint;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static java.lang.annotation.ElementType.TYPE_USE;
 
 import android.content.Context;
@@ -29,7 +30,6 @@ import androidx.media3.common.C;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.audio.AudioRendererEventListener;
 import androidx.media3.exoplayer.audio.AudioSink;
 import androidx.media3.exoplayer.audio.DefaultAudioSink;
@@ -440,7 +440,7 @@ public class DefaultRenderersFactory implements RenderersFactory {
             .setMaxDroppedFramesToNotify(MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY)
             .experimentalSetParseAv1SampleDependencies(parseAv1SampleDependencies)
             .experimentalSetLateThresholdToDropDecoderInputUs(lateThresholdToDropDecoderInputUs);
-    if (Util.SDK_INT >= 34) {
+    if (SDK_INT >= 34) {
       videoRendererBuilder =
           videoRendererBuilder.experimentalSetEnableMediaCodecBufferDecodeOnlyFlag(
               enableMediaCodecBufferDecodeOnlyFlag);
@@ -889,7 +889,7 @@ public class DefaultRenderersFactory implements RenderersFactory {
               .setMaxDroppedFramesToNotify(MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY)
               .experimentalSetParseAv1SampleDependencies(parseAv1SampleDependencies)
               .experimentalSetLateThresholdToDropDecoderInputUs(lateThresholdToDropDecoderInputUs);
-      if (Util.SDK_INT >= 34) {
+      if (SDK_INT >= 34) {
         builder =
             builder.experimentalSetEnableMediaCodecBufferDecodeOnlyFlag(
                 enableMediaCodecBufferDecodeOnlyFlag);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultSuitableOutputChecker.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultSuitableOutputChecker.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkStateNotNull;
 
@@ -48,9 +49,9 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
   /** Creates the default {@link SuitableOutputChecker}. */
   public DefaultSuitableOutputChecker() {
-    if (Util.SDK_INT >= 35) {
+    if (SDK_INT >= 35) {
       impl = new ImplApi35();
-    } else if (Util.SDK_INT >= 23) {
+    } else if (SDK_INT >= 23) {
       impl = new ImplApi23();
     } else {
       impl = null;
@@ -255,18 +256,18 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
             || device.getType() == AudioDeviceInfo.TYPE_WIRED_HEADSET) {
           return true;
         }
-        if (Util.SDK_INT >= 26 && device.getType() == AudioDeviceInfo.TYPE_USB_HEADSET) {
+        if (SDK_INT >= 26 && device.getType() == AudioDeviceInfo.TYPE_USB_HEADSET) {
           return true;
         }
-        if (Util.SDK_INT >= 28 && device.getType() == AudioDeviceInfo.TYPE_HEARING_AID) {
+        if (SDK_INT >= 28 && device.getType() == AudioDeviceInfo.TYPE_HEARING_AID) {
           return true;
         }
-        if (Util.SDK_INT >= 31
+        if (SDK_INT >= 31
             && (device.getType() == AudioDeviceInfo.TYPE_BLE_HEADSET
                 || device.getType() == AudioDeviceInfo.TYPE_BLE_SPEAKER)) {
           return true;
         }
-        if (Util.SDK_INT >= 33 && device.getType() == AudioDeviceInfo.TYPE_BLE_BROADCAST) {
+        if (SDK_INT >= 33 && device.getType() == AudioDeviceInfo.TYPE_BLE_BROADCAST) {
           return true;
         }
       }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.C.AUDIO_SESSION_ID_UNSET;
 import static androidx.media3.common.C.TRACK_TYPE_AUDIO;
 import static androidx.media3.common.C.TRACK_TYPE_CAMERA_MOTION;
@@ -394,7 +395,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
       if (builder.foregroundModeTimeoutMs > 0) {
         internalPlayer.experimentalSetForegroundModeTimeoutMs(builder.foregroundModeTimeoutMs);
       }
-      if (Util.SDK_INT >= 31) {
+      if (SDK_INT >= 31) {
         Api31.registerMediaMetricsListener(
             applicationContext, /* player= */ this, builder.usePlatformDiagnostics, playerId);
       }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/MediaExtractorCompat.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/MediaExtractorCompat.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.annotation.VisibleForTesting.NONE;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
@@ -45,7 +46,6 @@ import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.MediaFormatUtil;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DataSourceUtil;
 import androidx.media3.datasource.DataSpec;
@@ -1003,7 +1003,7 @@ public final class MediaExtractorCompat {
       Format format = getFormat(scratchFormatHolder, scratchNoDataDecoderInputBuffer);
       MediaFormat mediaFormatResult = MediaFormatUtil.createMediaFormatFromFormat(format);
       if (compatibilityTrackMimeType != null) {
-        if (Util.SDK_INT >= 29) {
+        if (SDK_INT >= 29) {
           mediaFormatResult.removeKey(MediaFormat.KEY_CODECS_STRING);
         }
         mediaFormatResult.setString(MediaFormat.KEY_MIME, compatibilityTrackMimeType);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/StreamVolumeManager.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/StreamVolumeManager.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.annotation.SuppressLint;
@@ -31,7 +32,6 @@ import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.BackgroundThreadStateHandler;
 import androidx.media3.common.util.Clock;
 import androidx.media3.common.util.Log;
-import androidx.media3.common.util.Util;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /** A manager that wraps {@link AudioManager} to control/listen audio stream volume. */
@@ -247,7 +247,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
             return state;
           }
           checkNotNull(audioManager);
-          if (Util.SDK_INT >= 23) {
+          if (SDK_INT >= 23) {
             audioManager.adjustStreamVolume(
                 state.streamType,
                 muted ? AudioManager.ADJUST_MUTE : AudioManager.ADJUST_UNMUTE,

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/analytics/MediaMetricsListener.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/analytics/MediaMetricsListener.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.analytics;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Util.castNonNull;
 
@@ -764,7 +765,7 @@ public final class MediaMetricsListener
           int subErrorCode = Util.getErrorCodeFromPlatformDiagnosticsInfo(diagnosticsInfo);
           int errorCode = getDrmErrorCode(subErrorCode);
           return new ErrorInfo(errorCode, subErrorCode);
-        } else if (Util.SDK_INT >= 23 && cause instanceof MediaDrmResetException) {
+        } else if (SDK_INT >= 23 && cause instanceof MediaDrmResetException) {
           return new ErrorInfo(PlaybackErrorEvent.ERROR_DRM_SYSTEM_ERROR, /* subErrorCode= */ 0);
         } else if (cause instanceof NotProvisionedException) {
           return new ErrorInfo(

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/analytics/PlayerId.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/analytics/PlayerId.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.analytics;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 
@@ -22,7 +23,6 @@ import android.media.metrics.LogSessionId;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.ExoPlayer.Builder;
 import java.util.Objects;
 
@@ -55,7 +55,7 @@ public final class PlayerId {
    */
   public PlayerId(String playerName) {
     this.name = playerName;
-    this.logSessionIdApi31 = Util.SDK_INT >= 31 ? new LogSessionIdApi31() : null;
+    this.logSessionIdApi31 = SDK_INT >= 31 ? new LogSessionIdApi31() : null;
     equalityToken = new Object();
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -16,6 +16,7 @@
 package androidx.media3.exoplayer.audio;
 
 import static android.media.AudioFormat.CHANNEL_OUT_STEREO;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static java.lang.Math.max;
 
@@ -121,7 +122,7 @@ public final class AudioCapabilities {
       Context context, AudioAttributes audioAttributes, @Nullable AudioDeviceInfo routedDevice) {
     @Nullable
     AudioDeviceInfoApi23 routedDeviceApi23 =
-        Util.SDK_INT >= 23 && routedDevice != null ? new AudioDeviceInfoApi23(routedDevice) : null;
+        SDK_INT >= 23 && routedDevice != null ? new AudioDeviceInfoApi23(routedDevice) : null;
     return getCapabilitiesInternal(context, audioAttributes, routedDeviceApi23);
   }
 
@@ -147,11 +148,11 @@ public final class AudioCapabilities {
     AudioDeviceInfoApi23 currentDevice =
         routedDevice != null
             ? routedDevice
-            : Util.SDK_INT >= 33
+            : SDK_INT >= 33
                 ? Api33.getDefaultRoutedDeviceForAttributes(audioManager, audioAttributes)
                 : null;
 
-    if (Util.SDK_INT >= 33 && (Util.isTv(context) || Util.isAutomotive(context))) {
+    if (SDK_INT >= 33 && (Util.isTv(context) || Util.isAutomotive(context))) {
       // TV or automotive devices generally shouldn't support audio offload for surround encodings,
       // so the encodings we get from AudioManager.getDirectProfilesForAttributes should include
       // the PCM encodings and surround encodings for passthrough mode.
@@ -160,7 +161,7 @@ public final class AudioCapabilities {
 
     // If a connection to Bluetooth device is detected, we only return the minimum capabilities that
     // is supported by all the devices.
-    if (Util.SDK_INT >= 23 && Api23.isBluetoothConnected(audioManager, currentDevice)) {
+    if (SDK_INT >= 23 && Api23.isBluetoothConnected(audioManager, currentDevice)) {
       return DEFAULT_AUDIO_CAPABILITIES;
     }
 
@@ -171,7 +172,7 @@ public final class AudioCapabilities {
     // offload, as well as for encodings we want to list for passthrough mode. Therefore we only use
     // it on TV and automotive devices, which generally shouldn't support audio offload for surround
     // encodings.
-    if (Util.SDK_INT >= 29 && (Util.isTv(context) || Util.isAutomotive(context))) {
+    if (SDK_INT >= 29 && (Util.isTv(context) || Util.isAutomotive(context))) {
       supportedEncodings.addAll(Api29.getDirectPlaybackSupportedEncodings(audioAttributes));
       return new AudioCapabilities(
           getAudioProfiles(Ints.toArray(supportedEncodings.build()), DEFAULT_MAX_CHANNEL_COUNT));
@@ -325,7 +326,7 @@ public final class AudioCapabilities {
           audioProfile.getMaxSupportedChannelCountForPassthrough(sampleRate, audioAttributes);
     } else {
       channelCount = format.channelCount;
-      if (format.sampleMimeType.equals(MimeTypes.AUDIO_DTS_X) && Util.SDK_INT < 33) {
+      if (format.sampleMimeType.equals(MimeTypes.AUDIO_DTS_X) && SDK_INT < 33) {
         // Some DTS:X TVs reports ACTION_HDMI_AUDIO_PLUG.EXTRA_MAX_CHANNEL_COUNT as 8
         // instead of 10. See https://github.com/androidx/media/issues/396
         if (channelCount > 10) {
@@ -374,7 +375,7 @@ public final class AudioCapabilities {
   }
 
   private static int getChannelConfigForPassthrough(int channelCount) {
-    if (Util.SDK_INT <= 28) {
+    if (SDK_INT <= 28) {
       // In passthrough mode the channel count used to configure the audio track doesn't affect how
       // the stream is handled, except that some devices do overly-strict channel configuration
       // checks. Therefore we override the channel count so that a known-working channel
@@ -388,7 +389,7 @@ public final class AudioCapabilities {
 
     // Workaround for Nexus Player not reporting support for mono passthrough. See
     // [Internal: b/34268671].
-    if (Util.SDK_INT <= 26 && "fugu".equals(Build.DEVICE) && channelCount == 1) {
+    if (SDK_INT <= 26 && "fugu".equals(Build.DEVICE) && channelCount == 1) {
       channelCount = 2;
     }
 
@@ -448,7 +449,7 @@ public final class AudioCapabilities {
   private static final class AudioProfile {
 
     public static final AudioProfile DEFAULT_AUDIO_PROFILE =
-        (Util.SDK_INT >= 33)
+        (SDK_INT >= 33)
             ? new AudioProfile(
                 C.ENCODING_PCM_16BIT,
                 getAllChannelMasksForMaxChannelCount(DEFAULT_MAX_CHANNEL_COUNT))
@@ -492,7 +493,7 @@ public final class AudioCapabilities {
       if (channelMasks != null) {
         // We built the AudioProfile on API 33.
         return maxChannelCount;
-      } else if (Util.SDK_INT >= 29) {
+      } else if (SDK_INT >= 29) {
         return Api29.getMaxSupportedChannelCountForPassthrough(
             encoding, sampleRate, audioAttributes);
       }
@@ -574,11 +575,11 @@ public final class AudioCapabilities {
       ImmutableSet.Builder<Integer> allBluetoothDeviceTypes =
           new ImmutableSet.Builder<Integer>()
               .add(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP, AudioDeviceInfo.TYPE_BLUETOOTH_SCO);
-      if (Util.SDK_INT >= 31) {
+      if (SDK_INT >= 31) {
         allBluetoothDeviceTypes.add(
             AudioDeviceInfo.TYPE_BLE_HEADSET, AudioDeviceInfo.TYPE_BLE_SPEAKER);
       }
-      if (Util.SDK_INT >= 33) {
+      if (SDK_INT >= 33) {
         allBluetoothDeviceTypes.add(AudioDeviceInfo.TYPE_BLE_BROADCAST);
       }
       return allBluetoothDeviceTypes.build();
@@ -594,7 +595,7 @@ public final class AudioCapabilities {
         AudioAttributes audioAttributes) {
       ImmutableList.Builder<Integer> supportedEncodingsListBuilder = ImmutableList.builder();
       for (int encoding : ALL_SURROUND_ENCODINGS_AND_MAX_CHANNELS.keySet()) {
-        if (Util.SDK_INT < Util.getApiLevelThatAudioFormatIntroducedAudioEncoding(encoding)) {
+        if (SDK_INT < Util.getApiLevelThatAudioFormatIntroducedAudioEncoding(encoding)) {
           // Example: AudioFormat.ENCODING_DTS_UHD_P2 is supported only from API 34.
           continue;
         }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilitiesReceiver.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilitiesReceiver.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.audio;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.content.BroadcastReceiver;
@@ -91,7 +92,7 @@ public final class AudioCapabilitiesReceiver {
         context,
         listener,
         audioAttributes,
-        Util.SDK_INT >= 23 && routedDevice != null ? new AudioDeviceInfoApi23(routedDevice) : null);
+        SDK_INT >= 23 && routedDevice != null ? new AudioDeviceInfoApi23(routedDevice) : null);
   }
 
   /* package */ AudioCapabilitiesReceiver(
@@ -105,7 +106,7 @@ public final class AudioCapabilitiesReceiver {
     this.audioAttributes = audioAttributes;
     this.routedDevice = routedDevice;
     handler = Util.createHandlerForCurrentOrMainLooper();
-    audioDeviceCallback = Util.SDK_INT >= 23 ? new AudioDeviceCallbackV23() : null;
+    audioDeviceCallback = SDK_INT >= 23 ? new AudioDeviceCallbackV23() : null;
     hdmiAudioPlugBroadcastReceiver = new HdmiAudioPlugBroadcastReceiver();
     Uri externalSurroundSoundUri = AudioCapabilities.getExternalSurroundSoundGlobalSettingUri();
     externalSurroundSoundSettingObserver =
@@ -159,7 +160,7 @@ public final class AudioCapabilitiesReceiver {
     if (externalSurroundSoundSettingObserver != null) {
       externalSurroundSoundSettingObserver.register();
     }
-    if (Util.SDK_INT >= 23 && audioDeviceCallback != null) {
+    if (SDK_INT >= 23 && audioDeviceCallback != null) {
       Api23.registerAudioDeviceCallback(context, audioDeviceCallback, handler);
     }
     Intent stickyIntent =
@@ -183,7 +184,7 @@ public final class AudioCapabilitiesReceiver {
       return;
     }
     audioCapabilities = null;
-    if (Util.SDK_INT >= 23 && audioDeviceCallback != null) {
+    if (SDK_INT >= 23 && audioDeviceCallback != null) {
       Api23.unregisterAudioDeviceCallback(context, audioDeviceCallback);
     }
     context.unregisterReceiver(hdmiAudioPlugBroadcastReceiver);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTrackPositionTracker.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioTrackPositionTracker.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.audio;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Util.castNonNull;
 import static androidx.media3.common.util.Util.durationUsToSampleCount;
@@ -618,8 +619,7 @@ import java.lang.reflect.Method;
    * b/18899620, b/19187573, b/21145353].
    */
   private static boolean needsPassthroughWorkarounds(@C.Encoding int outputEncoding) {
-    return Util.SDK_INT < 23
-        && (outputEncoding == C.ENCODING_AC3 || outputEncoding == C.ENCODING_E_AC3);
+    return SDK_INT < 23 && (outputEncoding == C.ENCODING_AC3 || outputEncoding == C.ENCODING_E_AC3);
   }
 
   private long getPlaybackHeadPositionUs() {
@@ -679,7 +679,7 @@ import java.lang.reflect.Method;
       rawPlaybackHeadPosition += passthroughWorkaroundPauseOffset;
     }
 
-    if (Util.SDK_INT <= 29) {
+    if (SDK_INT <= 29) {
       if (rawPlaybackHeadPosition == 0
           && this.rawPlaybackHeadPosition > 0
           && state == PLAYSTATE_PLAYING) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DecoderAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DecoderAudioRenderer.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.audio;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.exoplayer.DecoderReuseEvaluation.DISCARD_REASON_DRM_SESSION_CHANGED;
 import static androidx.media3.exoplayer.DecoderReuseEvaluation.DISCARD_REASON_REUSE_NOT_IMPLEMENTED;
@@ -762,7 +763,7 @@ public abstract class DecoderAudioRenderer<
         audioSink.setAudioSessionId((Integer) message);
         break;
       case MSG_SET_PREFERRED_AUDIO_DEVICE:
-        if (Util.SDK_INT >= 23) {
+        if (SDK_INT >= 23) {
           Api23.setAudioSinkPreferredDevice(audioSink, message);
         }
         break;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioOffloadSupportProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioOffloadSupportProvider.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.audio;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.content.Context;
@@ -71,7 +72,7 @@ public final class DefaultAudioOffloadSupportProvider
     checkNotNull(format);
     checkNotNull(audioAttributes);
 
-    if (Util.SDK_INT < 29 || format.sampleRate == Format.NO_VALUE) {
+    if (SDK_INT < 29 || format.sampleRate == Format.NO_VALUE) {
       return AudioOffloadSupport.DEFAULT_UNSUPPORTED;
     }
 
@@ -82,7 +83,7 @@ public final class DefaultAudioOffloadSupportProvider
     @C.Encoding
     int encoding = MimeTypes.getEncoding(checkNotNull(format.sampleMimeType), format.codecs);
     if (encoding == C.ENCODING_INVALID
-        || Util.SDK_INT < Util.getApiLevelThatAudioFormatIntroducedAudioEncoding(encoding)) {
+        || SDK_INT < Util.getApiLevelThatAudioFormatIntroducedAudioEncoding(encoding)) {
       // Example: AudioFormat.ENCODING_OPUS is supported only from API 30.
       return AudioOffloadSupport.DEFAULT_UNSUPPORTED;
     }
@@ -99,7 +100,7 @@ public final class DefaultAudioOffloadSupportProvider
       return AudioOffloadSupport.DEFAULT_UNSUPPORTED;
     }
 
-    if (Util.SDK_INT >= 31) {
+    if (SDK_INT >= 31) {
       return Api31.getOffloadedPlaybackSupport(
           audioFormat,
           audioAttributes.getAudioAttributesV21().audioAttributes,
@@ -165,8 +166,7 @@ public final class DefaultAudioOffloadSupportProvider
       // (b/191950723) Gapless is not supported pre-API 33 due to playback position
       // issue upon transition of gapless tracks
       boolean isGaplessSupported =
-          Util.SDK_INT > 32
-              && playbackOffloadSupport == AudioManager.PLAYBACK_OFFLOAD_GAPLESS_SUPPORTED;
+          SDK_INT > 32 && playbackOffloadSupport == AudioManager.PLAYBACK_OFFLOAD_GAPLESS_SUPPORTED;
       return audioOffloadSupport
           .setIsFormatSupported(true)
           .setIsGaplessSupported(isGaplessSupported)

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.audio;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.Util.constrainValue;
@@ -597,7 +598,7 @@ public final class DefaultAudioSink implements AudioSink {
     audioCapabilities = context != null ? null : builder.audioCapabilities;
     audioProcessorChain = builder.audioProcessorChain;
     enableFloatOutput = builder.enableFloatOutput;
-    preferAudioTrackPlaybackParams = Util.SDK_INT >= 23 && builder.enableAudioTrackPlaybackParams;
+    preferAudioTrackPlaybackParams = SDK_INT >= 23 && builder.enableAudioTrackPlaybackParams;
     offloadMode = OFFLOAD_MODE_DISABLED;
     audioTrackBufferSizeProvider = builder.audioTrackBufferSizeProvider;
     audioOffloadSupportProvider = checkNotNull(builder.audioOffloadSupportProvider);
@@ -850,7 +851,7 @@ public final class DefaultAudioSink implements AudioSink {
             configuration.inputFormat.encoderDelay, configuration.inputFormat.encoderPadding);
       }
     }
-    if (Util.SDK_INT >= 31 && playerId != null) {
+    if (SDK_INT >= 31 && playerId != null) {
       Api31.setLogSessionIdOnAudioTrack(audioTrack, playerId);
     }
     audioSessionId = audioTrack.getAudioSessionId();
@@ -866,13 +867,13 @@ public final class DefaultAudioSink implements AudioSink {
       audioTrack.attachAuxEffect(auxEffectInfo.effectId);
       audioTrack.setAuxEffectSendLevel(auxEffectInfo.sendLevel);
     }
-    if (preferredDevice != null && Util.SDK_INT >= 23) {
+    if (preferredDevice != null && SDK_INT >= 23) {
       Api23.setPreferredDeviceOnAudioTrack(audioTrack, preferredDevice);
       if (audioCapabilitiesReceiver != null) {
         audioCapabilitiesReceiver.setRoutedDevice(preferredDevice.audioDeviceInfo);
       }
     }
-    if (Util.SDK_INT >= 24 && audioCapabilitiesReceiver != null) {
+    if (SDK_INT >= 24 && audioCapabilitiesReceiver != null) {
       onRoutingChangedListener =
           new OnRoutingChangedListenerApi24(audioTrack, audioCapabilitiesReceiver);
     }
@@ -1357,7 +1358,7 @@ public final class DefaultAudioSink implements AudioSink {
   }
 
   private static boolean isAudioTrackDeadObject(int status) {
-    return (Util.SDK_INT >= 24 && status == AudioTrack.ERROR_DEAD_OBJECT)
+    return (SDK_INT >= 24 && status == AudioTrack.ERROR_DEAD_OBJECT)
         || status == ERROR_NATIVE_DEAD_OBJECT;
   }
 
@@ -1369,9 +1370,7 @@ public final class DefaultAudioSink implements AudioSink {
   @Override
   public boolean hasPendingData() {
     return isAudioTrackInitialized()
-        && (Util.SDK_INT < 29
-            || !audioTrack.isOffloadedPlayback()
-            || !handledOffloadOnPresentationEnded)
+        && (SDK_INT < 29 || !audioTrack.isOffloadedPlayback() || !handledOffloadOnPresentationEnded)
         && audioTrackPositionTracker.hasPendingData(getWrittenFrames());
   }
 
@@ -1473,7 +1472,7 @@ public final class DefaultAudioSink implements AudioSink {
     if (!isAudioTrackInitialized()) {
       return C.TIME_UNSET;
     }
-    if (Util.SDK_INT >= 23) {
+    if (SDK_INT >= 23) {
       return Api23.getAudioTrackBufferSizeUs(audioTrack, configuration);
     }
     long byteRate =
@@ -1505,7 +1504,7 @@ public final class DefaultAudioSink implements AudioSink {
   @RequiresApi(29)
   @Override
   public void setOffloadMode(@OffloadMode int offloadMode) {
-    Assertions.checkState(Util.SDK_INT >= 29);
+    Assertions.checkState(SDK_INT >= 29);
     this.offloadMode = offloadMode;
   }
 
@@ -1560,7 +1559,7 @@ public final class DefaultAudioSink implements AudioSink {
         pendingConfiguration = null;
       }
       audioTrackPositionTracker.reset();
-      if (Util.SDK_INT >= 24 && onRoutingChangedListener != null) {
+      if (SDK_INT >= 24 && onRoutingChangedListener != null) {
         onRoutingChangedListener.release();
         onRoutingChangedListener = null;
       }
@@ -1735,9 +1734,7 @@ public final class DefaultAudioSink implements AudioSink {
   }
 
   private boolean useAudioTrackPlaybackParams() {
-    return configuration != null
-        && configuration.enableAudioTrackPlaybackParams
-        && Util.SDK_INT >= 23;
+    return configuration != null && configuration.enableAudioTrackPlaybackParams && SDK_INT >= 23;
   }
 
   /**
@@ -1841,7 +1838,7 @@ public final class DefaultAudioSink implements AudioSink {
   }
 
   private static boolean isOffloadedPlayback(AudioTrack audioTrack) {
-    return Util.SDK_INT >= 29 && audioTrack.isOffloadedPlayback();
+    return SDK_INT >= 29 && audioTrack.isOffloadedPlayback();
   }
 
   private static int getFramesPerEncodedSample(@C.Encoding int encoding, ByteBuffer buffer) {
@@ -1902,7 +1899,7 @@ public final class DefaultAudioSink implements AudioSink {
 
   private int writeNonBlockingWithAvSync(
       AudioTrack audioTrack, ByteBuffer buffer, int size, long presentationTimeUs) {
-    if (Util.SDK_INT >= 26) {
+    if (SDK_INT >= 26) {
       // The underlying platform AudioTrack writes AV sync headers directly.
       return audioTrack.write(
           buffer, size, AudioTrack.WRITE_NON_BLOCKING, presentationTimeUs * 1000);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioTrackProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioTrackProvider.java
@@ -15,6 +15,8 @@
  */
 package androidx.media3.exoplayer.audio;
 
+import static android.os.Build.VERSION.SDK_INT;
+
 import android.media.AudioFormat;
 import android.media.AudioTrack;
 import androidx.annotation.RequiresApi;
@@ -37,7 +39,7 @@ public class DefaultAudioTrackProvider implements DefaultAudioSink.AudioTrackPro
       AudioSink.AudioTrackConfig audioTrackConfig,
       AudioAttributes audioAttributes,
       int audioSessionId) {
-    if (Util.SDK_INT >= 23) {
+    if (SDK_INT >= 23) {
       return createAudioTrackV23(audioTrackConfig, audioAttributes, audioSessionId);
     } else {
       return createAudioTrackV21(audioTrackConfig, audioAttributes, audioSessionId);
@@ -61,7 +63,7 @@ public class DefaultAudioTrackProvider implements DefaultAudioSink.AudioTrackPro
             .setTransferMode(AudioTrack.MODE_STREAM)
             .setBufferSizeInBytes(audioTrackConfig.bufferSize)
             .setSessionId(audioSessionId);
-    if (Util.SDK_INT >= 29) {
+    if (SDK_INT >= 29) {
       setOffloadedPlaybackV29(audioTrackBuilder, audioTrackConfig.offload);
     }
     return customizeAudioTrackBuilder(audioTrackBuilder).build();

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.audio;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.exoplayer.DecoderReuseEvaluation.DISCARD_REASON_MAX_INPUT_SIZE_EXCEEDED;
 import static androidx.media3.exoplayer.DecoderReuseEvaluation.REUSE_RESULT_NO;
@@ -264,7 +265,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
         eventHandler,
         eventListener,
         audioSink,
-        Util.SDK_INT >= 35 ? new LoudnessCodecController() : null);
+        SDK_INT >= 35 ? new LoudnessCodecController() : null);
   }
 
   /**
@@ -610,7 +611,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
       if (MimeTypes.AUDIO_RAW.equals(format.sampleMimeType)) {
         // For PCM streams, the encoder passes through int samples despite set to float mode.
         pcmEncoding = format.pcmEncoding;
-      } else if (Util.SDK_INT >= 24 && mediaFormat.containsKey(MediaFormat.KEY_PCM_ENCODING)) {
+      } else if (SDK_INT >= 24 && mediaFormat.containsKey(MediaFormat.KEY_PCM_ENCODING)) {
         pcmEncoding = mediaFormat.getInteger(MediaFormat.KEY_PCM_ENCODING);
       } else if (mediaFormat.containsKey(VIVO_BITS_PER_SAMPLE_KEY)) {
         pcmEncoding = Util.getPcmEncoding(mediaFormat.getInteger(VIVO_BITS_PER_SAMPLE_KEY));
@@ -649,7 +650,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
       }
     }
     try {
-      if (Util.SDK_INT >= 29) {
+      if (SDK_INT >= 29) {
         if (isBypassEnabled()
             && getConfiguration().offloadModePreferred != AudioSink.OFFLOAD_MODE_DISABLED) {
           // TODO(b/280050553): Investigate potential issue where bypass is enabled for passthrough
@@ -749,7 +750,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
   @Override
   protected void onRelease() {
     audioSink.release();
-    if (Util.SDK_INT >= 35 && loudnessCodecController != null) {
+    if (SDK_INT >= 35 && loudnessCodecController != null) {
       loudnessCodecController.release();
     }
   }
@@ -908,7 +909,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
         audioSink.setAuxEffectInfo(checkNotNull(auxEffectInfo));
         break;
       case MSG_SET_PREFERRED_AUDIO_DEVICE:
-        if (Util.SDK_INT >= 23) {
+        if (SDK_INT >= 23) {
           Api23.setAudioSinkPreferredDevice(audioSink, message);
         }
         break;
@@ -930,7 +931,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
 
   @Override
   protected void handleInputBufferSupplementalData(DecoderInputBuffer buffer) {
-    if (Util.SDK_INT >= 29
+    if (SDK_INT >= 29
         && buffer.format != null
         && Objects.equals(buffer.format.sampleMimeType, MimeTypes.AUDIO_OPUS)
         && isBypassEnabled()) {
@@ -983,7 +984,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
       // Android TV running M, so there's no point requesting a non-default input size. Doing so may
       // cause a native crash, whereas not doing so will cause a more controlled failure when
       // attempting to fill an input buffer. See: https://github.com/google/ExoPlayer/issues/4057.
-      if (Util.SDK_INT < 24 && !(Util.SDK_INT == 23 && Util.isTv(context))) {
+      if (SDK_INT < 24 && !(SDK_INT == 23 && Util.isTv(context))) {
         return Format.NO_VALUE;
       }
     }
@@ -1013,27 +1014,27 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
     // Set codec max values.
     MediaFormatUtil.maybeSetInteger(mediaFormat, MediaFormat.KEY_MAX_INPUT_SIZE, codecMaxInputSize);
     // Set codec configuration values.
-    if (Util.SDK_INT >= 23) {
+    if (SDK_INT >= 23) {
       mediaFormat.setInteger(MediaFormat.KEY_PRIORITY, 0 /* realtime priority */);
       if (codecOperatingRate != CODEC_OPERATING_RATE_UNSET && !deviceDoesntSupportOperatingRate()) {
         mediaFormat.setFloat(MediaFormat.KEY_OPERATING_RATE, codecOperatingRate);
       }
     }
-    if (Util.SDK_INT <= 28 && MimeTypes.AUDIO_AC4.equals(format.sampleMimeType)) {
+    if (SDK_INT <= 28 && MimeTypes.AUDIO_AC4.equals(format.sampleMimeType)) {
       // On some older builds, the AC-4 decoder expects to receive samples formatted as raw frames
       // not sync frames. Set a format key to override this.
       mediaFormat.setInteger("ac4-is-sync", 1);
     }
-    if (Util.SDK_INT >= 24
+    if (SDK_INT >= 24
         && audioSink.getFormatSupport(
                 Util.getPcmFormat(C.ENCODING_PCM_FLOAT, format.channelCount, format.sampleRate))
             == AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY) {
       mediaFormat.setInteger(MediaFormat.KEY_PCM_ENCODING, AudioFormat.ENCODING_PCM_FLOAT);
     }
-    if (Util.SDK_INT >= 32) {
+    if (SDK_INT >= 32) {
       mediaFormat.setInteger(MediaFormat.KEY_MAX_OUTPUT_CHANNEL_COUNT, 99);
     }
-    if (Util.SDK_INT >= 35) {
+    if (SDK_INT >= 35) {
       mediaFormat.setInteger(MediaFormat.KEY_IMPORTANCE, max(0, -rendererPriority));
     }
     return mediaFormat;
@@ -1041,7 +1042,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
 
   private void setAudioSessionId(int audioSessionId) {
     audioSink.setAudioSessionId(audioSessionId);
-    if (Util.SDK_INT >= 35 && loudnessCodecController != null) {
+    if (SDK_INT >= 35 && loudnessCodecController != null) {
       loudnessCodecController.setAudioSessionId(audioSessionId);
     }
   }
@@ -1052,7 +1053,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
       // If codec is null, then the importance will be set when initializing the codec.
       return;
     }
-    if (Util.SDK_INT >= 35) {
+    if (SDK_INT >= 35) {
       Bundle codecParameters = new Bundle();
       codecParameters.putInt(MediaFormat.KEY_IMPORTANCE, max(0, -rendererPriority));
       codec.setParameters(codecParameters);
@@ -1077,8 +1078,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
    * <p>See <a href="https://github.com/google/ExoPlayer/issues/5821">GitHub issue #5821</a>.
    */
   private static boolean deviceDoesntSupportOperatingRate() {
-    return Util.SDK_INT == 23
-        && ("ZTE B2017G".equals(Build.MODEL) || "AXON 7 mini".equals(Build.MODEL));
+    return SDK_INT == 23 && ("ZTE B2017G".equals(Build.MODEL) || "AXON 7 mini".equals(Build.MODEL));
   }
 
   /**
@@ -1089,7 +1089,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
    */
   private static boolean codecNeedsDiscardChannelsWorkaround(String codecName) {
     // The workaround applies to Samsung Galaxy S6 and Samsung Galaxy S7.
-    return Util.SDK_INT < 24
+    return SDK_INT < 24
         && "OMX.SEC.aac.dec".equals(codecName)
         && "samsung".equals(Build.MANUFACTURER)
         && (Build.DEVICE.startsWith("zeroflte")

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/ClearKeyUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/ClearKeyUtil.java
@@ -15,6 +15,8 @@
  */
 package androidx.media3.exoplayer.drm;
 
+import static android.os.Build.VERSION.SDK_INT;
+
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.Util;
 import org.json.JSONArray;
@@ -35,7 +37,7 @@ import org.json.JSONObject;
    * @return The adjusted request data.
    */
   public static byte[] adjustRequestData(byte[] request) {
-    if (Util.SDK_INT >= 27) {
+    if (SDK_INT >= 27) {
       return request;
     }
     // Prior to O-MR1 the ClearKey CDM encoded the values in the "kids" array using Base64 encoding
@@ -53,7 +55,7 @@ import org.json.JSONObject;
    * @return The adjusted response data.
    */
   public static byte[] adjustResponseData(byte[] response) {
-    if (Util.SDK_INT >= 27) {
+    if (SDK_INT >= 27) {
       return response;
     }
     // Prior to O-MR1 the ClearKey CDM expected Base64 encoding rather than Base64Url encoding for

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSessionManager.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DefaultDrmSessionManager.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.drm;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
@@ -593,7 +594,7 @@ public class DefaultDrmSessionManager implements DrmSessionManager {
     } else if (C.CENC_TYPE_cbcs.equals(schemeType)) {
       // Support for cbcs (AES-CBC with pattern encryption) was added in API 24. However, the
       // implementation was not stable until API 25.
-      return Util.SDK_INT >= 25;
+      return SDK_INT >= 25;
     } else if (C.CENC_TYPE_cbc1.equals(schemeType) || C.CENC_TYPE_cens.equals(schemeType)) {
       // Support for cbc1 (AES-CTR with pattern encryption) and cens (AES-CBC without pattern
       // encryption) was also added in API 24 and made stable from API 25, however support was

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DrmUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DrmUtil.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.drm;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
 import static java.lang.annotation.ElementType.METHOD;
@@ -90,7 +91,7 @@ public final class DrmUtil {
       String diagnosticsInfo = ((MediaDrm.MediaDrmStateException) exception).getDiagnosticInfo();
       int drmErrorCode = Util.getErrorCodeFromPlatformDiagnosticsInfo(diagnosticsInfo);
       return Util.getErrorCodeForMediaDrmErrorCode(drmErrorCode);
-    } else if (Util.SDK_INT >= 23 && Api23.isMediaDrmResetException(exception)) {
+    } else if (SDK_INT >= 23 && Api23.isMediaDrmResetException(exception)) {
       return PlaybackException.ERROR_CODE_DRM_SYSTEM_ERROR;
     } else if (exception instanceof NotProvisionedException
         || isFailureToConstructNotProvisionedException(exception)) {
@@ -122,7 +123,7 @@ public final class DrmUtil {
    * See b/291440132.
    */
   public static boolean isFailureToConstructNotProvisionedException(@Nullable Throwable e) {
-    return Util.SDK_INT == 34
+    return SDK_INT == 34
         && e instanceof NoSuchMethodError
         && e.getMessage() != null
         && e.getMessage().contains("Landroid/media/NotProvisionedException;.<init>(");
@@ -133,7 +134,7 @@ public final class DrmUtil {
    * See b/291440132.
    */
   public static boolean isFailureToConstructResourceBusyException(@Nullable Throwable e) {
-    return Util.SDK_INT == 34
+    return SDK_INT == 34
         && e instanceof NoSuchMethodError
         && e.getMessage() != null
         && e.getMessage().contains("Landroid/media/ResourceBusyException;.<init>(");

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.drm;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.annotation.SuppressLint;
@@ -39,7 +40,6 @@ import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.ParsableByteArray;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.analytics.PlayerId;
 import androidx.media3.extractor.mp4.PsshAtomUtil;
 import androidx.media3.extractor.mp4.PsshAtomUtil.PsshAtom;
@@ -144,7 +144,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
   @RequiresApi(23)
   public void setOnKeyStatusChangeListener(
       @Nullable ExoMediaDrm.OnKeyStatusChangeListener listener) {
-    if (Util.SDK_INT < 23) {
+    if (SDK_INT < 23) {
       throw new UnsupportedOperationException();
     }
 
@@ -172,7 +172,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
   @Override
   @RequiresApi(23)
   public void setOnExpirationUpdateListener(@Nullable OnExpirationUpdateListener listener) {
-    if (Util.SDK_INT < 23) {
+    if (SDK_INT < 23) {
       throw new UnsupportedOperationException();
     }
 
@@ -199,7 +199,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
   @UnstableApi
   @Override
   public void setPlayerIdForSession(byte[] sessionId, PlayerId playerId) {
-    if (Util.SDK_INT >= 31) {
+    if (SDK_INT >= 31) {
       try {
         Api31.setLogSessionIdOnMediaDrmSession(mediaDrm, sessionId, playerId);
       } catch (UnsupportedOperationException e) {
@@ -238,8 +238,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
     }
 
     @KeyRequest.RequestType
-    int requestType =
-        Util.SDK_INT >= 23 ? request.getRequestType() : KeyRequest.REQUEST_TYPE_UNKNOWN;
+    int requestType = SDK_INT >= 23 ? request.getRequestType() : KeyRequest.REQUEST_TYPE_UNKNOWN;
 
     return new KeyRequest(requestData, licenseServerUrl, requestType);
   }
@@ -248,7 +247,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
     if (MOCK_LA_URL.equals(licenseServerUrl)) {
       return "";
     }
-    if (Util.SDK_INT >= 33 && "https://default.url".equals(licenseServerUrl)) {
+    if (SDK_INT >= 33 && "https://default.url".equals(licenseServerUrl)) {
       // Work around b/247808112
       String pluginVersion = getPropertyString("version");
       if (Objects.equals(pluginVersion, "1.2") || Objects.equals(pluginVersion, "aidl-1")) {
@@ -293,7 +292,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
   @Override
   public boolean requiresSecureDecoder(byte[] sessionId, String mimeType) {
     boolean result;
-    if (Util.SDK_INT >= 31 && isMediaDrmRequiresSecureDecoderImplemented()) {
+    if (SDK_INT >= 31 && isMediaDrmRequiresSecureDecoderImplemented()) {
       result =
           Api31.requiresSecureDecoder(mediaDrm, mimeType, mediaDrm.getSecurityLevel(sessionId));
     } else {
@@ -341,7 +340,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
   @UnstableApi
   @RequiresApi(29)
   public void removeOfflineLicense(byte[] keySetId) {
-    if (Util.SDK_INT < 29) {
+    if (SDK_INT < 29) {
       throw new UnsupportedOperationException();
     }
     mediaDrm.removeOfflineLicense(keySetId);
@@ -351,7 +350,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
   @UnstableApi
   @RequiresApi(29)
   public List<byte[]> getOfflineLicenseKeySetIds() {
-    if (Util.SDK_INT < 29) {
+    if (SDK_INT < 29) {
       throw new UnsupportedOperationException();
     }
     return mediaDrm.getOfflineLicenseKeySetIds();
@@ -361,7 +360,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
   @Override
   @Nullable
   public PersistableBundle getMetrics() {
-    if (Util.SDK_INT < 28) {
+    if (SDK_INT < 28) {
       return null;
     }
     return mediaDrm.getMetrics();
@@ -429,7 +428,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
       return schemeDatas.get(0);
     }
 
-    if (Util.SDK_INT >= 28 && schemeDatas.size() > 1) {
+    if (SDK_INT >= 28 && schemeDatas.size() > 1) {
       // For API level 28 and above, concatenate multiple PSSH scheme datas if possible.
       SchemeData firstSchemeData = schemeDatas.get(0);
       int concatenatedDataLength = 0;
@@ -466,9 +465,9 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
     for (int i = 0; i < schemeDatas.size(); i++) {
       SchemeData schemeData = schemeDatas.get(i);
       int version = PsshAtomUtil.parseVersion(Assertions.checkNotNull(schemeData.data));
-      if (Util.SDK_INT < 23 && version == 0) {
+      if (SDK_INT < 23 && version == 0) {
         return schemeData;
-      } else if (Util.SDK_INT >= 23 && version == 1) {
+      } else if (SDK_INT >= 23 && version == 1) {
         return schemeData;
       }
     }
@@ -508,7 +507,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
     // that only provides V1 PSSH atoms. API levels 23 and above understand V0 and V1 PSSH atoms,
     // and so we do not extract the data.
     // Some Amazon devices also require data to be extracted from the PSSH atom for PlayReady.
-    if ((Util.SDK_INT < 23 && C.WIDEVINE_UUID.equals(uuid))
+    if ((SDK_INT < 23 && C.WIDEVINE_UUID.equals(uuid))
         || (C.PLAYREADY_UUID.equals(uuid)
             && "Amazon".equals(Build.MANUFACTURER)
             && ("AFTB".equals(Build.MODEL) // Fire TV Gen 1
@@ -526,7 +525,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
 
   private static String adjustRequestMimeType(UUID uuid, String mimeType) {
     // Prior to API level 26 the ClearKey CDM only accepted "cenc" as the scheme for MP4.
-    if (Util.SDK_INT < 26
+    if (SDK_INT < 26
         && C.CLEARKEY_UUID.equals(uuid)
         && (MimeTypes.VIDEO_MP4.equals(mimeType) || MimeTypes.AUDIO_MP4.equals(mimeType))) {
       return CENC_SCHEME_MIME_TYPE;
@@ -543,7 +542,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
 
   private static boolean cdmRequiresCommonPsshUuid(UUID uuid) {
     // ClearKey had to be accessed using the Common PSSH UUID prior to API level 27.
-    return Util.SDK_INT < 27 && Objects.equals(uuid, C.CLEARKEY_UUID);
+    return SDK_INT < 27 && Objects.equals(uuid, C.CLEARKEY_UUID);
   }
 
   private static void forceWidevineL3(MediaDrm mediaDrm) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/AsynchronousMediaCodecAdapter.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/AsynchronousMediaCodecAdapter.java
@@ -16,6 +16,7 @@
 
 package androidx.media3.exoplayer.mediacodec;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static java.lang.annotation.ElementType.TYPE_USE;
 
 import android.media.MediaCodec;
@@ -35,7 +36,6 @@ import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.TraceUtil;
-import androidx.media3.common.util.Util;
 import androidx.media3.decoder.CryptoInfo;
 import com.google.common.base.Supplier;
 import java.io.IOException;
@@ -129,7 +129,7 @@ import java.nio.ByteBuffer;
         TraceUtil.endSection();
         if (configuration.surface == null
             && configuration.codecInfo.detachedSurfaceSupported
-            && Util.SDK_INT >= 35) {
+            && SDK_INT >= 35) {
           flags |= MediaCodec.CONFIGURE_FLAG_DETACHED_SURFACE;
         }
         codecAdapter.initialize(
@@ -147,11 +147,11 @@ import java.nio.ByteBuffer;
 
     @ChecksSdkIntAtLeast(api = 34)
     private static boolean useSynchronousBufferQueueingWithAsyncCryptoFlag(Format format) {
-      if (Util.SDK_INT < 34) {
+      if (SDK_INT < 34) {
         return false;
       }
       // CONFIGURE_FLAG_USE_CRYPTO_ASYNC only works for audio on API 35+ (see b/316565675).
-      return Util.SDK_INT >= 35 || MimeTypes.isVideo(format.sampleMimeType);
+      return SDK_INT >= 35 || MimeTypes.isVideo(format.sampleMimeType);
     }
   }
 
@@ -198,7 +198,7 @@ import java.nio.ByteBuffer;
     TraceUtil.beginSection("startCodec");
     codec.start();
     TraceUtil.endSection();
-    if (Util.SDK_INT >= 35 && loudnessCodecController != null) {
+    if (SDK_INT >= 35 && loudnessCodecController != null) {
       loudnessCodecController.addMediaCodec(codec);
     }
     state = STATE_INITIALIZED;
@@ -289,11 +289,11 @@ import java.nio.ByteBuffer;
           // MediaCodec.release() returns too early before fully detaching a Surface, and a
           // subsequent MediaCodec.configure() call using the same Surface then fails. See
           // https://github.com/google/ExoPlayer/issues/8696 and b/191966399.
-          if (Util.SDK_INT >= 30 && Util.SDK_INT < 33) {
+          if (SDK_INT >= 30 && SDK_INT < 33) {
             codec.stop();
           }
         } finally {
-          if (Util.SDK_INT >= 35 && loudnessCodecController != null) {
+          if (SDK_INT >= 35 && loudnessCodecController != null) {
             loudnessCodecController.removeMediaCodec(codec);
           }
           codec.release();

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/AsynchronousMediaCodecBufferEnqueuer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/AsynchronousMediaCodecBufferEnqueuer.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.mediacodec;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.annotation.VisibleForTesting.NONE;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Util.castNonNull;
@@ -30,7 +31,6 @@ import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 import androidx.media3.common.util.ConditionVariable;
 import androidx.media3.common.util.NullableType;
-import androidx.media3.common.util.Util;
 import androidx.media3.decoder.CryptoInfo;
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -298,7 +298,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     frameworkCryptoInfo.key = checkNotNull(copy(cryptoInfo.key, frameworkCryptoInfo.key));
     frameworkCryptoInfo.iv = checkNotNull(copy(cryptoInfo.iv, frameworkCryptoInfo.iv));
     frameworkCryptoInfo.mode = cryptoInfo.mode;
-    if (Util.SDK_INT >= 24) {
+    if (SDK_INT >= 24) {
       android.media.MediaCodec.CryptoInfo.Pattern pattern =
           new android.media.MediaCodec.CryptoInfo.Pattern(
               cryptoInfo.encryptedBlocks, cryptoInfo.clearBlocks);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/DefaultMediaCodecAdapterFactory.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/DefaultMediaCodecAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.mediacodec;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static java.lang.annotation.ElementType.TYPE_USE;
 
 import android.content.Context;
@@ -146,7 +147,7 @@ public final class DefaultMediaCodecAdapterFactory implements MediaCodecAdapter.
   @Override
   public MediaCodecAdapter createAdapter(MediaCodecAdapter.Configuration configuration)
       throws IOException {
-    if (Util.SDK_INT >= 23
+    if (SDK_INT >= 23
         && (asynchronousMode == MODE_ENABLED
             || (asynchronousMode == MODE_DEFAULT && shouldUseAsynchronousAdapterInDefaultMode()))) {
       int trackType = MimeTypes.getTrackType(configuration.format.sampleMimeType);
@@ -166,14 +167,14 @@ public final class DefaultMediaCodecAdapterFactory implements MediaCodecAdapter.
   }
 
   private boolean shouldUseAsynchronousAdapterInDefaultMode() {
-    if (Util.SDK_INT >= 31) {
+    if (SDK_INT >= 31) {
       // Asynchronous codec interactions started to be reliable for all devices on API 31+.
       return true;
     }
     // Allow additional devices that work reliably with the asynchronous adapter and show
     // performance problems when not using it.
     if (context != null
-        && Util.SDK_INT >= 28
+        && SDK_INT >= 28
         && context.getPackageManager().hasSystemFeature("com.amazon.hardware.tv_screen")) {
       return true;
     }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecDecoderException.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecDecoderException.java
@@ -15,6 +15,8 @@
  */
 package androidx.media3.exoplayer.mediacodec;
 
+import static android.os.Build.VERSION.SDK_INT;
+
 import android.media.MediaCodec;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -43,7 +45,7 @@ public class MediaCodecDecoderException extends DecoderException {
             ? ((MediaCodec.CodecException) cause).getDiagnosticInfo()
             : null;
     errorCode =
-        Util.SDK_INT >= 23
+        SDK_INT >= 23
             ? getErrorCodeV23(cause)
             : Util.getErrorCodeFromPlatformDiagnosticsInfo(diagnosticInfo);
   }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.mediacodec;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.exoplayer.DecoderReuseEvaluation.DISCARD_REASON_AUDIO_CHANNEL_COUNT_CHANGED;
 import static androidx.media3.exoplayer.DecoderReuseEvaluation.DISCARD_REASON_AUDIO_ENCODING_CHANGED;
 import static androidx.media3.exoplayer.DecoderReuseEvaluation.DISCARD_REASON_AUDIO_SAMPLE_RATE_CHANGED;
@@ -247,7 +248,7 @@ public final class MediaCodecInfo {
    * @see CodecCapabilities#getMaxSupportedInstances()
    */
   public int getMaxSupportedInstances() {
-    if (Util.SDK_INT < 23 || capabilities == null) {
+    if (SDK_INT < 23 || capabilities == null) {
       return MAX_SUPPORTED_INSTANCES_UNKNOWN;
     }
     return getMaxSupportedInstancesV23(capabilities);
@@ -355,7 +356,7 @@ public final class MediaCodecInfo {
     }
 
     CodecProfileLevel[] profileLevels = getProfileLevels();
-    if (Util.SDK_INT <= 23 && MimeTypes.VIDEO_VP9.equals(mimeType) && profileLevels.length == 0) {
+    if (SDK_INT <= 23 && MimeTypes.VIDEO_VP9.equals(mimeType) && profileLevels.length == 0) {
       // Some older devices don't report profile levels for VP9. Estimate them using other data in
       // the codec capabilities.
       profileLevels = estimateLegacyVp9ProfileLevels(capabilities);
@@ -379,13 +380,13 @@ public final class MediaCodecInfo {
     // exists.
     return !Objects.equals(format.sampleMimeType, MimeTypes.AUDIO_FLAC)
         || format.pcmEncoding != C.ENCODING_PCM_32BIT
-        || Util.SDK_INT >= 34
+        || SDK_INT >= 34
         || !name.equals("c2.android.flac.decoder");
   }
 
   /** Whether the codec handles HDR10+ out-of-band metadata. */
   public boolean isHdr10PlusOutOfBandMetadataSupported() {
-    if (Util.SDK_INT >= 29 && MimeTypes.VIDEO_VP9.equals(mimeType)) {
+    if (SDK_INT >= 29 && MimeTypes.VIDEO_VP9.equals(mimeType)) {
       for (CodecProfileLevel capabilities : getProfileLevels()) {
         if (capabilities.profile == CodecProfileLevel.VP9Profile2HDR10Plus) {
           return true;
@@ -531,7 +532,7 @@ public final class MediaCodecInfo {
       return false;
     }
 
-    if (Util.SDK_INT >= 29) {
+    if (SDK_INT >= 29) {
       @MediaCodecPerformancePointCoverageProvider.PerformancePointCoverageResult
       int evaluation =
           MediaCodecPerformancePointCoverageProvider.areResolutionAndFrameRateCovered(
@@ -657,7 +658,7 @@ public final class MediaCodecInfo {
   }
 
   private static int adjustMaxInputChannelCount(String name, String mimeType, int maxChannelCount) {
-    if (maxChannelCount > 1 || (Util.SDK_INT >= 26 && maxChannelCount > 0)) {
+    if (maxChannelCount > 1 || (SDK_INT >= 26 && maxChannelCount > 0)) {
       // The maximum channel count looks like it's been set correctly.
       return maxChannelCount;
     }
@@ -710,7 +711,7 @@ public final class MediaCodecInfo {
   }
 
   private static boolean isDetachedSurfaceSupported(@Nullable CodecCapabilities capabilities) {
-    return Util.SDK_INT >= 35
+    return SDK_INT >= 35
         && capabilities != null
         && capabilities.isFeatureSupported(CodecCapabilities.FEATURE_DetachedSurface)
         && !needsDetachedSurfaceUnsupportedWorkaround();
@@ -735,7 +736,7 @@ public final class MediaCodecInfo {
       if (!capabilities.areSizeAndRateSupported(width, height, floorFrameRate)) {
         return false;
       }
-      if (Util.SDK_INT < 24) {
+      if (SDK_INT < 24) {
         return true;
       }
       @Nullable
@@ -761,8 +762,8 @@ public final class MediaCodecInfo {
   }
 
   /**
-   * Called on devices with {@link Util#SDK_INT} 23 and below, for VP9 decoders whose {@link
-   * CodecCapabilities} do not correctly report profile levels. The returned {@link
+   * Called on devices with {@link Build.VERSION#SDK_INT} 23 and below, for VP9 decoders whose
+   * {@link CodecCapabilities} do not correctly report profile levels. The returned {@link
    * CodecProfileLevel CodecProfileLevels} are estimated based on other data in the {@link
    * CodecCapabilities}.
    *
@@ -818,7 +819,7 @@ public final class MediaCodecInfo {
    * @return True if the decoder is known to fail when adapting.
    */
   private static boolean needsDisableAdaptationWorkaround(String name) {
-    return Util.SDK_INT <= 22
+    return SDK_INT <= 22
         && ("ODROID-XU3".equals(Build.MODEL) || "Nexus 10".equals(Build.MODEL))
         && ("OMX.Exynos.AVC.Decoder".equals(name) || "OMX.Exynos.AVC.Decoder.secure".equals(name));
   }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecPerformancePointCoverageProvider.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecPerformancePointCoverageProvider.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.mediacodec;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static java.lang.annotation.ElementType.TYPE_USE;
 
 import android.media.MediaCodecInfo.VideoCapabilities;
@@ -23,7 +24,6 @@ import androidx.annotation.IntDef;
 import androidx.annotation.RequiresApi;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
-import androidx.media3.common.util.Util;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -85,8 +85,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
    */
   public static @PerformancePointCoverageResult int areResolutionAndFrameRateCovered(
       VideoCapabilities videoCapabilities, int width, int height, double frameRate) {
-    if (Util.SDK_INT < 29
-        || (shouldIgnorePerformancePoints != null && shouldIgnorePerformancePoints)) {
+    if (SDK_INT < 29 || (shouldIgnorePerformancePoints != null && shouldIgnorePerformancePoints)) {
       return COVERAGE_RESULT_NO_PERFORMANCE_POINTS_UNSUPPORTED;
     }
 
@@ -131,7 +130,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
      * Checks if the CDD-requirement to support H264 720p at 60 fps is covered by PerformancePoints.
      */
     private static boolean shouldIgnorePerformancePoints() {
-      if (Util.SDK_INT >= 35) {
+      if (SDK_INT >= 35) {
         // The same check as below is tested in CTS and we should get reliable results from API 35.
         return false;
       }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.mediacodec;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.Assertions.checkStateNotNull;
@@ -945,9 +946,9 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       return true;
     }
     if (codecDrainAction == DRAIN_ACTION_FLUSH_AND_UPDATE_DRM_SESSION) {
-      checkState(Util.SDK_INT >= 23); // Implied by DRAIN_ACTION_FLUSH_AND_UPDATE_DRM_SESSION
+      checkState(SDK_INT >= 23); // Implied by DRAIN_ACTION_FLUSH_AND_UPDATE_DRM_SESSION
       // Needed to keep lint happy (it doesn't understand the checkState call alone)
-      if (Util.SDK_INT >= 23) {
+      if (SDK_INT >= 23) {
         try {
           updateDrmSessionV23();
         } catch (ExoPlaybackException e) {
@@ -1215,7 +1216,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     long codecInitializedTimestamp;
     String codecName = codecInfo.name;
     float codecOperatingRate =
-        Util.SDK_INT < 23
+        SDK_INT < 23
             ? CODEC_OPERATING_RATE_UNSET
             : getCodecOperatingRateV23(targetPlaybackSpeed, inputFormat, getStreamFormats());
     if (codecOperatingRate <= assumedMinimumCodecOperatingRate) {
@@ -1224,7 +1225,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     codecInitializingTimestamp = getClock().elapsedRealtime();
     MediaCodecAdapter.Configuration configuration =
         getMediaCodecConfiguration(codecInfo, inputFormat, crypto, codecOperatingRate);
-    if (Util.SDK_INT >= 31) {
+    if (SDK_INT >= 31) {
       Api31.setLogSessionIdToMediaCodecFormat(configuration, getPlayerId());
     }
     try {
@@ -1610,7 +1611,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
           DISCARD_REASON_DRM_SESSION_CHANGED);
     }
     boolean drainAndUpdateCodecDrmSession = sourceDrmSession != codecDrmSession;
-    Assertions.checkState(!drainAndUpdateCodecDrmSession || Util.SDK_INT >= 23);
+    Assertions.checkState(!drainAndUpdateCodecDrmSession || SDK_INT >= 23);
 
     DecoderReuseEvaluation evaluation = canReuseCodec(codecInfo, oldFormat, newFormat);
     @DecoderDiscardReasons int overridingDiscardReasons = 0;
@@ -1899,7 +1900,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
    * @return False if codec release and re-initialization was triggered. True in all other cases.
    */
   private boolean updateCodecOperatingRate(@Nullable Format format) throws ExoPlaybackException {
-    if (Util.SDK_INT < 23) {
+    if (SDK_INT < 23) {
       return true;
     }
 
@@ -2323,7 +2324,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       return true;
     }
 
-    if (Util.SDK_INT < 23) {
+    if (SDK_INT < 23) {
       // MediaCrypto.setMediaDrmSession is only available from API level 23, so re-initialization is
       // required to switch to newSession on older API levels.
       return true;
@@ -2572,14 +2573,14 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
    * @return The mode specifying when the adaptation workaround should be enabled.
    */
   private @AdaptationWorkaroundMode int codecAdaptationWorkaroundMode(String name) {
-    if (Util.SDK_INT <= 25
+    if (SDK_INT <= 25
         && "OMX.Exynos.avc.dec.secure".equals(name)
         && (Build.MODEL.startsWith("SM-T585")
             || Build.MODEL.startsWith("SM-A510")
             || Build.MODEL.startsWith("SM-A520")
             || Build.MODEL.startsWith("SM-J700"))) {
       return ADAPTATION_WORKAROUND_MODE_ALWAYS;
-    } else if (Util.SDK_INT < 24
+    } else if (SDK_INT < 24
         && ("OMX.Nvidia.h264.decode".equals(name) || "OMX.Nvidia.h264.decode.secure".equals(name))
         && ("flounder".equals(Build.DEVICE)
             || "flounder_lte".equals(Build.DEVICE)
@@ -2605,7 +2606,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
    *     {@link MediaFormat}. False otherwise.
    */
   private static boolean codecNeedsSosFlushWorkaround(String name) {
-    return Util.SDK_INT == 29 && "c2.android.aac.decoder".equals(name);
+    return SDK_INT == 29 && "c2.android.aac.decoder".equals(name);
   }
 
   /**
@@ -2622,8 +2623,8 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
    */
   private static boolean codecNeedsEosPropagationWorkaround(MediaCodecInfo codecInfo) {
     String name = codecInfo.name;
-    return (Util.SDK_INT <= 25 && "OMX.rk.video_decoder.avc".equals(name))
-        || (Util.SDK_INT <= 29
+    return (SDK_INT <= 25 && "OMX.rk.video_decoder.avc".equals(name))
+        || (SDK_INT <= 29
             && ("OMX.broadcom.video_decoder.tunnel".equals(name)
                 || "OMX.broadcom.video_decoder.tunnel.secure".equals(name)
                 || "OMX.bcm.vdec.avc.tunnel".equals(name)
@@ -2647,7 +2648,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
    *     buffer with {@link MediaCodec#BUFFER_FLAG_END_OF_STREAM} set. False otherwise.
    */
   private static boolean codecNeedsEosFlushWorkaround(String name) {
-    return Util.SDK_INT <= 23 && "OMX.google.vorbis.decoder".equals(name);
+    return SDK_INT <= 23 && "OMX.google.vorbis.decoder".equals(name);
   }
 
   /**
@@ -2662,7 +2663,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
    * @return True if the decoder may throw an exception after receiving an end-of-stream buffer.
    */
   private static boolean codecNeedsEosOutputExceptionWorkaround(String name) {
-    return Util.SDK_INT == 21 && "OMX.google.aac.decoder".equals(name);
+    return SDK_INT == 21 && "OMX.google.aac.decoder".equals(name);
   }
 
   private static final class OutputStreamInfo {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.mediacodec;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.CodecSpecificDataUtil.getHevcProfileAndLevel;
 import static java.lang.Math.max;
 
@@ -158,7 +159,7 @@ public final class MediaCodecUtil {
     MediaCodecListCompat mediaCodecList =
         new MediaCodecListCompatV21(secure, tunneling, specialCodec);
     ArrayList<MediaCodecInfo> decoderInfos = getDecoderInfosInternal(key, mediaCodecList);
-    if (secure && decoderInfos.isEmpty() && Util.SDK_INT <= 23) {
+    if (secure && decoderInfos.isEmpty() && SDK_INT <= 23) {
       // Some devices don't list secure decoders on API level 21 [Internal: b/18678462]. Try the
       // legacy path. We also try this path on API levels 22 and 23 as a defensive measure.
       mediaCodecList = new MediaCodecListCompatV16();
@@ -490,7 +491,7 @@ public final class MediaCodecUtil {
             return decoderInfos;
           }
         } catch (Exception e) {
-          if (Util.SDK_INT <= 23 && !decoderInfos.isEmpty()) {
+          if (SDK_INT <= 23 && !decoderInfos.isEmpty()) {
             // Suppress error querying secondary codec capabilities up to API level 23.
             Log.e(TAG, "Skipping codec " + name + " (failed to query capabilities)");
           } else {
@@ -574,7 +575,7 @@ public final class MediaCodecUtil {
     }
 
     // Work around https://github.com/google/ExoPlayer/issues/3249.
-    if (Util.SDK_INT < 24
+    if (SDK_INT < 24
         && ("OMX.SEC.aac.dec".equals(name) || "OMX.Exynos.AAC.Decoder".equals(name))
         && "samsung".equals(Build.MANUFACTURER)
         && (Build.DEVICE.startsWith("zeroflte") // Galaxy S6
@@ -589,7 +590,7 @@ public final class MediaCodecUtil {
     }
 
     // MTK AC3 decoder doesn't support decoding JOC streams in 2-D. See [Internal: b/69400041].
-    if (Util.SDK_INT <= 23
+    if (SDK_INT <= 23
         && MimeTypes.AUDIO_E_AC3_JOC.equals(mimeType)
         && "OMX.MTK.AUDIO.DECODER.DSPAC3".equals(name)) {
       return false;
@@ -607,7 +608,7 @@ public final class MediaCodecUtil {
    */
   private static void applyWorkarounds(String mimeType, List<MediaCodecInfo> decoderInfos) {
     if (MimeTypes.AUDIO_RAW.equals(mimeType)) {
-      if (Util.SDK_INT < 26
+      if (SDK_INT < 26
           && Build.DEVICE.equals("R9")
           && decoderInfos.size() == 1
           && decoderInfos.get(0).name.equals("OMX.MTK.AUDIO.DECODER.RAW")) {
@@ -634,7 +635,7 @@ public final class MediaCodecUtil {
               // Prefer generic decoders over ones provided by the device.
               return 1;
             }
-            if (Util.SDK_INT < 26 && name.equals("OMX.MTK.AUDIO.DECODER.RAW")) {
+            if (SDK_INT < 26 && name.equals("OMX.MTK.AUDIO.DECODER.RAW")) {
               // This decoder may modify the audio, so any other compatible decoders take
               // precedence. See [Internal: b/62337687].
               return -1;
@@ -643,7 +644,7 @@ public final class MediaCodecUtil {
           });
     }
 
-    if (Util.SDK_INT < 32 && decoderInfos.size() > 1) {
+    if (SDK_INT < 32 && decoderInfos.size() > 1) {
       String firstCodecName = decoderInfos.get(0).name;
       // Prefer anything other than OMX.qti.audio.decoder.flac on older devices. See [Internal
       // ref: b/199124812].
@@ -654,7 +655,7 @@ public final class MediaCodecUtil {
   }
 
   private static boolean isAlias(android.media.MediaCodecInfo info) {
-    return Util.SDK_INT >= 29 && isAliasV29(info);
+    return SDK_INT >= 29 && isAliasV29(info);
   }
 
   @RequiresApi(29)
@@ -668,7 +669,7 @@ public final class MediaCodecUtil {
    */
   private static boolean isHardwareAccelerated(
       android.media.MediaCodecInfo codecInfo, String mimeType) {
-    if (Util.SDK_INT >= 29) {
+    if (SDK_INT >= 29) {
       return isHardwareAcceleratedV29(codecInfo);
     }
     // codecInfo.isHardwareAccelerated() != codecInfo.isSoftwareOnly() is not necessarily true.
@@ -686,7 +687,7 @@ public final class MediaCodecUtil {
    * best-effort approximation for lower levels.
    */
   private static boolean isSoftwareOnly(android.media.MediaCodecInfo codecInfo, String mimeType) {
-    if (Util.SDK_INT >= 29) {
+    if (SDK_INT >= 29) {
       return isSoftwareOnlyV29(codecInfo);
     }
     if (MimeTypes.isAudio(mimeType)) {
@@ -717,7 +718,7 @@ public final class MediaCodecUtil {
    * best-effort approximation for lower levels.
    */
   private static boolean isVendor(android.media.MediaCodecInfo codecInfo) {
-    if (Util.SDK_INT >= 29) {
+    if (SDK_INT >= 29) {
       return isVendorV29(codecInfo);
     }
     String codecName = Ascii.toLowerCase(codecInfo.getName());

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/SynchronousMediaCodecAdapter.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/SynchronousMediaCodecAdapter.java
@@ -16,6 +16,7 @@
 
 package androidx.media3.exoplayer.mediacodec;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.annotation.SuppressLint;
@@ -30,7 +31,6 @@ import androidx.annotation.RequiresApi;
 import androidx.media3.common.C;
 import androidx.media3.common.util.TraceUtil;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.decoder.CryptoInfo;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -54,7 +54,7 @@ public final class SynchronousMediaCodecAdapter implements MediaCodecAdapter {
         int flags = 0;
         if (configuration.surface == null
             && configuration.codecInfo.detachedSurfaceSupported
-            && Util.SDK_INT >= 35) {
+            && SDK_INT >= 35) {
           flags |= MediaCodec.CONFIGURE_FLAG_DETACHED_SURFACE;
         }
         codec.configure(
@@ -90,7 +90,7 @@ public final class SynchronousMediaCodecAdapter implements MediaCodecAdapter {
       MediaCodec mediaCodec, @Nullable LoudnessCodecController loudnessCodecController) {
     this.codec = mediaCodec;
     this.loudnessCodecController = loudnessCodecController;
-    if (Util.SDK_INT >= 35 && loudnessCodecController != null) {
+    if (SDK_INT >= 35 && loudnessCodecController != null) {
       loudnessCodecController.addMediaCodec(codec);
     }
   }
@@ -163,7 +163,7 @@ public final class SynchronousMediaCodecAdapter implements MediaCodecAdapter {
   @Override
   public void release() {
     try {
-      if (Util.SDK_INT >= 30 && Util.SDK_INT < 33) {
+      if (SDK_INT >= 30 && SDK_INT < 33) {
         // Stopping the codec before releasing it works around a bug on APIs 30, 31 and 32 where
         // MediaCodec.release() returns too early before fully detaching a Surface, and a
         // subsequent MediaCodec.configure() call using the same Surface then fails. See
@@ -171,7 +171,7 @@ public final class SynchronousMediaCodecAdapter implements MediaCodecAdapter {
         codec.stop();
       }
     } finally {
-      if (Util.SDK_INT >= 35 && loudnessCodecController != null) {
+      if (SDK_INT >= 35 && loudnessCodecController != null) {
         loudnessCodecController.removeMediaCodec(codec);
       }
       codec.release();

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DownloadNotificationHelper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DownloadNotificationHelper.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.offline;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.core.app.NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE;
 
 import android.annotation.SuppressLint;
@@ -28,7 +29,6 @@ import androidx.annotation.StringRes;
 import androidx.core.app.NotificationCompat;
 import androidx.media3.common.C;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.R;
 import androidx.media3.exoplayer.scheduler.Requirements;
 import java.util.List;
@@ -227,7 +227,7 @@ public final class DownloadNotificationHelper {
     notificationBuilder.setProgress(maxProgress, currentProgress, indeterminateProgress);
     notificationBuilder.setOngoing(ongoing);
     notificationBuilder.setShowWhen(showWhen);
-    if (Util.SDK_INT >= 31) {
+    if (SDK_INT >= 31) {
       Api31.setForegroundServiceBehavior(notificationBuilder);
     }
     return notificationBuilder.build();

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DownloadService.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/DownloadService.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.offline;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.exoplayer.offline.Download.STOP_REASON_NONE;
 
 import android.annotation.SuppressLint;
@@ -595,7 +596,7 @@ public abstract class DownloadService extends Service {
     if (downloadManagerHelper == null) {
       boolean foregroundAllowed = foregroundNotificationUpdater != null;
       // See https://developer.android.com/about/versions/12/foreground-services.
-      boolean canStartForegroundServiceFromBackground = Util.SDK_INT < 31;
+      boolean canStartForegroundServiceFromBackground = SDK_INT < 31;
       @Nullable
       Scheduler scheduler =
           foregroundAllowed && canStartForegroundServiceFromBackground ? getScheduler() : null;
@@ -683,7 +684,7 @@ public abstract class DownloadService extends Service {
         break;
     }
 
-    if (Util.SDK_INT >= 26 && startedInForeground && foregroundNotificationUpdater != null) {
+    if (SDK_INT >= 26 && startedInForeground && foregroundNotificationUpdater != null) {
       // From API level 26, services started in the foreground are required to show a notification.
       foregroundNotificationUpdater.showNotificationIfNotAlready();
     }
@@ -844,7 +845,7 @@ public abstract class DownloadService extends Service {
 
     // Stop the service, either because the DownloadManager is not waiting for requirements to be
     // met, or because we've scheduled the service to be restarted when they are.
-    if (Util.SDK_INT < 28 && taskRemoved) { // See [Internal: b/74248644].
+    if (SDK_INT < 28 && taskRemoved) { // See [Internal: b/74248644].
       stopSelf();
       isStopped = true;
     } else {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/scheduler/PlatformScheduler.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/scheduler/PlatformScheduler.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.scheduler;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.app.job.JobInfo;
@@ -55,7 +56,7 @@ public final class PlatformScheduler implements Scheduler {
           | Requirements.NETWORK_UNMETERED
           | Requirements.DEVICE_IDLE
           | Requirements.DEVICE_CHARGING
-          | (Util.SDK_INT >= 26 ? Requirements.DEVICE_STORAGE_NOT_LOW : 0);
+          | (SDK_INT >= 26 ? Requirements.DEVICE_STORAGE_NOT_LOW : 0);
 
   private final int jobId;
   private final ComponentName jobServiceComponentName;
@@ -120,7 +121,7 @@ public final class PlatformScheduler implements Scheduler {
     }
     builder.setRequiresDeviceIdle(requirements.isIdleRequired());
     builder.setRequiresCharging(requirements.isChargingRequired());
-    if (Util.SDK_INT >= 26 && requirements.isStorageNotLowRequired()) {
+    if (SDK_INT >= 26 && requirements.isStorageNotLowRequired()) {
       builder.setRequiresStorageNotLow(true);
     }
     builder.setPersisted(true);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/scheduler/Requirements.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/scheduler/Requirements.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.scheduler;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
 import static java.lang.annotation.ElementType.METHOD;
@@ -36,7 +37,6 @@ import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
 import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -202,7 +202,7 @@ public final class Requirements implements Parcelable {
   private boolean isDeviceIdle(Context context) {
     PowerManager powerManager =
         (PowerManager) Assertions.checkNotNull(context.getSystemService(Context.POWER_SERVICE));
-    return Util.SDK_INT >= 23 ? powerManager.isDeviceIdleMode() : !powerManager.isInteractive();
+    return SDK_INT >= 23 ? powerManager.isDeviceIdleMode() : !powerManager.isInteractive();
   }
 
   private boolean isStorageNotLow(Context context) {
@@ -216,7 +216,7 @@ public final class Requirements implements Parcelable {
     // RequirementsWatcher only fires an event to re-check the requirements when NetworkCapabilities
     // change from API level 24. We assume that network capability is validated for API level 23 to
     // keep in sync.
-    if (Util.SDK_INT < 24) {
+    if (SDK_INT < 24) {
       return true;
     }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/scheduler/RequirementsWatcher.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/scheduler/RequirementsWatcher.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.scheduler;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.content.BroadcastReceiver;
@@ -88,7 +89,7 @@ public final class RequirementsWatcher {
 
     IntentFilter filter = new IntentFilter();
     if (requirements.isNetworkRequired()) {
-      if (Util.SDK_INT >= 24) {
+      if (SDK_INT >= 24) {
         registerNetworkCallbackV24();
       } else {
         filter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
@@ -99,7 +100,7 @@ public final class RequirementsWatcher {
       filter.addAction(Intent.ACTION_POWER_DISCONNECTED);
     }
     if (requirements.isIdleRequired()) {
-      if (Util.SDK_INT >= 23) {
+      if (SDK_INT >= 23) {
         filter.addAction(PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED);
       } else {
         filter.addAction(Intent.ACTION_SCREEN_ON);
@@ -119,7 +120,7 @@ public final class RequirementsWatcher {
   public void stop() {
     context.unregisterReceiver(checkNotNull(receiver));
     receiver = null;
-    if (Util.SDK_INT >= 24 && networkCallback != null) {
+    if (SDK_INT >= 24 && networkCallback != null) {
       unregisterNetworkCallbackV24();
     }
   }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/MediaParserExtractorAdapter.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/MediaParserExtractorAdapter.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.source;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.exoplayer.source.mediaparser.MediaParserUtil.PARAMETER_EAGERLY_EXPOSE_TRACK_TYPE;
 import static androidx.media3.exoplayer.source.mediaparser.MediaParserUtil.PARAMETER_INCLUDE_SUPPLEMENTAL_DATA;
 import static androidx.media3.exoplayer.source.mediaparser.MediaParserUtil.PARAMETER_IN_BAND_CRYPTO_INFO;
@@ -28,7 +29,6 @@ import androidx.annotation.RequiresApi;
 import androidx.media3.common.C;
 import androidx.media3.common.DataReader;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.analytics.PlayerId;
 import androidx.media3.exoplayer.source.mediaparser.InputReaderAdapterV30;
 import androidx.media3.exoplayer.source.mediaparser.MediaParserUtil;
@@ -107,7 +107,7 @@ public final class MediaParserExtractorAdapter implements ProgressiveMediaExtrac
       mediaParser.setParameter(parameter.getKey(), parameter.getValue());
     }
     parserName = MediaParser.PARSER_NAME_UNKNOWN;
-    if (Util.SDK_INT >= 31) {
+    if (SDK_INT >= 31) {
       MediaParserUtil.setLogSessionIdOnMediaParser(mediaParser, playerId);
     }
   }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/chunk/MediaParserChunkExtractor.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/chunk/MediaParserChunkExtractor.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.source.chunk;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.exoplayer.source.mediaparser.MediaParserUtil.PARAMETER_EAGERLY_EXPOSE_TRACK_TYPE;
 import static androidx.media3.exoplayer.source.mediaparser.MediaParserUtil.PARAMETER_EXPOSE_CAPTION_FORMATS;
@@ -34,7 +35,6 @@ import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.analytics.PlayerId;
 import androidx.media3.exoplayer.source.mediaparser.InputReaderAdapterV30;
 import androidx.media3.exoplayer.source.mediaparser.MediaParserUtil;
@@ -196,7 +196,7 @@ public final class MediaParserChunkExtractor implements ChunkExtractor {
           MediaParserUtil.toCaptionsMediaFormat(closedCaptionFormats.get(i)));
     }
     mediaParser.setParameter(PARAMETER_EXPOSE_CAPTION_FORMATS, closedCaptionMediaFormats);
-    if (Util.SDK_INT >= 31) {
+    if (SDK_INT >= 31) {
       MediaParserUtil.setLogSessionIdOnMediaParser(mediaParser, playerId);
     }
     outputConsumerAdapter.setMuxedCaptionFormats(closedCaptionFormats);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.trackselection;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_DISABLED;
 import static androidx.media3.common.TrackSelectionParameters.AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_REQUIRED;
 import static androidx.media3.common.util.Assertions.checkNotNull;
@@ -2482,7 +2483,7 @@ public class DefaultTrackSelector extends MappingTrackSelector
 
   @Override
   public void release() {
-    if (Util.SDK_INT >= 32 && spatializer != null) {
+    if (SDK_INT >= 32 && spatializer != null) {
       spatializer.release();
     }
     super.release();
@@ -2592,7 +2593,7 @@ public class DefaultTrackSelector extends MappingTrackSelector
       parameters = this.parameters;
     }
     if (parameters.constrainAudioChannelCountToDeviceCapabilities
-        && Util.SDK_INT >= 32
+        && SDK_INT >= 32
         && spatializer == null) {
       spatializer = new SpatializerWrapperV32(context, /* defaultTrackSelector= */ this);
     }
@@ -2868,10 +2869,8 @@ public class DefaultTrackSelector extends MappingTrackSelector
     return !parameters.constrainAudioChannelCountToDeviceCapabilities
         || (format.channelCount == Format.NO_VALUE || format.channelCount <= 2)
         || (isDolbyAudio(format)
-            && (Util.SDK_INT < 32
-                || spatializer == null
-                || !spatializer.isSpatializationSupported()))
-        || (Util.SDK_INT >= 32
+            && (SDK_INT < 32 || spatializer == null || !spatializer.isSpatializationSupported()))
+        || (SDK_INT >= 32
             && spatializer != null
             && spatializer.isSpatializationSupported()
             && spatializer.isAvailable()
@@ -3065,7 +3064,7 @@ public class DefaultTrackSelector extends MappingTrackSelector
     synchronized (lock) {
       shouldInvalidate =
           parameters.constrainAudioChannelCountToDeviceCapabilities
-              && Util.SDK_INT >= 32
+              && SDK_INT >= 32
               && spatializer != null
               && spatializer.isSpatializationSupported();
     }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.video;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static android.view.Display.DEFAULT_DISPLAY;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
@@ -764,7 +765,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     @DecoderSupport
     int decoderSupport = isPreferredDecoder ? DECODER_SUPPORT_PRIMARY : DECODER_SUPPORT_FALLBACK;
 
-    if (Util.SDK_INT >= 26
+    if (SDK_INT >= 26
         && MimeTypes.VIDEO_DOLBY_VISION.equals(format.sampleMimeType)
         && !Api26.doesDisplaySupportDolbyVision(context)) {
       decoderSupport = DECODER_SUPPORT_FALLBACK_MIMETYPE;
@@ -835,7 +836,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     if (format.sampleMimeType == null) {
       return ImmutableList.of();
     }
-    if (Util.SDK_INT >= 26
+    if (SDK_INT >= 26
         && MimeTypes.VIDEO_DOLBY_VISION.equals(format.sampleMimeType)
         && !Api26.doesDisplaySupportDolbyVision(context)) {
       List<MediaCodecInfo> alternativeDecoderInfos =
@@ -1214,7 +1215,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       if (codec != null && videoSink == null) {
         MediaCodecInfo codecInfo = checkNotNull(getCodecInfo());
         boolean canUpdateSurface = hasSurfaceForCodec(codecInfo);
-        if (Util.SDK_INT >= 23 && canUpdateSurface && !codecNeedsSetOutputSurfaceWorkaround) {
+        if (SDK_INT >= 23 && canUpdateSurface && !codecNeedsSetOutputSurfaceWorkaround) {
           setOutputSurface(codec, getSurfaceForCodec(codecInfo));
         } else {
           releaseCodec();
@@ -1259,7 +1260,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   @Override
   protected boolean getCodecNeedsEosPropagation() {
     // Since API 23, onFrameRenderedListener allows for detection of the renderer EOS.
-    return tunneling && Util.SDK_INT < 23;
+    return tunneling && SDK_INT < 23;
   }
 
   @Override
@@ -1525,7 +1526,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     if (!tunneling) {
       buffersInCodecCount++;
     }
-    if (Util.SDK_INT < 23 && tunneling) {
+    if (SDK_INT < 23 && tunneling) {
       // In tunneled mode before API 23 we don't have a way to know when the buffer is output, so
       // treat it as if it were output immediately.
       onProcessedTunneledBuffer(buffer.timeUs);
@@ -1534,7 +1535,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
 
   @Override
   protected int getCodecBufferFlags(DecoderInputBuffer buffer) {
-    if (Util.SDK_INT >= 34
+    if (SDK_INT >= 34
         && (enableMediaCodecBufferDecodeOnlyFlag || tunneling)
         && isBufferBeforeStartTime(buffer)) {
       // The buffer likely needs to be dropped because its timestamp is less than the start time.
@@ -2146,11 +2147,11 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   }
 
   protected boolean shouldUseDetachedSurface(MediaCodecInfo codecInfo) {
-    return Util.SDK_INT >= 35 && codecInfo.detachedSurfaceSupported;
+    return SDK_INT >= 35 && codecInfo.detachedSurfaceSupported;
   }
 
   protected boolean shouldUsePlaceholderSurface(MediaCodecInfo codecInfo) {
-    return Util.SDK_INT >= 23
+    return SDK_INT >= 23
         && !tunneling
         && !codecNeedsSetOutputSurfaceWorkaround(codecInfo.name)
         && (!codecInfo.secure || PlaceholderSurface.isSecureSupported(context));
@@ -2164,7 +2165,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   }
 
   private void maybeSetupTunnelingForFirstFrame() {
-    if (!tunneling || Util.SDK_INT < 23) {
+    if (!tunneling || SDK_INT < 23) {
       // The first frame notification for tunneling is triggered by onQueueInputBuffer prior to API
       // level 23 and no setup is needed here.
       return;
@@ -2175,7 +2176,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       return;
     }
     tunnelingOnFrameRenderedListener = new OnFrameRenderedListenerV23(codec);
-    if (Util.SDK_INT >= 33) {
+    if (SDK_INT >= 33) {
       // This should be the default anyway according to the API contract, but some devices are known
       // to not adhere to this contract and need to get the parameter explicitly. See
       // https://github.com/androidx/media/issues/1169.
@@ -2191,7 +2192,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       // If codec is null, then the importance will be set when initializing the codec.
       return;
     }
-    if (Util.SDK_INT >= 35) {
+    if (SDK_INT >= 35) {
       Bundle codecParameters = new Bundle();
       codecParameters.putInt(MediaFormat.KEY_IMPORTANCE, max(0, -rendererPriority));
       codec.setParameters(codecParameters);
@@ -2257,9 +2258,9 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   }
 
   private void setOutputSurface(MediaCodecAdapter codec, @Nullable Surface surface) {
-    if (Util.SDK_INT >= 23 && surface != null) {
+    if (SDK_INT >= 23 && surface != null) {
       setOutputSurfaceV23(codec, surface);
-    } else if (Util.SDK_INT >= 35) {
+    } else if (SDK_INT >= 35) {
       detachOutputSurfaceV35(codec);
     } else {
       throw new IllegalStateException();
@@ -2323,7 +2324,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
     MediaFormatUtil.maybeSetInteger(
         mediaFormat, MediaFormat.KEY_MAX_INPUT_SIZE, codecMaxValues.inputSize);
     // Set codec configuration values.
-    if (Util.SDK_INT >= 23) {
+    if (SDK_INT >= 23) {
       mediaFormat.setInteger(MediaFormat.KEY_PRIORITY, 0 /* realtime priority */);
       if (codecOperatingRate != CODEC_OPERATING_RATE_UNSET) {
         mediaFormat.setFloat(MediaFormat.KEY_OPERATING_RATE, codecOperatingRate);
@@ -2337,7 +2338,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       mediaFormat.setFeatureEnabled(CodecCapabilities.FEATURE_TunneledPlayback, true);
       mediaFormat.setInteger(MediaFormat.KEY_AUDIO_SESSION_ID, tunnelingAudioSessionId);
     }
-    if (Util.SDK_INT >= 35) {
+    if (SDK_INT >= 35) {
       mediaFormat.setInteger(MediaFormat.KEY_IMPORTANCE, max(0, -rendererPriority));
     }
     return mediaFormat;
@@ -2557,7 +2558,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
   }
 
   private static boolean evaluateDeviceNeedsSetOutputSurfaceWorkaround() {
-    if (Util.SDK_INT <= 28) {
+    if (SDK_INT <= 28) {
       // Workaround for MiTV and MiBox devices which have been observed broken up to API 28.
       // https://github.com/google/ExoPlayer/issues/5169,
       // https://github.com/google/ExoPlayer/issues/6899.
@@ -2578,7 +2579,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
           break; // Do nothing.
       }
     }
-    if (Util.SDK_INT <= 27 && "HWEML".equals(Build.DEVICE)) {
+    if (SDK_INT <= 27 && "HWEML".equals(Build.DEVICE)) {
       // Workaround for Huawei P20:
       // https://github.com/google/ExoPlayer/issues/4468#issuecomment-459291645.
       return true;
@@ -2598,7 +2599,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       default:
         break; // Do nothing.
     }
-    if (Util.SDK_INT <= 26) {
+    if (SDK_INT <= 26) {
       // In general, devices running API level 27 or later should be unaffected unless observed
       // otherwise. Enable the workaround on a per-device basis. Works around:
       // https://github.com/google/ExoPlayer/issues/3236,
@@ -2795,7 +2796,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       // This was fixed in https://android-review.googlesource.com/1156807.
       //
       // The workaround queues the event for subsequent processing, where the lock will not be held.
-      if (Util.SDK_INT < 30) {
+      if (SDK_INT < 30) {
         Message message =
             Message.obtain(
                 handler,

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/PlaybackVideoGraphWrapper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/PlaybackVideoGraphWrapper.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.video;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.VideoFrameProcessor.DROP_OUTPUT_FRAME;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
@@ -497,7 +498,7 @@ public final class PlaybackVideoGraphWrapper implements VideoSinkProvider, Video
       if (requestOpenGlToneMapping) {
         outputColorInfo = ColorInfo.SDR_BT709_LIMITED;
       } else if (inputColorInfo.colorTransfer == C.COLOR_TRANSFER_HLG
-          && Util.SDK_INT < 34
+          && SDK_INT < 34
           && GlUtil.isBt2020PqExtensionSupported()) {
         // PQ SurfaceView output is supported from API 33, but HLG output is supported from API
         // 34. Therefore, convert HLG to PQ if PQ is supported, so that HLG input can be displayed
@@ -506,8 +507,7 @@ public final class PlaybackVideoGraphWrapper implements VideoSinkProvider, Video
             inputColorInfo.buildUpon().setColorTransfer(C.COLOR_TRANSFER_ST2084).build();
         // Force OpenGL tone mapping if the GL extension required to output HDR colors is not
         // available. OpenGL tone mapping is only supported on API 29+.
-      } else if (!GlUtil.isColorTransferSupported(inputColorInfo.colorTransfer)
-          && Util.SDK_INT >= 29) {
+      } else if (!GlUtil.isColorTransferSupported(inputColorInfo.colorTransfer) && SDK_INT >= 29) {
         Log.w(
             TAG,
             Util.formatInvariant(

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/VideoFrameReleaseHelper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/VideoFrameReleaseHelper.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.video;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.content.Context;
@@ -297,7 +298,7 @@ public final class VideoFrameReleaseHelper {
    * called to update the surface.
    */
   private void updateSurfaceMediaFrameRate() {
-    if (Util.SDK_INT < 30 || surface == null) {
+    if (SDK_INT < 30 || surface == null) {
       return;
     }
 
@@ -345,7 +346,7 @@ public final class VideoFrameReleaseHelper {
    *     unchanged.
    */
   private void updateSurfacePlaybackFrameRate(boolean forceUpdate) {
-    if (Util.SDK_INT < 30
+    if (SDK_INT < 30
         || surface == null
         || changeFrameRateStrategy == C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF) {
       return;
@@ -371,7 +372,7 @@ public final class VideoFrameReleaseHelper {
    * C#VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF}.
    */
   private void clearSurfaceFrameRate() {
-    if (Util.SDK_INT < 30
+    if (SDK_INT < 30
         || surface == null
         || changeFrameRateStrategy == C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF
         || surfacePlaybackFrameRate == 0) {

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/AudioFocusManagerTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/AudioFocusManagerTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.exoplayer.AudioFocusManager.PLAYER_COMMAND_DO_NOT_PLAY;
 import static androidx.media3.exoplayer.AudioFocusManager.PLAYER_COMMAND_PLAY_WHEN_READY;
 import static androidx.media3.exoplayer.AudioFocusManager.PLAYER_COMMAND_WAIT_FOR_CALLBACK;
@@ -29,7 +30,6 @@ import android.os.Looper;
 import androidx.media3.common.AudioAttributes;
 import androidx.media3.common.C;
 import androidx.media3.common.Player;
-import androidx.media3.common.util.Util;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Before;
@@ -550,7 +550,7 @@ public class AudioFocusManagerTest {
   }
 
   private int getAudioFocusGainFromRequest(ShadowAudioManager.AudioFocusRequest audioFocusRequest) {
-    return Util.SDK_INT >= 26
+    return SDK_INT >= 26
         ? audioFocusRequest.audioFocusRequest.getFocusGain()
         : audioFocusRequest.durationHint;
   }

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/AudioCapabilitiesEndToEndTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/AudioCapabilitiesEndToEndTest.java
@@ -18,6 +18,7 @@ package androidx.media3.exoplayer.audio;
 import static android.media.AudioFormat.CHANNEL_OUT_5POINT1;
 import static android.media.AudioFormat.CHANNEL_OUT_STEREO;
 import static android.media.AudioFormat.ENCODING_AC3;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.test.utils.robolectric.ShadowMediaCodecConfig.CODEC_INFO_AAC;
 import static androidx.media3.test.utils.robolectric.ShadowMediaCodecConfig.CODEC_INFO_AC3;
@@ -44,7 +45,6 @@ import androidx.media3.common.MimeTypes;
 import androidx.media3.common.Player;
 import androidx.media3.common.Tracks;
 import androidx.media3.common.Tracks.Group;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.DecoderCounters;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.Renderer;
@@ -462,7 +462,7 @@ public class AudioCapabilitiesEndToEndTest {
             .setFlags(0)
             .build());
     directPlaybackDevice = createDirectPlaybackDevice(ENCODING_AC3, CHANNEL_OUT_5POINT1);
-    if (Util.SDK_INT >= 33) {
+    if (SDK_INT >= 33) {
       shadowOf(audioManager).addOutputDeviceWithDirectProfiles(checkNotNull(directPlaybackDevice));
     }
     shadowOf(audioManager)
@@ -474,7 +474,7 @@ public class AudioCapabilitiesEndToEndTest {
     ShadowAudioTrack.clearAllowedNonPcmEncodings();
     ShadowAudioTrack.clearDirectPlaybackSupportedFormats();
     if (directPlaybackDevice != null) {
-      if (Util.SDK_INT >= 33) {
+      if (SDK_INT >= 33) {
         shadowOf(audioManager).removeOutputDeviceWithDirectProfiles(directPlaybackDevice);
       }
       shadowOf(audioManager)
@@ -486,7 +486,7 @@ public class AudioCapabilitiesEndToEndTest {
   private void setupDefaultPcmSupport() {
     AudioDeviceInfoBuilder defaultDevice =
         AudioDeviceInfoBuilder.newBuilder().setType(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER);
-    if (Util.SDK_INT >= 33) {
+    if (SDK_INT >= 33) {
       defaultDevice.setProfiles(ImmutableList.of(createPcmProfile()));
       shadowOf(audioManager).addOutputDeviceWithDirectProfiles(defaultDevice.build());
     } else {
@@ -510,7 +510,7 @@ public class AudioCapabilitiesEndToEndTest {
   private static AudioDeviceInfo createDirectPlaybackDevice(int encoding, int channelMask) {
     AudioDeviceInfoBuilder directPlaybackDevice =
         AudioDeviceInfoBuilder.newBuilder().setType(AudioDeviceInfo.TYPE_HDMI);
-    if (Util.SDK_INT >= 33) {
+    if (SDK_INT >= 33) {
       ImmutableList<AudioProfile> expectedProfiles =
           ImmutableList.of(
               AudioProfileBuilder.newBuilder()

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/AudioCapabilitiesTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/AudioCapabilitiesTest.java
@@ -16,6 +16,7 @@
 package androidx.media3.exoplayer.audio;
 
 import static android.media.AudioFormat.CHANNEL_OUT_5POINT1;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.exoplayer.audio.AudioCapabilities.ALL_SURROUND_ENCODINGS_AND_MAX_CHANNELS;
 import static androidx.media3.exoplayer.audio.AudioCapabilities.getCapabilities;
@@ -37,7 +38,6 @@ import androidx.media3.common.AudioAttributes;
 import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
-import androidx.media3.common.util.Util;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.collect.ImmutableList;
@@ -489,7 +489,7 @@ public class AudioCapabilitiesTest {
         audioAttributes.getAudioAttributesV21().audioAttributes);
     AudioDeviceInfoBuilder deviceInfoBuilder =
         AudioDeviceInfoBuilder.newBuilder().setType(AudioDeviceInfo.TYPE_HDMI);
-    if (Util.SDK_INT >= 33) {
+    if (SDK_INT >= 33) {
       ImmutableList<AudioProfile> expectedProfiles =
           ImmutableList.of(
               AudioProfileBuilder.newBuilder()

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/DefaultAudioSinkTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/DefaultAudioSinkTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.audio;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.exoplayer.audio.AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY;
 import static androidx.media3.exoplayer.audio.AudioSink.SINK_FORMAT_SUPPORTED_WITH_TRANSCODING;
@@ -774,7 +775,7 @@ public final class DefaultAudioSinkTest {
   // Adding the permission to the test AndroidManifest.xml doesn't work to appease lint.
   @SuppressWarnings({"StickyBroadcast", "MissingPermission"})
   private void addHdmiDevice() {
-    if (Util.SDK_INT >= 23) {
+    if (SDK_INT >= 23) {
       // AudioFormat.getChannelIndexMask() in the implementation of
       // ShadowAudioTrack.addDirectPlaybackSupport requires API 23+.
       // https://cs.android.com/android/platform/superproject/main/+/main:external/robolectric/shadows/framework/src/main/java/org/robolectric/shadows/ShadowAudioTrack.java?q=format.getChannelIndexMask()
@@ -794,7 +795,7 @@ public final class DefaultAudioSinkTest {
       // https://cs.android.com/android/platform/superproject/main/+/main:external/robolectric/shadows/framework/src/main/java/org/robolectric/shadows/AudioDeviceInfoBuilder.java?q=VERSION_CODES.M
       AudioDeviceInfoBuilder hdmiDeviceBuilder =
           AudioDeviceInfoBuilder.newBuilder().setType(AudioDeviceInfo.TYPE_HDMI);
-      if (Util.SDK_INT >= 33) {
+      if (SDK_INT >= 33) {
         ImmutableList<AudioProfile> expectedProfiles =
             ImmutableList.of(
                 AudioProfileBuilder.newBuilder()
@@ -833,7 +834,7 @@ public final class DefaultAudioSinkTest {
   // Adding the permission to the test AndroidManifest.xml doesn't work to appease lint.
   @SuppressWarnings({"StickyBroadcast", "MissingPermission"})
   private void removeHdmiDevice() {
-    if (Util.SDK_INT >= 23 && hdmiDevice != null) {
+    if (SDK_INT >= 23 && hdmiDevice != null) {
       ShadowAudioTrack.clearAllowedNonPcmEncodings();
       ShadowAudioTrack.clearDirectPlaybackSupportedFormats();
       getShadowAudioManager().removeOutputDeviceWithDirectProfiles(hdmiDevice);
@@ -851,7 +852,7 @@ public final class DefaultAudioSinkTest {
   }
 
   private void addBluetoothDevice() {
-    if (Util.SDK_INT >= 23) {
+    if (SDK_INT >= 23) {
       // For API 33+, AudioManager.getDirectProfilesForAttributes returns the AudioProfile for the
       // routed device. To simulate the Bluetooth is connected and routed, we need to remove the
       // profile of the HDMI device, which means that the HDMI device is no longer routed, but
@@ -859,7 +860,7 @@ public final class DefaultAudioSinkTest {
       removeHdmiDevice();
       AudioDeviceInfoBuilder bluetoothDeviceBuilder =
           AudioDeviceInfoBuilder.newBuilder().setType(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP);
-      if (Util.SDK_INT >= 33) {
+      if (SDK_INT >= 33) {
         bluetoothDeviceBuilder.setProfiles(ImmutableList.of(createPcmProfile()));
       }
       bluetoothDevice = bluetoothDeviceBuilder.build();
@@ -872,7 +873,7 @@ public final class DefaultAudioSinkTest {
   }
 
   private void removeBluetoothDevice() {
-    if (Util.SDK_INT >= 23 && bluetoothDevice != null) {
+    if (SDK_INT >= 23 && bluetoothDevice != null) {
       // Add back the HDMI device back as the routed device to simulate that the bluetooth device
       // has gone and is no longer routed.
       addHdmiDevice();

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/DefaultBandwidthMeterTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/DefaultBandwidthMeterTest.java
@@ -17,6 +17,7 @@ package androidx.media3.exoplayer.upstream;
 
 import static android.net.NetworkInfo.State.CONNECTED;
 import static android.net.NetworkInfo.State.DISCONNECTED;
+import static android.os.Build.VERSION.SDK_INT;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
@@ -32,7 +33,6 @@ import android.telephony.TelephonyManager;
 import androidx.media3.common.C;
 import androidx.media3.common.util.BackgroundExecutor;
 import androidx.media3.common.util.NetworkTypeObserver;
-import androidx.media3.common.util.Util;
 import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DataSpec;
 import androidx.media3.test.utils.FakeClock;
@@ -796,7 +796,7 @@ public final class DefaultBandwidthMeterTest {
   private void setActiveNetworkInfo(NetworkInfo networkInfo, int networkTypeOverride) {
     // Set network info in ConnectivityManager and TelephonyDisplayInfo in TelephonyManager.
     Shadows.shadowOf(connectivityManager).setActiveNetworkInfo(networkInfo);
-    if (Util.SDK_INT >= 31) {
+    if (SDK_INT >= 31) {
       Object displayInfo =
           ShadowTelephonyManager.createTelephonyDisplayInfo(
               networkInfo.getType(), networkTypeOverride);

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/experimental/ExperimentalBandwidthMeterTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/experimental/ExperimentalBandwidthMeterTest.java
@@ -17,6 +17,7 @@ package androidx.media3.exoplayer.upstream.experimental;
 
 import static android.net.NetworkInfo.State.CONNECTED;
 import static android.net.NetworkInfo.State.DISCONNECTED;
+import static android.os.Build.VERSION.SDK_INT;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
@@ -32,7 +33,6 @@ import android.telephony.TelephonyManager;
 import androidx.media3.common.C;
 import androidx.media3.common.util.BackgroundExecutor;
 import androidx.media3.common.util.NetworkTypeObserver;
-import androidx.media3.common.util.Util;
 import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DataSpec;
 import androidx.media3.test.utils.FakeDataSource;
@@ -805,7 +805,7 @@ public final class ExperimentalBandwidthMeterTest {
   private void setActiveNetworkInfo(NetworkInfo networkInfo, int networkTypeOverride) {
     // Set network info in ConnectivityManager and TelephonyDisplayInfo in TelephonyManager.
     Shadows.shadowOf(connectivityManager).setActiveNetworkInfo(networkInfo);
-    if (Util.SDK_INT >= 31) {
+    if (SDK_INT >= 31) {
       Object displayInfo =
           ShadowTelephonyManager.createTelephonyDisplayInfo(
               networkInfo.getType(), networkTypeOverride);

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/MediaParserHlsMediaChunkExtractor.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/MediaParserHlsMediaChunkExtractor.java
@@ -19,6 +19,7 @@ import static android.media.MediaParser.PARAMETER_TS_IGNORE_AAC_STREAM;
 import static android.media.MediaParser.PARAMETER_TS_IGNORE_AVC_STREAM;
 import static android.media.MediaParser.PARAMETER_TS_IGNORE_SPLICE_INFO_STREAM;
 import static android.media.MediaParser.PARAMETER_TS_MODE;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.exoplayer.source.mediaparser.MediaParserUtil.PARAMETER_EAGERLY_EXPOSE_TRACK_TYPE;
 import static androidx.media3.exoplayer.source.mediaparser.MediaParserUtil.PARAMETER_EXPOSE_CAPTION_FORMATS;
 import static androidx.media3.exoplayer.source.mediaparser.MediaParserUtil.PARAMETER_IGNORE_TIMESTAMP_OFFSET;
@@ -38,7 +39,6 @@ import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.analytics.PlayerId;
 import androidx.media3.exoplayer.source.mediaparser.InputReaderAdapterV30;
 import androidx.media3.exoplayer.source.mediaparser.MediaParserUtil;
@@ -270,7 +270,7 @@ public final class MediaParserHlsMediaChunkExtractor implements HlsMediaChunkExt
         mediaParser.setParameter(PARAMETER_TS_IGNORE_AVC_STREAM, true);
       }
     }
-    if (Util.SDK_INT >= 31) {
+    if (SDK_INT >= 31) {
       MediaParserUtil.setLogSessionIdOnMediaParser(mediaParser, playerId);
     }
     return mediaParser;

--- a/libraries/exoplayer_workmanager/src/main/java/androidx/media3/exoplayer/workmanager/WorkManagerScheduler.java
+++ b/libraries/exoplayer_workmanager/src/main/java/androidx/media3/exoplayer/workmanager/WorkManagerScheduler.java
@@ -15,6 +15,8 @@
  */
 package androidx.media3.exoplayer.workmanager;
 
+import static android.os.Build.VERSION.SDK_INT;
+
 import android.content.Context;
 import android.content.Intent;
 import androidx.annotation.RequiresApi;
@@ -49,7 +51,7 @@ public final class WorkManagerScheduler implements Scheduler {
   private static final int SUPPORTED_REQUIREMENTS =
       Requirements.NETWORK
           | Requirements.NETWORK_UNMETERED
-          | (Util.SDK_INT >= 23 ? Requirements.DEVICE_IDLE : 0)
+          | (SDK_INT >= 23 ? Requirements.DEVICE_IDLE : 0)
           | Requirements.DEVICE_CHARGING
           | Requirements.DEVICE_STORAGE_NOT_LOW;
 
@@ -105,7 +107,7 @@ public final class WorkManagerScheduler implements Scheduler {
     } else {
       builder.setRequiredNetworkType(NetworkType.NOT_REQUIRED);
     }
-    if (Util.SDK_INT >= 23 && requirements.isIdleRequired()) {
+    if (SDK_INT >= 23 && requirements.isIdleRequired()) {
       setRequiresDeviceIdle(builder);
     }
     if (requirements.isChargingRequired()) {

--- a/libraries/session/src/main/java/androidx/media3/session/DefaultActionFactory.java
+++ b/libraries/session/src/main/java/androidx/media3/session/DefaultActionFactory.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static android.view.KeyEvent.KEYCODE_MEDIA_FAST_FORWARD;
 import static android.view.KeyEvent.KEYCODE_MEDIA_NEXT;
 import static android.view.KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE;
@@ -43,7 +44,6 @@ import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 import androidx.core.graphics.drawable.IconCompat;
 import androidx.media3.common.Player;
-import androidx.media3.common.util.Util;
 
 /** The default {@link MediaNotification.ActionFactory}. */
 /* package */ final class DefaultActionFactory implements MediaNotification.ActionFactory {
@@ -114,7 +114,7 @@ import androidx.media3.common.util.Util;
       MediaSession mediaSession, @Player.Command long command) {
     int keyCode = toKeyCode(command);
     Intent intent = getMediaButtonIntent(mediaSession, keyCode);
-    if (Util.SDK_INT >= 26
+    if (SDK_INT >= 26
         && command == COMMAND_PLAY_PAUSE
         && !mediaSession.getPlayer().getPlayWhenReady()) {
       return Api26.createForegroundServicePendingIntent(service, keyCode, intent);
@@ -123,7 +123,7 @@ import androidx.media3.common.util.Util;
           service,
           /* requestCode= */ keyCode,
           intent,
-          Util.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0);
+          SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0);
     }
   }
 
@@ -136,7 +136,7 @@ import androidx.media3.common.util.Util;
         service,
         /* requestCode= */ KEYCODE_MEDIA_STOP,
         intent,
-        Util.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0);
+        SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0);
   }
 
   private Intent getMediaButtonIntent(MediaSession mediaSession, int mediaKeyCode) {
@@ -178,8 +178,7 @@ import androidx.media3.common.util.Util;
         service,
         /* requestCode= */ ++customActionPendingIntentRequestCode,
         intent,
-        PendingIntent.FLAG_UPDATE_CURRENT
-            | (Util.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0));
+        PendingIntent.FLAG_UPDATE_CURRENT | (SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0));
   }
 
   /** Returns whether {@code intent} was part of a {@link #createMediaAction media action}. */

--- a/libraries/session/src/main/java/androidx/media3/session/DefaultMediaNotificationProvider.java
+++ b/libraries/session/src/main/java/androidx/media3/session/DefaultMediaNotificationProvider.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.C.INDEX_UNSET;
 import static androidx.media3.common.Player.COMMAND_INVALID;
 import static androidx.media3.common.Player.COMMAND_PLAY_PAUSE;
@@ -371,7 +372,7 @@ public class DefaultMediaNotificationProvider implements MediaNotification.Provi
         .setShowWhen(displayElapsedTimeWithChronometer)
         .setUsesChronometer(displayElapsedTimeWithChronometer);
 
-    if (Util.SDK_INT >= 31) {
+    if (SDK_INT >= 31) {
       Api31.setForegroundServiceBehavior(builder);
     }
 
@@ -621,7 +622,7 @@ public class DefaultMediaNotificationProvider implements MediaNotification.Provi
   }
 
   private void ensureNotificationChannel() {
-    if (Util.SDK_INT < 26 || notificationManager.getNotificationChannel(channelId) != null) {
+    if (SDK_INT < 26 || notificationManager.getNotificationChannel(channelId) != null) {
       return;
     }
     Api26.createNotificationChannel(
@@ -682,7 +683,7 @@ public class DefaultMediaNotificationProvider implements MediaNotification.Provi
         NotificationManager notificationManager, String channelId, String channelName) {
       NotificationChannel channel =
           new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_LOW);
-      if (Util.SDK_INT <= 27) {
+      if (SDK_INT <= 27) {
         // API 28+ will automatically hide the app icon 'badge' for notifications using
         // Notification.MediaStyle, but we have to manually hide it for APIs 26 (when badges were
         // added) and 27.

--- a/libraries/session/src/main/java/androidx/media3/session/MediaButtonReceiver.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaButtonReceiver.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 
 import android.app.ForegroundServiceStartNotAllowedException;
@@ -25,14 +26,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
-import android.os.Build;
 import android.view.KeyEvent;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -125,7 +124,7 @@ public class MediaButtonReceiver extends BroadcastReceiver {
       // Only handle the intent once with the earliest key event that arrives.
       return;
     }
-    if (Util.SDK_INT >= 26) {
+    if (SDK_INT >= 26) {
       if (keyEvent.getKeyCode() != KeyEvent.KEYCODE_MEDIA_PLAY
           && keyEvent.getKeyCode() != KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE
           && keyEvent.getKeyCode() != KeyEvent.KEYCODE_HEADSETHOOK) {
@@ -159,8 +158,7 @@ public class MediaButtonReceiver extends BroadcastReceiver {
         try {
           ContextCompat.startForegroundService(context, intent);
         } catch (/* ForegroundServiceStartNotAllowedException */ IllegalStateException e) {
-          if (Build.VERSION.SDK_INT >= 31
-              && Api31.instanceOfForegroundServiceStartNotAllowedException(e)) {
+          if (SDK_INT >= 31 && Api31.instanceOfForegroundServiceStartNotAllowedException(e)) {
             onForegroundServiceStartNotAllowedException(
                 intent, Api31.castToForegroundServiceStartNotAllowedException(e));
           } else {

--- a/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplBase.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplBase.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkIndex;
 import static androidx.media3.common.util.Assertions.checkNotNull;
@@ -415,7 +416,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
       return;
     }
 
-    if (Util.SDK_INT >= 31 && platformController != null) {
+    if (SDK_INT >= 31 && platformController != null) {
       // Ensure the platform session gets allow-listed to start a foreground service after receiving
       // the play command.
       platformController
@@ -2533,7 +2534,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
   private boolean requestConnectToService() {
     int flags =
-        Util.SDK_INT >= 29
+        SDK_INT >= 29
             ? Context.BIND_AUTO_CREATE | Context.BIND_INCLUDE_CAPABILITIES
             : Context.BIND_AUTO_CREATE;
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplLegacy.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplLegacy.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
@@ -1232,7 +1233,7 @@ import org.checkerframework.checker.initialization.qual.UnderInitialization;
 
   @Override
   public void setDeviceMuted(boolean muted, @C.VolumeFlags int flags) {
-    if (Util.SDK_INT < 23) {
+    if (SDK_INT < 23) {
       Log.w(TAG, "Session doesn't support setting mute state at API level less than 23");
       return;
     }
@@ -1812,7 +1813,7 @@ import org.checkerframework.checker.initialization.qual.UnderInitialization;
 
   @Nullable
   private static String getRoutingControllerId(MediaControllerCompat controllerCompat) {
-    if (Util.SDK_INT < 30) {
+    if (SDK_INT < 30) {
       return null;
     }
     android.media.session.MediaController fwkController =

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -17,6 +17,7 @@ package androidx.media3.session;
 
 import static android.app.Service.STOP_FOREGROUND_DETACH;
 import static android.app.Service.STOP_FOREGROUND_REMOVE;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -443,7 +444,7 @@ import java.util.concurrent.TimeoutException;
   }
 
   private void stopForeground(boolean removeNotifications) {
-    if (Util.SDK_INT >= 24) {
+    if (SDK_INT >= 24) {
       Api24.stopForeground(mediaSessionService, removeNotifications);
     } else {
       mediaSessionService.stopForeground(removeNotifications);

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSession.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSession.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.annotation.VisibleForTesting.PRIVATE;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
@@ -798,7 +799,7 @@ public class MediaSession {
    */
   @UnstableApi
   public final void setSessionActivity(@Nullable PendingIntent activityPendingIntent) {
-    if (Util.SDK_INT >= 31 && activityPendingIntent != null) {
+    if (SDK_INT >= 31 && activityPendingIntent != null) {
       checkArgument(Api31.isActivity(activityPendingIntent));
     }
     impl.setSessionActivity(activityPendingIntent);
@@ -822,7 +823,7 @@ public class MediaSession {
   @UnstableApi
   public final void setSessionActivity(
       ControllerInfo controller, @Nullable PendingIntent activityPendingIntent) {
-    if (Util.SDK_INT >= 31 && activityPendingIntent != null) {
+    if (SDK_INT >= 31 && activityPendingIntent != null) {
       checkArgument(Api31.isActivity(activityPendingIntent));
     }
     impl.setSessionActivity(controller, activityPendingIntent);
@@ -2257,7 +2258,7 @@ public class MediaSession {
     @CanIgnoreReturnValue
     @SuppressWarnings("unchecked")
     public BuilderT setSessionActivity(PendingIntent pendingIntent) {
-      if (Util.SDK_INT >= 31) {
+      if (SDK_INT >= 31) {
         checkArgument(Api31.isActivity(pendingIntent));
       }
       sessionActivity = checkNotNull(pendingIntent);

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.Player.COMMAND_CHANGE_MEDIA_ITEMS;
 import static androidx.media3.common.Player.COMMAND_PLAY_PAUSE;
 import static androidx.media3.common.Player.COMMAND_PREPARE;
@@ -111,7 +112,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   private static final String TAG = "MediaSessionLegacyStub";
 
   private static final int PENDING_INTENT_FLAG_MUTABLE =
-      Util.SDK_INT >= 31 ? PendingIntent.FLAG_MUTABLE : 0;
+      SDK_INT >= 31 ? PendingIntent.FLAG_MUTABLE : 0;
   private static final String DEFAULT_MEDIA_SESSION_TAG_PREFIX = "androidx.media3.session.id";
   private static final String DEFAULT_MEDIA_SESSION_TAG_DELIM = ".";
 
@@ -151,7 +152,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     broadcastReceiverComponentName = queryPackageManagerForMediaButtonReceiver(context);
     @Nullable ComponentName receiverComponentName = broadcastReceiverComponentName;
     boolean isReceiverComponentAService = false;
-    if (receiverComponentName == null || Util.SDK_INT < 31) {
+    if (receiverComponentName == null || SDK_INT < 31) {
       // Below API 26, media button events are sent to the receiver at runtime also. We always want
       // these to arrive at the service at runtime. release() then set the receiver for restart if
       // available.
@@ -185,7 +186,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       intent.setComponent(receiverComponentName);
       mediaButtonIntent =
           isReceiverComponentAService
-              ? (Util.SDK_INT >= 26
+              ? (SDK_INT >= 26
                   ? PendingIntent.getForegroundService(
                       context, /* requestCode= */ 0, intent, PENDING_INTENT_FLAG_MUTABLE)
                   : PendingIntent.getService(
@@ -203,10 +204,10 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         new MediaSessionCompat(
             context,
             sessionCompatId,
-            Util.SDK_INT < 31 ? receiverComponentName : null,
-            Util.SDK_INT < 31 ? mediaButtonIntent : null,
+            SDK_INT < 31 ? receiverComponentName : null,
+            SDK_INT < 31 ? mediaButtonIntent : null,
             /* sessionInfo= */ tokenExtras);
-    if (Util.SDK_INT >= 31 && broadcastReceiverComponentName != null) {
+    if (SDK_INT >= 31 && broadcastReceiverComponentName != null) {
       Api31.setMediaButtonBroadcastReceiver(sessionCompat, broadcastReceiverComponentName);
     }
 
@@ -249,7 +250,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
   @SuppressWarnings("PendingIntentMutability") // We can't use SaferPendingIntent.
   public void release() {
-    if (Util.SDK_INT < 31) {
+    if (SDK_INT < 31) {
       if (broadcastReceiverComponentName == null) {
         // No broadcast receiver available. Playback resumption not supported.
         setMediaButtonReceiver(sessionCompat, /* mediaButtonReceiverIntent= */ null);

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionService.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionService.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkStateNotNull;
@@ -657,7 +658,7 @@ public abstract class MediaSessionService extends Service {
           getMediaNotificationManager().shouldRunInForeground(startInForegroundWhenPaused);
       onUpdateNotification(session, startInForegroundRequired);
     } catch (/* ForegroundServiceStartNotAllowedException */ IllegalStateException e) {
-      if ((Util.SDK_INT >= 31) && Api31.instanceOfForegroundServiceStartNotAllowedException(e)) {
+      if ((SDK_INT >= 31) && Api31.instanceOfForegroundServiceStartNotAllowedException(e)) {
         Log.e(TAG, "Failed to start foreground", e);
         onForegroundServiceStartNotAllowedException();
         return false;
@@ -733,7 +734,7 @@ public abstract class MediaSessionService extends Service {
 
     @Override
     public boolean onPlayRequested(MediaSession session) {
-      if (Util.SDK_INT < 31 || Util.SDK_INT >= 33) {
+      if (SDK_INT < 31 || SDK_INT >= 33) {
         return true;
       }
       // Check if service can start foreground successfully on Android 12 and 12L.

--- a/libraries/session/src/main/java/androidx/media3/session/MediaStyleNotificationHelper.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaStyleNotificationHelper.java
@@ -16,6 +16,7 @@
 package androidx.media3.session;
 
 import static android.Manifest.permission.MEDIA_CONTENT_CONTROL;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.core.app.NotificationCompat.COLOR_DEFAULT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 
@@ -33,7 +34,6 @@ import androidx.core.app.NotificationBuilderWithBuilderAccessor;
 import androidx.core.graphics.drawable.IconCompat;
 import androidx.media3.common.util.NullableType;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
@@ -200,7 +200,7 @@ public class MediaStyleNotificationHelper {
       if (actionsToShowInCompact != null) {
         style.setShowActionsInCompactView(actionsToShowInCompact);
       }
-      if (Util.SDK_INT >= 34 && remoteDeviceName != null) {
+      if (SDK_INT >= 34 && remoteDeviceName != null) {
         Api34Impl.setRemotePlaybackInfo(
             style, remoteDeviceName, remoteDeviceIconRes, remoteDeviceIntent);
         builder.getBuilder().setStyle(style);
@@ -332,7 +332,7 @@ public class MediaStyleNotificationHelper {
 
     @Override
     public void apply(NotificationBuilderWithBuilderAccessor builder) {
-      if (Util.SDK_INT < 24) {
+      if (SDK_INT < 24) {
         super.apply(builder);
         return;
       }
@@ -341,7 +341,7 @@ public class MediaStyleNotificationHelper {
       if (actionsToShowInCompact != null) {
         style.setShowActionsInCompactView(actionsToShowInCompact);
       }
-      if (Util.SDK_INT >= 34 && remoteDeviceName != null) {
+      if (SDK_INT >= 34 && remoteDeviceName != null) {
         Api34Impl.setRemotePlaybackInfo(
             style, remoteDeviceName, remoteDeviceIconRes, remoteDeviceIntent);
         builder.getBuilder().setStyle(style);
@@ -357,7 +357,7 @@ public class MediaStyleNotificationHelper {
     @Nullable
     @SuppressWarnings("nullness:override.return") // NotificationCompat doesn't annotate @Nullable
     public RemoteViews makeContentView(NotificationBuilderWithBuilderAccessor builder) {
-      if (Util.SDK_INT >= 24) {
+      if (SDK_INT >= 24) {
         // No custom content view required
         return null;
       }
@@ -385,7 +385,7 @@ public class MediaStyleNotificationHelper {
     @Nullable
     @SuppressWarnings("nullness:override.return") // NotificationCompat doesn't annotate @Nullable
     public RemoteViews makeBigContentView(NotificationBuilderWithBuilderAccessor builder) {
-      if (Util.SDK_INT >= 24) {
+      if (SDK_INT >= 24) {
         // No custom big content view required
         return null;
       }
@@ -414,7 +414,7 @@ public class MediaStyleNotificationHelper {
     @Nullable
     @SuppressWarnings("nullness:override.return") // NotificationCompat doesn't annotate @Nullable
     public RemoteViews makeHeadsUpContentView(NotificationBuilderWithBuilderAccessor builder) {
-      if (Util.SDK_INT >= 24) {
+      if (SDK_INT >= 24) {
         // No custom heads up content view required
         return null;
       }

--- a/libraries/session/src/main/java/androidx/media3/session/legacy/LegacyParcelableUtil.java
+++ b/libraries/session/src/main/java/androidx/media3/session/legacy/LegacyParcelableUtil.java
@@ -15,13 +15,13 @@
  */
 package androidx.media3.session.legacy;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.annotation.RestrictTo.Scope.LIBRARY;
 
 import android.os.Parcel;
 import android.os.Parcelable;
 import androidx.annotation.RestrictTo;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import java.util.ArrayList;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.PolyNull;
@@ -88,7 +88,7 @@ public final class LegacyParcelableUtil {
   // TODO: b/335804969 - Remove this workaround once the bug fix is in the androidx.media dependency
   @SuppressWarnings("unchecked")
   private static <T> T maybeApplyMediaDescriptionParcelableBugWorkaround(T value) {
-    if (Util.SDK_INT < 21 || Util.SDK_INT >= 23) {
+    if (SDK_INT < 21 || SDK_INT >= 23) {
       return value;
     }
     if (value instanceof android.support.v4.media.MediaBrowserCompat.MediaItem) {

--- a/libraries/session/src/test/java/androidx/media3/session/ConnectionStateTest.java
+++ b/libraries/session/src/test/java/androidx/media3/session/ConnectionStateTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.app.PendingIntent;
@@ -23,7 +24,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import androidx.media3.common.MediaLibraryInfo;
 import androidx.media3.common.Player;
-import androidx.media3.common.util.Util;
 import androidx.media3.test.utils.TestExoPlayerBuilder;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -53,7 +53,7 @@ public class ConnectionStateTest {
                 context,
                 /* requestCode= */ 0,
                 new Intent(),
-                /* flags= */ Util.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0),
+                /* flags= */ SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0),
             /* customLayout= */ ImmutableList.of(
                 new CommandButton.Builder(CommandButton.ICON_ARTIST)
                     .setPlayerCommand(Player.COMMAND_SEEK_TO_NEXT)

--- a/libraries/test_exoplayer_playback/src/androidTest/java/androidx/media3/test/exoplayer/playback/gts/CommonEncryptionDrmTest.java
+++ b/libraries/test_exoplayer_playback/src/androidTest/java/androidx/media3/test/exoplayer/playback/gts/CommonEncryptionDrmTest.java
@@ -15,13 +15,13 @@
  */
 package androidx.media3.test.exoplayer.playback.gts;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.test.exoplayer.playback.gts.GtsTestUtil.shouldSkipWidevineTest;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.Player;
-import androidx.media3.common.util.Util;
 import androidx.media3.test.utils.ActionSchedule;
 import androidx.media3.test.utils.HostActivity;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -88,7 +88,7 @@ public final class CommonEncryptionDrmTest {
   public void cbcsSchemeTypeV25() {
     // cbcs support was added in API 24, but it is stable from API 25 onwards.
     // See [internal: b/65634809].
-    assumeTrue(Util.SDK_INT >= 25);
+    assumeTrue(SDK_INT >= 25);
     testRunner
         .setStreamName("test_widevine_h264_scheme_cbcs")
         .setManifestUrl(DashTestData.WIDEVINE_SCHEME_CBCS)

--- a/libraries/test_exoplayer_playback/src/androidTest/java/androidx/media3/test/exoplayer/playback/gts/DashStreamingTest.java
+++ b/libraries/test_exoplayer_playback/src/androidTest/java/androidx/media3/test/exoplayer/playback/gts/DashStreamingTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.test.exoplayer.playback.gts;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.test.exoplayer.playback.gts.GtsTestUtil.shouldSkipWidevineTest;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assume.assumeFalse;
@@ -23,7 +24,6 @@ import static org.junit.Assume.assumeTrue;
 import android.content.pm.PackageManager;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.Player;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.exoplayer.mediacodec.MediaCodecInfo;
 import androidx.media3.exoplayer.mediacodec.MediaCodecUtil;
@@ -197,7 +197,7 @@ public final class DashStreamingTest {
 
   @Test
   public void h265FixedV23() throws Exception {
-    if (Util.SDK_INT < 23 || isPc()) {
+    if (SDK_INT < 23 || isPc()) {
       // Pass.
       return;
     }
@@ -212,7 +212,7 @@ public final class DashStreamingTest {
 
   @Test
   public void h265AdaptiveV24() throws Exception {
-    if (Util.SDK_INT < 24 || isPc()) {
+    if (SDK_INT < 24 || isPc()) {
       // Pass.
       return;
     }
@@ -228,7 +228,7 @@ public final class DashStreamingTest {
 
   @Test
   public void h265AdaptiveWithSeekingV24() throws Exception {
-    if (Util.SDK_INT < 24 || isPc()) {
+    if (SDK_INT < 24 || isPc()) {
       // Pass.
       return;
     }
@@ -245,7 +245,7 @@ public final class DashStreamingTest {
 
   @Test
   public void h265AdaptiveWithRendererDisablingV24() throws Exception {
-    if (Util.SDK_INT < 24 || isPc()) {
+    if (SDK_INT < 24 || isPc()) {
       // Pass.
       return;
     }
@@ -264,7 +264,7 @@ public final class DashStreamingTest {
 
   @Test
   public void vp9Fixed360pV23() throws Exception {
-    if (Util.SDK_INT < 23) {
+    if (SDK_INT < 23) {
       // Pass.
       return;
     }
@@ -280,7 +280,7 @@ public final class DashStreamingTest {
 
   @Test
   public void vp9AdaptiveV24() throws Exception {
-    if (Util.SDK_INT < 24) {
+    if (SDK_INT < 24) {
       // Pass.
       return;
     }
@@ -296,7 +296,7 @@ public final class DashStreamingTest {
 
   @Test
   public void vp9AdaptiveWithSeekingV24() throws Exception {
-    if (Util.SDK_INT < 24) {
+    if (SDK_INT < 24) {
       // Pass.
       return;
     }
@@ -313,7 +313,7 @@ public final class DashStreamingTest {
 
   @Test
   public void vp9AdaptiveWithRendererDisablingV24() throws Exception {
-    if (Util.SDK_INT < 24) {
+    if (SDK_INT < 24) {
       // Pass.
       return;
     }
@@ -333,7 +333,7 @@ public final class DashStreamingTest {
   // 23.976 fps.
   @Test
   public void test23FpsH264FixedV23() throws Exception {
-    if (Util.SDK_INT < 23) {
+    if (SDK_INT < 23) {
       // Pass.
       return;
     }
@@ -351,7 +351,7 @@ public final class DashStreamingTest {
   // 24 fps.
   @Test
   public void test24FpsH264FixedV23() throws Exception {
-    if (Util.SDK_INT < 23) {
+    if (SDK_INT < 23) {
       // Pass.
       return;
     }
@@ -369,7 +369,7 @@ public final class DashStreamingTest {
   // 29.97 fps.
   @Test
   public void test29FpsH264FixedV23() throws Exception {
-    if (Util.SDK_INT < 23) {
+    if (SDK_INT < 23) {
       // Pass.
       return;
     }
@@ -459,7 +459,7 @@ public final class DashStreamingTest {
 
   @Test
   public void widevineH265FixedV23() throws Exception {
-    assumeTrue(Util.SDK_INT >= 23);
+    assumeTrue(SDK_INT >= 23);
     assumeFalse(shouldSkipWidevineTest(testRule.getActivity()));
     assumeFalse(isPc());
 
@@ -476,7 +476,7 @@ public final class DashStreamingTest {
 
   @Test
   public void widevineH265AdaptiveV24() throws Exception {
-    assumeTrue(Util.SDK_INT >= 24);
+    assumeTrue(SDK_INT >= 24);
     assumeFalse(shouldSkipWidevineTest(testRule.getActivity()));
     assumeFalse(isPc());
 
@@ -494,7 +494,7 @@ public final class DashStreamingTest {
 
   @Test
   public void widevineH265AdaptiveWithSeekingV24() throws Exception {
-    assumeTrue(Util.SDK_INT >= 24);
+    assumeTrue(SDK_INT >= 24);
     assumeFalse(shouldSkipWidevineTest(testRule.getActivity()));
     assumeFalse(isPc());
 
@@ -513,7 +513,7 @@ public final class DashStreamingTest {
 
   @Test
   public void widevineH265AdaptiveWithRendererDisablingV24() throws Exception {
-    assumeTrue(Util.SDK_INT >= 24);
+    assumeTrue(SDK_INT >= 24);
     assumeFalse(shouldSkipWidevineTest(testRule.getActivity()));
     assumeFalse(isPc());
 
@@ -534,7 +534,7 @@ public final class DashStreamingTest {
 
   @Test
   public void widevineVp9Fixed360pV23() throws Exception {
-    assumeTrue(Util.SDK_INT >= 23);
+    assumeTrue(SDK_INT >= 23);
     assumeFalse(shouldSkipWidevineTest(testRule.getActivity()));
 
     testRunner
@@ -551,7 +551,7 @@ public final class DashStreamingTest {
 
   @Test
   public void widevineVp9AdaptiveV24() throws Exception {
-    assumeTrue(Util.SDK_INT >= 24);
+    assumeTrue(SDK_INT >= 24);
     assumeFalse(shouldSkipWidevineTest(testRule.getActivity()));
 
     testRunner
@@ -568,7 +568,7 @@ public final class DashStreamingTest {
 
   @Test
   public void widevineVp9AdaptiveWithSeekingV24() throws Exception {
-    assumeTrue(Util.SDK_INT >= 24);
+    assumeTrue(SDK_INT >= 24);
     assumeFalse(shouldSkipWidevineTest(testRule.getActivity()));
 
     testRunner
@@ -586,7 +586,7 @@ public final class DashStreamingTest {
 
   @Test
   public void widevineVp9AdaptiveWithRendererDisablingV24() throws Exception {
-    assumeTrue(Util.SDK_INT >= 24);
+    assumeTrue(SDK_INT >= 24);
     assumeFalse(shouldSkipWidevineTest(testRule.getActivity()));
 
     testRunner
@@ -607,7 +607,7 @@ public final class DashStreamingTest {
   // 23.976 fps.
   @Test
   public void widevine23FpsH264FixedV23() throws Exception {
-    assumeTrue(Util.SDK_INT >= 23);
+    assumeTrue(SDK_INT >= 23);
     assumeFalse(shouldSkipWidevineTest(testRule.getActivity()));
 
     testRunner
@@ -625,7 +625,7 @@ public final class DashStreamingTest {
   // 24 fps.
   @Test
   public void widevine24FpsH264FixedV23() throws Exception {
-    assumeTrue(Util.SDK_INT >= 23);
+    assumeTrue(SDK_INT >= 23);
     assumeFalse(shouldSkipWidevineTest(testRule.getActivity()));
 
     testRunner
@@ -643,7 +643,7 @@ public final class DashStreamingTest {
   // 29.97 fps.
   @Test
   public void widevine29FpsH264FixedV23() throws Exception {
-    assumeTrue(Util.SDK_INT >= 23);
+    assumeTrue(SDK_INT >= 23);
     assumeFalse(shouldSkipWidevineTest(testRule.getActivity()));
 
     testRunner
@@ -671,7 +671,7 @@ public final class DashStreamingTest {
 
   @Test
   public void decoderInfoH265V24() throws Exception {
-    assumeTrue(Util.SDK_INT >= 24);
+    assumeTrue(SDK_INT >= 24);
     assumeFalse(isPc());
 
     assertThat(
@@ -683,7 +683,7 @@ public final class DashStreamingTest {
 
   @Test
   public void decoderInfoVP9V24() throws Exception {
-    assumeTrue(Util.SDK_INT >= 24);
+    assumeTrue(SDK_INT >= 24);
 
     assertThat(
             MediaCodecUtil.getDecoderInfo(
@@ -696,7 +696,7 @@ public final class DashStreamingTest {
 
   private boolean isPc() {
     // See [internal b/162990153].
-    return Util.SDK_INT >= 27
+    return SDK_INT >= 27
         && testRule.getActivity().getPackageManager().hasSystemFeature(PackageManager.FEATURE_PC);
   }
 

--- a/libraries/test_exoplayer_playback/src/androidTest/java/androidx/media3/test/exoplayer/playback/gts/DashTestData.java
+++ b/libraries/test_exoplayer_playback/src/androidTest/java/androidx/media3/test/exoplayer/playback/gts/DashTestData.java
@@ -15,7 +15,7 @@
  */
 package androidx.media3.test.exoplayer.playback.gts;
 
-import androidx.media3.common.util.Util;
+import static android.os.Build.VERSION.SDK_INT;
 
 /** Test data for DASH tests. */
 /* package */ final class DashTestData {
@@ -54,14 +54,14 @@ import androidx.media3.common.util.Util;
   public static final String H264_MAIN_480P_VIDEO_REPRESENTATION_ID = "avc-main-480";
   // The highest quality H264 format mandated by the Android CDD.
   public static final String H264_CDD_FIXED =
-      Util.SDK_INT < 23
+      SDK_INT < 23
           ? H264_BASELINE_480P_VIDEO_REPRESENTATION_ID
           : H264_MAIN_480P_VIDEO_REPRESENTATION_ID;
   // Multiple H264 formats mandated by the Android CDD. Note: The CDD actually mandated main profile
   // support from API level 23, but we opt to test only from 24 due to known issues on API level 23
   // when switching between baseline and main profiles on certain devices.
   public static final String[] H264_CDD_ADAPTIVE =
-      Util.SDK_INT < 24
+      SDK_INT < 24
           ? new String[] {
             H264_BASELINE_240P_VIDEO_REPRESENTATION_ID, H264_BASELINE_480P_VIDEO_REPRESENTATION_ID
           }
@@ -106,14 +106,14 @@ import androidx.media3.common.util.Util;
   public static final String WIDEVINE_H264_MAIN_480P_VIDEO_REPRESENTATION_ID = "5";
   // The highest quality H264 format mandated by the Android CDD.
   public static final String WIDEVINE_H264_CDD_FIXED =
-      Util.SDK_INT < 23
+      SDK_INT < 23
           ? WIDEVINE_H264_BASELINE_480P_VIDEO_REPRESENTATION_ID
           : WIDEVINE_H264_MAIN_480P_VIDEO_REPRESENTATION_ID;
   // Multiple H264 formats mandated by the Android CDD. Note: The CDD actually mandated main profile
   // support from API level 23, but we opt to test only from 24 due to known issues on API level 23
   // when switching between baseline and main profiles on certain devices.
   public static final String[] WIDEVINE_H264_CDD_ADAPTIVE =
-      Util.SDK_INT < 24
+      SDK_INT < 24
           ? new String[] {
             WIDEVINE_H264_BASELINE_240P_VIDEO_REPRESENTATION_ID,
             WIDEVINE_H264_BASELINE_480P_VIDEO_REPRESENTATION_ID

--- a/libraries/test_exoplayer_playback/src/androidTest/java/androidx/media3/test/exoplayer/playback/gts/DashTestRunner.java
+++ b/libraries/test_exoplayer_playback/src/androidTest/java/androidx/media3/test/exoplayer/playback/gts/DashTestRunner.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.test.exoplayer.playback.gts;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.C.WIDEVINE_UUID;
 
 import android.media.MediaDrm;
@@ -28,7 +29,6 @@ import androidx.media3.common.MediaItem;
 import androidx.media3.common.TrackGroup;
 import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.Log;
-import androidx.media3.common.util.Util;
 import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.datasource.DefaultHttpDataSource;
@@ -73,7 +73,7 @@ import java.util.List;
 
   // Whether adaptive tests should enable video formats beyond those mandated by the Android CDD
   // if the device advertises support for them.
-  private static final boolean ALLOW_ADDITIONAL_VIDEO_FORMATS = Util.SDK_INT >= 24;
+  private static final boolean ALLOW_ADDITIONAL_VIDEO_FORMATS = SDK_INT >= 24;
 
   private static final String AUDIO_TAG_SUFFIX = ":Audio";
   private static final String VIDEO_TAG_SUFFIX = ":Video";

--- a/libraries/test_exoplayer_playback/src/androidTest/java/androidx/media3/test/exoplayer/playback/gts/DashWidevineOfflineTest.java
+++ b/libraries/test_exoplayer_playback/src/androidTest/java/androidx/media3/test/exoplayer/playback/gts/DashWidevineOfflineTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.test.exoplayer.playback.gts;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.test.exoplayer.playback.gts.GtsTestUtil.shouldSkipWidevineTest;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
@@ -29,7 +30,6 @@ import androidx.annotation.Nullable;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.Player;
-import androidx.media3.common.util.Util;
 import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DefaultHttpDataSource;
 import androidx.media3.exoplayer.dash.DashUtil;
@@ -105,7 +105,7 @@ public final class DashWidevineOfflineTest {
       "Needs to be reconfigured/rewritten with an offline-compatible licence [internal"
           + " b/176960595].")
   public void widevineOfflineLicenseV22() throws Exception {
-    assumeTrue(Util.SDK_INT >= 22);
+    assumeTrue(SDK_INT >= 22);
 
     downloadLicense();
     testRunner.run();
@@ -120,7 +120,7 @@ public final class DashWidevineOfflineTest {
       "Needs to be reconfigured/rewritten with an offline-compatible licence [internal"
           + " b/176960595].")
   public void widevineOfflineReleasedLicenseV22() throws Throwable {
-    assumeTrue(Util.SDK_INT >= 22 && Util.SDK_INT <= 28);
+    assumeTrue(SDK_INT >= 22 && SDK_INT <= 28);
 
     downloadLicense();
     releaseLicense(); // keySetId no longer valid.
@@ -145,7 +145,7 @@ public final class DashWidevineOfflineTest {
       "Needs to be reconfigured/rewritten with an offline-compatible licence [internal"
           + " b/176960595].")
   public void widevineOfflineReleasedLicenseV29() throws Throwable {
-    assumeTrue(Util.SDK_INT >= 29);
+    assumeTrue(SDK_INT >= 29);
 
     downloadLicense();
     releaseLicense(); // keySetId no longer valid.
@@ -170,7 +170,7 @@ public final class DashWidevineOfflineTest {
       "Needs to be reconfigured/rewritten with an offline-compatible licence [internal"
           + " b/176960595].")
   public void widevineOfflineExpiredLicenseV22() throws Exception {
-    assumeTrue(Util.SDK_INT >= 22);
+    assumeTrue(SDK_INT >= 22);
 
     downloadLicense();
 
@@ -202,7 +202,7 @@ public final class DashWidevineOfflineTest {
       "Needs to be reconfigured/rewritten with an offline-compatible licence [internal"
           + " b/176960595].")
   public void widevineOfflineLicenseExpiresOnPauseV22() throws Exception {
-    assumeTrue(Util.SDK_INT >= 22);
+    assumeTrue(SDK_INT >= 22);
 
     downloadLicense();
 

--- a/libraries/test_exoplayer_playback/src/androidTest/java/androidx/media3/test/exoplayer/playback/gts/EnumerateDecodersTest.java
+++ b/libraries/test_exoplayer_playback/src/androidTest/java/androidx/media3/test/exoplayer/playback/gts/EnumerateDecodersTest.java
@@ -15,13 +15,14 @@
  */
 package androidx.media3.test.exoplayer.playback.gts;
 
+import static android.os.Build.VERSION.SDK_INT;
+
 import android.media.MediaCodecInfo.AudioCapabilities;
 import android.media.MediaCodecInfo.CodecCapabilities;
 import android.media.MediaCodecInfo.CodecProfileLevel;
 import android.media.MediaCodecInfo.VideoCapabilities;
 import androidx.annotation.Nullable;
 import androidx.media3.common.MimeTypes;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.mediacodec.MediaCodecInfo;
 import androidx.media3.exoplayer.mediacodec.MediaCodecUtil;
 import androidx.media3.exoplayer.mediacodec.MediaCodecUtil.DecoderQueryException;
@@ -118,7 +119,7 @@ public class EnumerateDecodersTest {
     result.append(", mimeType=").append(codecCapabilities.getMimeType());
     result.append(", profileLevels=");
     appendProfileLevels(codecCapabilities.profileLevels, result);
-    if (Util.SDK_INT >= 23) {
+    if (SDK_INT >= 23) {
       result
           .append(", maxSupportedInstances=")
           .append(codecCapabilities.getMaxSupportedInstances());
@@ -138,7 +139,7 @@ public class EnumerateDecodersTest {
     if (isVideo && codecCapabilities.isFeatureSupported(CodecCapabilities.FEATURE_SecurePlayback)) {
       result.append(", FEATURE_SecurePlayback");
     }
-    if (Util.SDK_INT >= 26
+    if (SDK_INT >= 26
         && isVideo
         && codecCapabilities.isFeatureSupported(CodecCapabilities.FEATURE_PartialFrame)) {
       result.append(", FEATURE_PartialFrame");

--- a/libraries/test_session_common/src/main/java/androidx/media3/test/session/common/TestUtils.java
+++ b/libraries/test_session_common/src/main/java/androidx/media3/test/session/common/TestUtils.java
@@ -16,6 +16,7 @@
 package androidx.media3.test.session.common;
 
 import static android.content.Context.KEYGUARD_SERVICE;
+import static android.os.Build.VERSION.SDK_INT;
 import static java.lang.Math.min;
 
 import android.app.Activity;
@@ -29,7 +30,6 @@ import android.view.WindowManager;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.media3.common.Player;
-import androidx.media3.common.util.Util;
 import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -120,7 +120,7 @@ public class TestUtils {
 
   @UiThread
   static void setKeepScreenOn(Activity activity) {
-    if (Util.SDK_INT >= 27) {
+    if (SDK_INT >= 27) {
       activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
       activity.setTurnScreenOn(true);
       activity.setShowWhenLocked(true);

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerCompatCallbackWithMediaSessionTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerCompatCallbackWithMediaSessionTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static android.support.v4.media.MediaMetadataCompat.METADATA_KEY_DURATION;
 import static android.support.v4.media.MediaMetadataCompat.METADATA_KEY_MEDIA_ID;
 import static android.support.v4.media.MediaMetadataCompat.METADATA_KEY_USER_RATING;
@@ -53,7 +54,6 @@ import androidx.media3.common.Player;
 import androidx.media3.common.Player.RepeatMode;
 import androidx.media3.common.Player.State;
 import androidx.media3.common.Timeline;
-import androidx.media3.common.util.Util;
 import androidx.media3.test.session.common.HandlerThreadTestRule;
 import androidx.media3.test.session.common.PollingCheck;
 import androidx.media3.test.session.common.SurfaceActivity;
@@ -610,7 +610,7 @@ public class MediaControllerCompatCallbackWithMediaSessionTest {
     session.setPlayer(playerConfigToUpdate);
 
     // In API 21 and 22, onAudioInfoChanged is not called when playback is changed to local.
-    if (Util.SDK_INT <= 22) {
+    if (SDK_INT <= 22) {
       PollingCheck.waitFor(
           TIMEOUT_MS,
           () -> {

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerListenerWithMediaSessionCompatTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerListenerWithMediaSessionCompatTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.test.session.common.TestUtils.TIMEOUT_MS;
 import static androidx.media3.test.session.common.TestUtils.getEventsAsList;
 import static com.google.common.truth.Truth.assertThat;
@@ -37,7 +38,6 @@ import androidx.media3.common.MediaMetadata;
 import androidx.media3.common.PlaybackException;
 import androidx.media3.common.Player;
 import androidx.media3.common.util.ConditionVariable;
-import androidx.media3.common.util.Util;
 import androidx.media3.session.legacy.MediaMetadataCompat;
 import androidx.media3.test.session.R;
 import androidx.media3.test.session.common.CommonConstants;
@@ -349,7 +349,7 @@ public class MediaControllerListenerWithMediaSessionCompatTest {
     // We need to trigger MediaControllerCompat.Callback.onAudioInfoChanged in order to raise the
     // onAudioAttributesChanged() callback. In API 21 and 22, onAudioInfoChanged is not called when
     // playback is changed to local.
-    assumeTrue(Util.SDK_INT > 22);
+    assumeTrue(SDK_INT > 22);
 
     session.setPlaybackToRemote(
         /* volumeControl= */ VolumeProviderCompat.VOLUME_CONTROL_ABSOLUTE,
@@ -414,7 +414,7 @@ public class MediaControllerListenerWithMediaSessionCompatTest {
           }
         };
     threadTestRule.getHandler().postAndSync(() -> controller.addListener(listener));
-    String testRoutingSessionId = Util.SDK_INT >= 30 ? "route" : null;
+    String testRoutingSessionId = SDK_INT >= 30 ? "route" : null;
 
     session.setPlaybackToRemote(
         /* volumeControl= */ VolumeProviderCompat.VOLUME_CONTROL_ABSOLUTE,

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerWithMediaSessionCompatTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerWithMediaSessionCompatTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static android.support.v4.media.MediaMetadataCompat.METADATA_KEY_ADVERTISEMENT;
 import static android.support.v4.media.MediaMetadataCompat.METADATA_KEY_ALBUM_ART;
 import static android.support.v4.media.MediaMetadataCompat.METADATA_KEY_ARTIST;
@@ -72,7 +73,6 @@ import androidx.media3.common.Player.RepeatMode;
 import androidx.media3.common.Player.State;
 import androidx.media3.common.Timeline;
 import androidx.media3.common.util.BitmapLoader;
-import androidx.media3.common.util.Util;
 import androidx.media3.datasource.DataSourceBitmapLoader;
 import androidx.media3.test.session.common.HandlerThreadTestRule;
 import androidx.media3.test.session.common.MainLooperTestRule;
@@ -370,7 +370,7 @@ public class MediaControllerWithMediaSessionCompatTest {
     Intent sessionActivity = new Intent(context, MockActivity.class);
     PendingIntent pi =
         PendingIntent.getActivity(
-            context, 0, sessionActivity, Util.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0);
+            context, 0, sessionActivity, SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0);
     session.setSessionActivity(pi);
 
     MediaController controller = controllerTestRule.createController(session.getSessionToken());
@@ -576,7 +576,7 @@ public class MediaControllerWithMediaSessionCompatTest {
     assertThat(TextUtils.equals(metadata.description, testDescription)).isTrue();
     assertThat(metadata.artworkUri).isEqualTo(testIconUri);
     assertThat(metadata.artworkData).isEqualTo(testArtworkData);
-    if (Util.SDK_INT >= 23) {
+    if (SDK_INT >= 23) {
       // TODO(b/199055952): Test mediaUri for all API levels once the bug is fixed.
       assertThat(mediaItem.requestMetadata.mediaUri).isEqualTo(testMediaUri);
     }
@@ -1604,7 +1604,7 @@ public class MediaControllerWithMediaSessionCompatTest {
     int volumeControlType = VolumeProviderCompat.VOLUME_CONTROL_ABSOLUTE;
     int maxVolume = 100;
     int currentVolume = 45;
-    String routingSessionId = Util.SDK_INT >= 30 ? "route" : null;
+    String routingSessionId = SDK_INT >= 30 ? "route" : null;
 
     AtomicReference<DeviceInfo> deviceInfoRef = new AtomicReference<>();
     CountDownLatch latchForDeviceInfo = new CountDownLatch(1);
@@ -1639,7 +1639,7 @@ public class MediaControllerWithMediaSessionCompatTest {
 
   @Test
   public void setPlaybackToLocal_notifiesDeviceInfoAndVolume() throws Exception {
-    if (Util.SDK_INT <= 22) {
+    if (SDK_INT <= 22) {
       // In API 21 and 22, onAudioInfoChanged is not called.
       return;
     }

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionCallbackWithMediaControllerCompatTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionCallbackWithMediaControllerCompatTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media.MediaSessionManager.RemoteUserInfo.LEGACY_CONTROLLER;
 import static androidx.media3.common.Player.COMMAND_PLAY_PAUSE;
 import static androidx.media3.common.Player.COMMAND_PREPARE;
@@ -55,7 +56,6 @@ import androidx.media3.common.Rating;
 import androidx.media3.common.StarRating;
 import androidx.media3.common.util.ConditionVariable;
 import androidx.media3.common.util.Log;
-import androidx.media3.common.util.Util;
 import androidx.media3.session.MediaSession.ControllerInfo;
 import androidx.media3.test.session.common.HandlerThreadTestRule;
 import androidx.media3.test.session.common.MainLooperTestRule;
@@ -92,7 +92,7 @@ public class MediaSessionCallbackWithMediaControllerCompatTest {
 
   private static final String TEST_URI = "http://test.test";
   private static final String EXPECTED_CONTROLLER_PACKAGE_NAME =
-      Util.SDK_INT >= 24 ? SUPPORT_APP_PACKAGE_NAME : LEGACY_CONTROLLER;
+      SDK_INT >= 24 ? SUPPORT_APP_PACKAGE_NAME : LEGACY_CONTROLLER;
 
   @ClassRule public static MainLooperTestRule mainLooperTestRule = new MainLooperTestRule();
 

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionCompatCallbackWithMediaControllerTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionCompatCallbackWithMediaControllerTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static android.support.v4.media.session.MediaSessionCompat.FLAG_HANDLES_QUEUE_COMMANDS;
 import static androidx.media3.test.session.common.TestUtils.VOLUME_CHANGE_TIMEOUT_MS;
 import static com.google.common.truth.Truth.assertThat;
@@ -43,7 +44,6 @@ import androidx.media3.common.PlaybackParameters;
 import androidx.media3.common.Player;
 import androidx.media3.common.Rating;
 import androidx.media3.common.StarRating;
-import androidx.media3.common.util.Util;
 import androidx.media3.test.session.common.HandlerThreadTestRule;
 import androidx.media3.test.session.common.MainLooperTestRule;
 import androidx.media3.test.session.common.MockActivity;
@@ -91,7 +91,7 @@ public class MediaSessionCompatCallbackWithMediaControllerTest {
     // Create this test specific MediaSession to use our own Handler.
     PendingIntent intent =
         PendingIntent.getActivity(
-            context, 0, sessionActivity, Util.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0);
+            context, 0, sessionActivity, SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0);
 
     sessionCallback = new MediaSessionCallback();
     session = new MediaSessionCompat(context, TAG + "Compat");

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionKeyEventTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionKeyEventTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media.MediaSessionManager.RemoteUserInfo.LEGACY_CONTROLLER;
 import static androidx.media3.common.Player.STATE_ENDED;
 import static androidx.media3.session.MediaSession.ControllerInfo.LEGACY_CONTROLLER_VERSION;
@@ -32,7 +33,6 @@ import android.os.Bundle;
 import android.view.KeyEvent;
 import androidx.media3.common.ForwardingPlayer;
 import androidx.media3.common.Player;
-import androidx.media3.common.util.Util;
 import androidx.media3.session.MediaSession.ControllerInfo;
 import androidx.media3.test.session.common.HandlerThreadTestRule;
 import androidx.media3.test.session.common.MainLooperTestRule;
@@ -93,7 +93,7 @@ public class MediaSessionKeyEventTest {
     // Here's the requirement for an app to receive media key events via MediaSession.
     // - SDK < 26: Player should be playing for receiving key events
     // - SDK >= 26: Play a media item in the same process of the session for receiving key events.
-    if (Util.SDK_INT < 26) {
+    if (SDK_INT < 26) {
       handler.postAndSync(
           () -> {
             player.notifyPlayWhenReadyChanged(
@@ -270,7 +270,7 @@ public class MediaSessionKeyEventTest {
   public void playPauseKeyEvent_paused_play() throws Exception {
     // We don't receive media key events when we are not playing on API < 26, so we can't test this
     // case as it's not supported.
-    assumeTrue(Util.SDK_INT >= 26);
+    assumeTrue(SDK_INT >= 26);
 
     handler.postAndSync(
         () -> {
@@ -286,7 +286,7 @@ public class MediaSessionKeyEventTest {
   public void playPauseKeyEvent_fromIdle_prepareAndPlay() throws Exception {
     // We don't receive media key events when we are not playing on API < 26, so we can't test this
     // case as it's not supported.
-    assumeTrue(Util.SDK_INT >= 26);
+    assumeTrue(SDK_INT >= 26);
 
     handler.postAndSync(
         () -> {
@@ -303,7 +303,7 @@ public class MediaSessionKeyEventTest {
   public void playPauseKeyEvent_playWhenReadyAndEnded_seekAndPlay() throws Exception {
     // We don't receive media key events when we are not playing on API < 26, so we can't test this
     // case as it's not supported.
-    assumeTrue(Util.SDK_INT >= 26);
+    assumeTrue(SDK_INT >= 26);
 
     handler.postAndSync(
         () -> {
@@ -386,10 +386,10 @@ public class MediaSessionKeyEventTest {
       return SUPPORT_APP_PACKAGE_NAME;
     }
     // Legacy controllers
-    if (Util.SDK_INT >= 28) {
+    if (SDK_INT >= 28) {
       // Above API 28: package of the app using AudioManager.
       return SUPPORT_APP_PACKAGE_NAME;
-    } else if (Util.SDK_INT >= 24) {
+    } else if (SDK_INT >= 24) {
       // API 24 - 27: KeyEvent from system service has the package name "android".
       return "android";
     } else {

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static android.view.KeyEvent.KEYCODE_MEDIA_FAST_FORWARD;
 import static android.view.KeyEvent.KEYCODE_MEDIA_NEXT;
 import static android.view.KeyEvent.KEYCODE_MEDIA_PAUSE;
@@ -47,7 +48,6 @@ import androidx.media3.common.ForwardingPlayer;
 import androidx.media3.common.MediaLibraryInfo;
 import androidx.media3.common.Player;
 import androidx.media3.common.util.Log;
-import androidx.media3.common.util.Util;
 import androidx.media3.session.MediaSession.ControllerInfo;
 import androidx.media3.test.session.common.HandlerThreadTestRule;
 import androidx.media3.test.session.common.MainLooperTestRule;
@@ -208,7 +208,7 @@ public class MediaSessionTest {
 
   @Test
   public void builderSetSessionActivity_nonActivityIntent_throwsIllegalArgumentException() {
-    Assume.assumeTrue(Util.SDK_INT >= 31);
+    Assume.assumeTrue(SDK_INT >= 31);
     PendingIntent pendingIntent =
         PendingIntent.getBroadcast(
             ApplicationProvider.getApplicationContext(),
@@ -226,7 +226,7 @@ public class MediaSessionTest {
 
   @Test
   public void setSessionActivity_nonActivityIntent_throwsIllegalArgumentException() {
-    Assume.assumeTrue(Util.SDK_INT >= 31);
+    Assume.assumeTrue(SDK_INT >= 31);
     PendingIntent pendingIntent =
         PendingIntent.getBroadcast(
             ApplicationProvider.getApplicationContext(),
@@ -1035,7 +1035,7 @@ public class MediaSessionTest {
    * <p>Calling this method should only be required to test legacy behaviour.
    */
   private static String getControllerCallerPackageName(ControllerInfo controllerInfo) {
-    return (Util.SDK_INT > 23
+    return (SDK_INT > 23
             || controllerInfo.getControllerVersion() != ControllerInfo.LEGACY_CONTROLLER_VERSION)
         ? ApplicationProvider.getApplicationContext().getPackageName()
         : MediaSessionManager.RemoteUserInfo.LEGACY_CONTROLLER;

--- a/libraries/test_session_current/src/main/java/androidx/media3/session/MediaSessionProviderService.java
+++ b/libraries/test_session_current/src/main/java/androidx/media3/session/MediaSessionProviderService.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.Player.COMMAND_GET_TRACKS;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.session.MediaSession.ConnectionResult.accept;
@@ -101,7 +102,6 @@ import androidx.media3.common.Tracks;
 import androidx.media3.common.VideoSize;
 import androidx.media3.common.text.CueGroup;
 import androidx.media3.common.util.Log;
-import androidx.media3.common.util.Util;
 import androidx.media3.session.MediaSession.ControllerInfo;
 import androidx.media3.test.session.common.IRemoteMediaSession;
 import androidx.media3.test.session.common.MediaBrowserConstants;
@@ -199,7 +199,7 @@ public class MediaSessionProviderService extends Service {
                     MediaSessionProviderService.this,
                     /* requestCode= */ 0,
                     sessionActivity,
-                    Util.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0);
+                    SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0);
             builder.setSessionActivity(pendingIntent);
             break;
           }

--- a/libraries/test_session_current/src/main/java/androidx/media3/session/MockMediaLibraryService.java
+++ b/libraries/test_session_current/src/main/java/androidx/media3/session/MockMediaLibraryService.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.session.MediaConstants.EXTRAS_KEY_COMPLETION_STATUS;
 import static androidx.media3.session.MediaConstants.EXTRAS_KEY_ERROR_RESOLUTION_ACTION_INTENT_COMPAT;
@@ -80,7 +81,6 @@ import androidx.media3.common.MediaItem;
 import androidx.media3.common.MediaMetadata;
 import androidx.media3.common.util.ConditionVariable;
 import androidx.media3.common.util.Log;
-import androidx.media3.common.util.Util;
 import androidx.media3.session.MediaSession.ControllerInfo;
 import androidx.media3.test.session.common.CommonConstants;
 import androidx.media3.test.session.common.MediaBrowserConstants;
@@ -419,7 +419,7 @@ public class MockMediaLibraryService extends MediaLibraryService {
           || Objects.equals(parentId, PARENT_ID_SKIP_LIMIT_REACHED_ERROR)) {
         Bundle bundle = new Bundle();
         Intent signInIntent = new Intent("action");
-        int flags = Util.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0;
+        int flags = SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0;
         bundle.putParcelable(
             EXTRAS_KEY_ERROR_RESOLUTION_ACTION_INTENT_COMPAT,
             PendingIntent.getActivity(
@@ -445,7 +445,7 @@ public class MockMediaLibraryService extends MediaLibraryService {
       } else if (Objects.equals(parentId, PARENT_ID_AUTH_EXPIRED_ERROR_NON_FATAL)) {
         Bundle bundle = new Bundle();
         Intent signInIntent = new Intent("action");
-        int flags = Util.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0;
+        int flags = SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0;
         bundle.putParcelable(
             EXTRAS_KEY_ERROR_RESOLUTION_ACTION_INTENT_COMPAT,
             PendingIntent.getActivity(

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/FakeExoMediaDrm.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/FakeExoMediaDrm.java
@@ -16,6 +16,7 @@
 
 package androidx.media3.test.utils;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
@@ -136,7 +137,7 @@ public final class FakeExoMediaDrm implements ExoMediaDrm {
     public Builder throwNoSuchMethodErrorForProvisioningAndResourceBusy(
         boolean throwNoSuchMethodErrorForProvisioningAndResourceBusy) {
       checkState(
-          !throwNoSuchMethodErrorForProvisioningAndResourceBusy || Util.SDK_INT == 34,
+          !throwNoSuchMethodErrorForProvisioningAndResourceBusy || SDK_INT == 34,
           "The framework bug recreated by this method only exists on API 34.");
       this.throwNoSuchMethodErrorForProvisioningAndResourceBusy =
           throwNoSuchMethodErrorForProvisioningAndResourceBusy;

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/HostActivity.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/HostActivity.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.test.utils;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static org.junit.Assert.fail;
 
 import android.app.Activity;
@@ -196,7 +197,7 @@ public final class HostActivity extends Activity implements SurfaceHolder.Callba
   @Override
   public void onPause() {
     super.onPause();
-    if (Util.SDK_INT <= 23) {
+    if (SDK_INT <= 23) {
       maybeStopHostedTest();
     }
   }
@@ -204,7 +205,7 @@ public final class HostActivity extends Activity implements SurfaceHolder.Callba
   @Override
   public void onStop() {
     super.onStop();
-    if (Util.SDK_INT > 23) {
+    if (SDK_INT > 23) {
       maybeStopHostedTest();
     }
     if (wakeLock != null) {

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestUtil.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestUtil.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.test.utils;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static com.google.common.truth.Truth.assertThat;
@@ -949,7 +950,7 @@ public class TestUtil {
    * created on a non-Looper thread.
    */
   public static SurfaceView createSurfaceView(Context context) {
-    if (Util.SDK_INT >= 26 || Looper.myLooper() != null) {
+    if (SDK_INT >= 26 || Looper.myLooper() != null) {
       return new SurfaceView(context);
     }
     AtomicReference<SurfaceView> surfaceView = new AtomicReference<>();

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/AndroidTestUtil.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/AndroidTestUtil.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.MimeTypes.IMAGE_JPEG;
 import static androidx.media3.common.MimeTypes.IMAGE_PNG;
 import static androidx.media3.common.MimeTypes.IMAGE_WEBP;
@@ -24,7 +25,6 @@ import static androidx.media3.common.MimeTypes.VIDEO_H264;
 import static androidx.media3.common.MimeTypes.VIDEO_H265;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static androidx.media3.test.utils.TestUtil.retrieveTrackFormat;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
@@ -1293,7 +1293,7 @@ public final class AndroidTestUtil {
       throws IOException, InterruptedException {
     // b/298599172 - runUntilComparisonFrameOrEnded fails on this device because reading decoder
     //  output as a bitmap doesn't work.
-    assumeFalse(Util.SDK_INT == 21 && Ascii.toLowerCase(Build.MODEL).contains("nexus"));
+    assumeFalse(SDK_INT == 21 && Ascii.toLowerCase(Build.MODEL).contains("nexus"));
     ImmutableList.Builder<Bitmap> bitmaps = new ImmutableList.Builder<>();
     try (VideoDecodingWrapper decodingWrapper =
         new VideoDecodingWrapper(

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/CompositionPlayerSeekTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/CompositionPlayerSeekTest.java
@@ -16,6 +16,7 @@
 
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Util.isRunningOnEmulator;
 import static androidx.media3.common.util.Util.usToMs;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_ASSET;
@@ -121,7 +122,7 @@ public class CompositionPlayerSeekTest {
   public void seekToZero_afterPlayingSingleSequenceOfTwoVideos() throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     ImmutableList<Long> sequenceTimestampsUs =
         new ImmutableList.Builder<Long>()
             // Plays the first video
@@ -147,7 +148,7 @@ public class CompositionPlayerSeekTest {
   public void seekToFirstVideo_afterPlayingSingleSequenceOfTwoVideos() throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     // Skips the first three video frames
     long seekTimeMs = 100;
     ImmutableList<Long> sequenceTimestampsUs =
@@ -173,7 +174,7 @@ public class CompositionPlayerSeekTest {
   public void seekToStartOfSecondVideo_afterPlayingSingleSequenceOfTwoVideos() throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     // Seeks to the end of the first video
     long seekTimeMs = usToMs(VIDEO_DURATION_US);
     ImmutableList<Long> sequenceTimestampsUs =
@@ -198,7 +199,7 @@ public class CompositionPlayerSeekTest {
   public void seekToSecondVideo_afterPlayingSingleSequenceOfTwoVideos() throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     // Skips the first three image frames of the second image.
     long seekTimeMs = usToMs(VIDEO_DURATION_US) + 100;
     ImmutableList<Long> sequenceTimestampsUs =
@@ -225,7 +226,7 @@ public class CompositionPlayerSeekTest {
   public void seekToEndOfSecondVideo_afterPlayingSingleSequenceOfTwoVideos() throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     // Seeks to the end of the second video
     long seekTimeMs = usToMs(2 * VIDEO_DURATION_US);
     ImmutableList<Long> sequenceTimestampsUs =
@@ -249,7 +250,7 @@ public class CompositionPlayerSeekTest {
   public void seekToAfterEndOfSecondVideo_afterPlayingSingleSequenceOfTwoVideos() throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     long seekTimeMs = usToMs(3 * VIDEO_DURATION_US);
     ImmutableList<Long> sequenceTimestampsUs =
         new ImmutableList.Builder<Long>()
@@ -405,7 +406,7 @@ public class CompositionPlayerSeekTest {
   public void seekToZero_afterPlayingSingleSequenceOfVideoAndImage() throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     ImmutableList<Long> sequenceTimestampsUs =
         new ImmutableList.Builder<Long>()
             // Plays the video
@@ -431,7 +432,7 @@ public class CompositionPlayerSeekTest {
   public void seekToVideo_afterPlayingSingleSequenceOfVideoAndImage() throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     // Skips three video frames
     long seekTimeMs = 100;
     ImmutableList<Long> sequenceTimestampsUs =
@@ -458,7 +459,7 @@ public class CompositionPlayerSeekTest {
   public void seekToImage_afterPlayingSingleSequenceOfVideoAndImage() throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     // Skips video frames and three image frames
     long seekTimeMs = usToMs(VIDEO_DURATION_US) + 100;
     ImmutableList<Long> sequenceTimestampsUs =
@@ -537,7 +538,7 @@ public class CompositionPlayerSeekTest {
   public void seekToVideo_afterPlayingSingleSequenceOfImageAndVideo() throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     // Skips to the first video frame.
     long seekTimeMs = usToMs(IMAGE_DURATION_US);
     ImmutableList<Long> sequenceTimestampsUs =
@@ -562,7 +563,7 @@ public class CompositionPlayerSeekTest {
   public void seekToZero_duringPlayingFirstVideoInSingleSequenceOfTwoVideos() throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     ImmutableList<MediaItemConfig> mediaItems =
         ImmutableList.of(VIDEO_MEDIA_ITEM, VIDEO_MEDIA_ITEM);
     int numberOfFramesBeforeSeeking = 15;
@@ -590,7 +591,7 @@ public class CompositionPlayerSeekTest {
       throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     ImmutableList<MediaItemConfig> mediaItems =
         ImmutableList.of(VIDEO_MEDIA_ITEM, VIDEO_MEDIA_ITEM);
     int numberOfFramesBeforeSeeking = 15;
@@ -619,7 +620,7 @@ public class CompositionPlayerSeekTest {
       throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     ImmutableList<MediaItemConfig> mediaItems =
         ImmutableList.of(VIDEO_MEDIA_ITEM, VIDEO_MEDIA_ITEM);
     int numberOfFramesBeforeSeeking = 45;
@@ -652,7 +653,7 @@ public class CompositionPlayerSeekTest {
       throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     ImmutableList<MediaItemConfig> mediaItems =
         ImmutableList.of(VIDEO_MEDIA_ITEM, VIDEO_MEDIA_ITEM);
     int numberOfFramesBeforeSeeking = 15;
@@ -679,7 +680,7 @@ public class CompositionPlayerSeekTest {
       throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     ImmutableList<MediaItemConfig> mediaItems =
         ImmutableList.of(VIDEO_MEDIA_ITEM, VIDEO_MEDIA_ITEM);
     int numberOfFramesBeforeSeeking = 15;
@@ -750,7 +751,7 @@ public class CompositionPlayerSeekTest {
   public void seekToImage_duringPlayingFirstImageInSequenceOfVideoAndImage() throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     ImmutableList<MediaItemConfig> mediaItems =
         ImmutableList.of(VIDEO_MEDIA_ITEM, IMAGE_MEDIA_ITEM);
     int numberOfFramesBeforeSeeking = 15;
@@ -778,7 +779,7 @@ public class CompositionPlayerSeekTest {
   public void seekToVideo_duringPlayingFirstImageInSequenceOfImageAndVideo() throws Exception {
     assumeFalse(
         "Skipped due to failing audio decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     ImmutableList<MediaItemConfig> mediaItems =
         ImmutableList.of(IMAGE_MEDIA_ITEM, VIDEO_MEDIA_ITEM);
     int numberOfFramesBeforeSeeking = 3;
@@ -806,8 +807,7 @@ public class CompositionPlayerSeekTest {
   public void
       seekToSecondVideo_duringPlayingFirstVideoInSingleSequenceOfTwoVideosWithPrewarmingDisabled()
           throws Exception {
-    assumeFalse(
-        "Skipped due to failing audio decoder", isRunningOnEmulator() && Util.SDK_INT == 31);
+    assumeFalse("Skipped due to failing audio decoder", isRunningOnEmulator() && SDK_INT == 31);
     ImmutableList<MediaItemConfig> mediaItems =
         ImmutableList.of(VIDEO_MEDIA_ITEM, VIDEO_MEDIA_ITEM);
     int numberOfFramesBeforeSeeking = 15;

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/DefaultVideoCompositorPixelTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/DefaultVideoCompositorPixelTest.java
@@ -15,7 +15,7 @@
  */
 package androidx.media3.transformer;
 
-import static androidx.media3.common.util.Util.SDK_INT;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Util.isRunningOnEmulator;
 import static androidx.media3.test.utils.BitmapPixelTestUtil.MAXIMUM_AVERAGE_PIXEL_ABSOLUTE_DIFFERENCE;
 import static androidx.media3.test.utils.BitmapPixelTestUtil.maybeSaveTestBitmap;

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/EditingMetricsCollectorTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/EditingMetricsCollectorTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Util.usToMs;
 import static androidx.media3.transformer.AndroidTestUtil.JPG_ASSET;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_ASSET;
@@ -37,7 +38,6 @@ import androidx.media3.common.Format;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MediaLibraryInfo;
 import androidx.media3.common.Metadata;
-import androidx.media3.common.util.Util;
 import androidx.media3.muxer.MuxerException;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -76,7 +76,7 @@ public class EditingMetricsCollectorTest {
 
   @Test
   public void export_usePlatformDiagnosticsDisabled_doesNotCollectMetrics() throws Exception {
-    if (Util.SDK_INT < 35) {
+    if (SDK_INT < 35) {
       String reason = "Metrics collection is unsupported below API 35.";
       recordTestSkipped(context, testId, reason);
       throw new AssumptionViolatedException(reason);
@@ -108,7 +108,7 @@ public class EditingMetricsCollectorTest {
 
   @Test
   public void exportSuccess_populatesEditingEndedEvent() throws Exception {
-    assumeTrue("Reporting metrics requires API 35", Util.SDK_INT >= 35);
+    assumeTrue("Reporting metrics requires API 35", SDK_INT >= 35);
     assumeFormatsSupported(
         context,
         testId,
@@ -242,7 +242,7 @@ public class EditingMetricsCollectorTest {
 
   @Test
   public void exportError_populatesEditingEndedEvent() throws Exception {
-    assumeTrue("Reporting metrics requires API 35", Util.SDK_INT >= 35);
+    assumeTrue("Reporting metrics requires API 35", SDK_INT >= 35);
     assumeFormatsSupported(
         context,
         testId,
@@ -285,7 +285,7 @@ public class EditingMetricsCollectorTest {
 
   @Test
   public void exportCancelled_populatesEditingEndedEvent() throws Exception {
-    assumeTrue("Reporting metrics requires API 35", Util.SDK_INT >= 35);
+    assumeTrue("Reporting metrics requires API 35", SDK_INT >= 35);
     assumeFormatsSupported(
         context,
         testId,
@@ -331,7 +331,7 @@ public class EditingMetricsCollectorTest {
 
   @Test
   public void exportTwice_createsUniqueSessions() throws Exception {
-    assumeTrue("Reporting metrics requires API 35", Util.SDK_INT >= 35);
+    assumeTrue("Reporting metrics requires API 35", SDK_INT >= 35);
     assumeFormatsSupported(
         context,
         testId,

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/ForceEndOfStreamTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/ForceEndOfStreamTest.java
@@ -16,6 +16,7 @@
 
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.transformer.AndroidTestUtil.FORCE_TRANSCODE_VIDEO_EFFECTS;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_ASSET;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_ASSET_WITH_INCREASING_TIMESTAMPS_320W_240H_15S;
@@ -75,7 +76,7 @@ public class ForceEndOfStreamTest {
   public void transcode_decoderDroppingLastFourFrames_exportSucceeds() throws Exception {
     // TODO: b/370050055 - Do we need API 29+, or the device list from
     //  Util.isFrameDropAllowedOnSurfaceInput?
-    assumeTrue(Util.SDK_INT >= 29);
+    assumeTrue(SDK_INT >= 29);
     assumeFormatsSupported(
         context,
         testId,
@@ -97,7 +98,7 @@ public class ForceEndOfStreamTest {
   public void transcode_decoderDroppingNoFrame_exportSucceeds() throws Exception {
     // TODO: b/370050055 - Do we need API 29+, or the device list from
     //  Util.isFrameDropAllowedOnSurfaceInput?
-    assumeTrue(Util.SDK_INT >= 29);
+    assumeTrue(SDK_INT >= 29);
     assumeFormatsSupported(
         context,
         testId,
@@ -119,7 +120,7 @@ public class ForceEndOfStreamTest {
       throws Exception {
     // TODO: b/370050055 - Do we need API 29+, or the device list from
     //  Util.isFrameDropAllowedOnSurfaceInput?
-    assumeTrue(Util.SDK_INT >= 29);
+    assumeTrue(SDK_INT >= 29);
     assumeFormatsSupported(
         context,
         testId,

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/MediaProjectionActivity.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/MediaProjectionActivity.java
@@ -16,7 +16,7 @@
 package androidx.media3.transformer;
 
 import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION;
-import static androidx.media3.common.util.Util.SDK_INT;
+import static android.os.Build.VERSION.SDK_INT;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.app.Activity;

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/MediaProjectionAssetLoaderTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/MediaProjectionAssetLoaderTest.java
@@ -17,6 +17,7 @@ package androidx.media3.transformer;
 
 import static android.app.Activity.RESULT_OK;
 import static android.content.Context.MEDIA_PROJECTION_SERVICE;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static com.google.common.truth.Truth.assertThat;
@@ -86,7 +87,7 @@ public final class MediaProjectionAssetLoaderTest {
     // The test does pass on some earlier builds (back to API 23) but not on all devices.
     assumeTrue(
         Util.isRunningOnEmulator()
-            || (Util.SDK_INT >= 29
+            || (SDK_INT >= 29
                 && !Util.isWear(getInstrumentation().getContext())
                 && Build.MODEL.startsWith("Pixel")));
   }

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/SurfaceAssetLoaderTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/SurfaceAssetLoaderTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assume.assumeTrue;
@@ -33,7 +34,6 @@ import androidx.media3.common.Format;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.ConditionVariable;
-import androidx.media3.common.util.Util;
 import androidx.media3.test.utils.BitmapPixelTestUtil;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -67,7 +67,7 @@ public class SurfaceAssetLoaderTest {
 
   @Test
   public void encodingFromSurface_succeeds() throws Exception {
-    assumeTrue("ImageWriter with pixel format set requires API 29", Util.SDK_INT >= 29);
+    assumeTrue("ImageWriter with pixel format set requires API 29", SDK_INT >= 29);
 
     SettableFuture<SurfaceAssetLoader> surfaceAssetLoaderSettableFuture = SettableFuture.create();
     SettableFuture<Surface> surfaceSettableFuture = SettableFuture.create();
@@ -138,7 +138,7 @@ public class SurfaceAssetLoaderTest {
 
   @Test
   public void encodingFromSurface_withLargeTimestamps_succeeds() throws Exception {
-    assumeTrue("ImageWriter with pixel format set requires API 29", Util.SDK_INT >= 29);
+    assumeTrue("ImageWriter with pixel format set requires API 29", SDK_INT >= 29);
 
     SettableFuture<SurfaceAssetLoader> surfaceAssetLoaderSettableFuture = SettableFuture.create();
     SettableFuture<Surface> surfaceSettableFuture = SettableFuture.create();

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/SurfaceTestActivity.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/SurfaceTestActivity.java
@@ -15,13 +15,14 @@
  */
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
+
 import android.app.Activity;
 import android.app.KeyguardManager;
 import android.os.Bundle;
 import android.view.SurfaceView;
 import android.view.TextureView;
 import android.view.WindowManager;
-import androidx.media3.common.util.Util;
 import androidx.media3.transformer.test.R;
 
 /** An activity with surfaces for testing purposes. */
@@ -50,7 +51,7 @@ public final class SurfaceTestActivity extends Activity {
   }
 
   private static void setKeepScreenOn(Activity activity) {
-    if (Util.SDK_INT >= 27) {
+    if (SDK_INT >= 27) {
       activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
       activity.setTurnScreenOn(true);
       activity.setShowWhenLocked(true);

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerAndroidTestRunner.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerAndroidTestRunner.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -33,7 +34,6 @@ import androidx.media3.common.util.Clock;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.NullableType;
 import androidx.media3.common.util.SystemClock;
-import androidx.media3.common.util.Util;
 import androidx.media3.effect.DebugTraceUtil;
 import androidx.media3.test.utils.SsimHelper;
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -466,7 +466,7 @@ public class TransformerAndroidTestRunner {
       // ExportTestResult.
       throw interruptedException;
     } catch (Throwable analysisFailure) {
-      if (Util.SDK_INT == 21 && Ascii.toLowerCase(Build.MODEL).contains("nexus")) {
+      if (SDK_INT == 21 && Ascii.toLowerCase(Build.MODEL).contains("nexus")) {
         // b/233584640, b/230093713
         Log.i(TAG, testId + ": Skipping SSIM calculation due to known device-specific issue");
       } else {
@@ -496,7 +496,7 @@ public class TransformerAndroidTestRunner {
     if (connectivityManager == null) {
       return false;
     }
-    if (Util.SDK_INT >= 23) {
+    if (SDK_INT >= 23) {
       // getActiveNetwork is available from API 23.
       NetworkCapabilities activeNetworkCapabilities =
           connectivityManager.getNetworkCapabilities(connectivityManager.getActiveNetwork());

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerEndToEndTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerEndToEndTest.java
@@ -16,10 +16,10 @@
 package androidx.media3.transformer;
 
 import static android.media.MediaCodecInfo.CodecProfileLevel.AACObjectHE;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.MediaFormatUtil.createFormatFromMediaFormat;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static androidx.media3.common.util.Util.isRunningOnEmulator;
 import static androidx.media3.test.utils.TestUtil.retrieveTrackFormat;
 import static androidx.media3.transformer.AndroidTestUtil.JPG_ASSET;
@@ -91,7 +91,6 @@ import androidx.media3.common.audio.SonicAudioProcessor;
 import androidx.media3.common.audio.SpeedProvider;
 import androidx.media3.common.util.CodecSpecificDataUtil;
 import androidx.media3.common.util.GlUtil;
-import androidx.media3.common.util.Util;
 import androidx.media3.datasource.DataSourceBitmapLoader;
 import androidx.media3.effect.Contrast;
 import androidx.media3.effect.DefaultGlObjectsProvider;
@@ -1108,7 +1107,7 @@ public class TransformerEndToEndTest {
   @Test
   public void clippedMedia_trimOptimizationEnabled_completesWithOptimizationApplied()
       throws Exception {
-    if (!isRunningOnEmulator() || Util.SDK_INT < 33) {
+    if (!isRunningOnEmulator() || SDK_INT < 33) {
       // The trim optimization is only guaranteed to work on emulator for this (emulator-transcoded)
       // file.
       recordTestSkipped(context, testId, /* reason= */ "SDK 33+ Emulator only test");
@@ -1144,7 +1143,7 @@ public class TransformerEndToEndTest {
   public void
       clippedMedia_trimOptimizationEnabled_inputFileRotated270_completesWithOptimizationApplied()
           throws Exception {
-    if (!isRunningOnEmulator() || Util.SDK_INT < 33) {
+    if (!isRunningOnEmulator() || SDK_INT < 33) {
       // The trim optimization is only guaranteed to work on emulator for this (emulator-transcoded)
       // file.
       recordTestSkipped(context, testId, /* reason= */ "SDK 33+ Emulator only test");
@@ -1181,7 +1180,7 @@ public class TransformerEndToEndTest {
   public void
       clippedMedia_trimOptimizationEnabled_inputFileRotated180_completesWithOptimizationApplied()
           throws Exception {
-    if (!isRunningOnEmulator() || Util.SDK_INT < 33) {
+    if (!isRunningOnEmulator() || SDK_INT < 33) {
       // The trim optimization is only guaranteed to work on emulator for this (emulator-transcoded)
       // file.
       recordTestSkipped(context, testId, /* reason= */ "SDK 33+ Emulator only test");
@@ -1218,7 +1217,7 @@ public class TransformerEndToEndTest {
   public void
       clippedMediaAudioRemovedNoOpEffectAndRotated_trimOptimizationEnabled_completedWithOptimizationAppliedAndCorrectOrientation()
           throws Exception {
-    if (!isRunningOnEmulator() || Util.SDK_INT < 33) {
+    if (!isRunningOnEmulator() || SDK_INT < 33) {
       // The trim optimization is only guaranteed to work on emulator for this (emulator-transcoded)
       // file.
       recordTestSkipped(context, testId, /* reason= */ "SDK 33+ Emulator only test");
@@ -1801,7 +1800,7 @@ public class TransformerEndToEndTest {
     // Hevc support is available from API 24.
     // The asset has B-frames and B-frame support is available from API 25.
     // Dolby vision support is available from API 33.
-    assumeTrue(Util.SDK_INT >= 25 && Util.SDK_INT < 33);
+    assumeTrue(SDK_INT >= 25 && SDK_INT < 33);
     EditedMediaItem editedMediaItem =
         new EditedMediaItem.Builder(MediaItem.fromUri(Uri.parse(MP4_ASSET_DOLBY_VISION_HDR.uri)))
             .setRemoveAudio(true)
@@ -1819,7 +1818,7 @@ public class TransformerEndToEndTest {
 
   @Test
   public void transmuxDolbyVisionVideo_transmuxesSuccessfully() throws Exception {
-    assumeTrue("Dolby vision support available from API 33", Util.SDK_INT >= 33);
+    assumeTrue("Dolby vision support available from API 33", SDK_INT >= 33);
     Transformer transformer = new Transformer.Builder(context).build();
     MediaItem mediaItem = MediaItem.fromUri(Uri.parse(MP4_ASSET_DOLBY_VISION_HDR.uri));
 
@@ -2124,7 +2123,7 @@ public class TransformerEndToEndTest {
     FakeTrackOutput audioTrack = fakeExtractorOutput.trackOutputs.get(0);
     int expectedSampleCount = 68;
     audioTrack.assertSampleCount(expectedSampleCount);
-    if (Util.SDK_INT >= 30) {
+    if (SDK_INT >= 30) {
       // TODO: b/324842222 - Mp4Extractor doesn't interpret Transformer's generated output as
       //  "gapless" audio. The generated file should have encoderDelay = 742 and first
       //  sample PTS of 0.
@@ -2178,8 +2177,7 @@ public class TransformerEndToEndTest {
   @Test
   public void transmux_videoWithEditList_trimsFirstIdrFrameDuration() throws Exception {
     Context context = ApplicationProvider.getApplicationContext();
-    assumeTrue(
-        "MediaMuxer doesn't support B frames reliably on older SDK versions", Util.SDK_INT >= 29);
+    assumeTrue("MediaMuxer doesn't support B frames reliably on older SDK versions", SDK_INT >= 29);
     Transformer transformer = new Transformer.Builder(context).build();
     MediaItem mediaItem =
         MediaItem.fromUri(Uri.parse("asset:///media/mp4/iibbibb_editlist_videoonly.mp4"));
@@ -2259,7 +2257,7 @@ public class TransformerEndToEndTest {
         /* outputFormat= */ MP4_ASSET_WITH_SHORTER_AUDIO.videoFormat);
     assumeTrue(
         "Old SDKs have large audio encoder buffer, and hits deadlocks due to b/329087277.",
-        Util.SDK_INT >= 31);
+        SDK_INT >= 31);
     Context context = ApplicationProvider.getApplicationContext();
     Transformer transformer = new Transformer.Builder(context).build();
     MediaItem mediaItem = MediaItem.fromUri(Uri.parse(MP4_ASSET_WITH_SHORTER_AUDIO.uri));
@@ -2419,7 +2417,7 @@ public class TransformerEndToEndTest {
   public void export_setAudioEncodingBitrate_configuresEncoderWithRequestedBitrate()
       throws Exception {
     // On API 23, the encoder output format does not seem to contain bitrate, hence the test fails.
-    assumeTrue(Util.SDK_INT > 23);
+    assumeTrue(SDK_INT > 23);
     Context context = ApplicationProvider.getApplicationContext();
     int requestedBitrate = 60_000;
     // The MediaMuxer is not writing the bitrate hence use the InAppMuxer.
@@ -2590,7 +2588,7 @@ public class TransformerEndToEndTest {
   }
 
   private static boolean shouldSkipDeviceForAacObjectHeProfileEncoding() {
-    return Util.SDK_INT < 29;
+    return SDK_INT < 29;
   }
 
   private static AudioProcessor createSonic(float pitch) {

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerMultiSequenceCompositionTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerMultiSequenceCompositionTest.java
@@ -16,6 +16,7 @@
 
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Util.isRunningOnEmulator;
 import static androidx.media3.test.utils.BitmapPixelTestUtil.MAXIMUM_AVERAGE_PIXEL_ABSOLUTE_DIFFERENCE_LUMA;
@@ -236,7 +237,7 @@ public final class TransformerMultiSequenceCompositionTest {
   public void export_completesWithConsistentFrameCount() throws Exception {
     assumeFalse(
         "Skipped due to failing video decoder on API 31 emulator",
-        isRunningOnEmulator() && Util.SDK_INT == 31);
+        isRunningOnEmulator() && SDK_INT == 31);
     assumeFormatsSupported(
         context,
         testId,

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerPauseResumeTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerPauseResumeTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_ASSET_WITH_INCREASING_TIMESTAMPS_320W_240H_15S;
 import static androidx.media3.transformer.AndroidTestUtil.assumeFormatsSupported;
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
@@ -427,9 +428,9 @@ public class TransformerPauseResumeTest {
     // v26 emulators are not producing I-frames, due to which resuming export does not work as
     // expected.
     // On vivo 1820 and vivo 1906, the process crashes unexpectedly (see b/310566201).
-    return (Util.SDK_INT == 26 && Util.isRunningOnEmulator())
-        || (Util.SDK_INT == 27 && Ascii.equalsIgnoreCase(Build.MODEL, "vivo 1820"))
-        || (Util.SDK_INT == 28 && Ascii.equalsIgnoreCase(Build.MODEL, "vivo 1901"))
-        || (Util.SDK_INT == 28 && Ascii.equalsIgnoreCase(Build.MODEL, "vivo 1906"));
+    return (SDK_INT == 26 && Util.isRunningOnEmulator())
+        || (SDK_INT == 27 && Ascii.equalsIgnoreCase(Build.MODEL, "vivo 1820"))
+        || (SDK_INT == 28 && Ascii.equalsIgnoreCase(Build.MODEL, "vivo 1901"))
+        || (SDK_INT == 28 && Ascii.equalsIgnoreCase(Build.MODEL, "vivo 1906"));
   }
 }

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerProgressTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerProgressTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkStateNotNull;
 import static androidx.media3.common.util.Util.isRunningOnEmulator;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_TRIM_OPTIMIZATION;
@@ -33,7 +34,6 @@ import androidx.media3.common.GlTextureInfo;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.VideoFrameProcessingException;
 import androidx.media3.common.util.NullableType;
-import androidx.media3.common.util.Util;
 import androidx.media3.effect.BaseGlShaderProgram;
 import androidx.media3.effect.Brightness;
 import androidx.media3.effect.DebugTraceUtil;
@@ -169,7 +169,7 @@ public class TransformerProgressTest {
     // The trim optimization is only guaranteed to work on emulator for this file.
     assumeTrue(isRunningOnEmulator());
     // MediaCodec returns a segmentation fault fails at this SDK level on emulators.
-    assumeFalse(Util.SDK_INT == 26);
+    assumeFalse(SDK_INT == 26);
     Transformer transformer =
         new Transformer.Builder(context).experimentalSetTrimOptimizationEnabled(true).build();
     MediaItem mediaItem =
@@ -249,7 +249,7 @@ public class TransformerProgressTest {
     // The trim optimization is only guaranteed to work on emulator for this file.
     assumeTrue(isRunningOnEmulator());
     // MediaCodec returns a segmentation fault fails at this SDK level on emulators.
-    assumeFalse(Util.SDK_INT == 26);
+    assumeFalse(SDK_INT == 26);
     Transformer transformer =
         new Transformer.Builder(context).experimentalSetTrimOptimizationEnabled(true).build();
     MediaItem mediaItem =

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerUltraHdrTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerUltraHdrTest.java
@@ -17,6 +17,7 @@
 
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.transformer.AndroidTestUtil.JPG_ASSET;
 import static androidx.media3.transformer.AndroidTestUtil.JPG_ULTRA_HDR_ASSET;
 import static androidx.media3.transformer.AndroidTestUtil.assertSdrColors;
@@ -33,7 +34,6 @@ import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.BitmapLoader;
-import androidx.media3.common.util.Util;
 import androidx.media3.datasource.DataSourceBitmapLoader;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -77,7 +77,7 @@ public final class TransformerUltraHdrTest {
   @Test
   public void exportUltraHdrImage_withUltraHdrEnabledOnUnsupportedApiLevel_fallbackToExportSdr()
       throws Exception {
-    assumeTrue(Util.SDK_INT < 34);
+    assumeTrue(SDK_INT < 34);
     assumeFormatsSupported(
         context,
         testId,

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/DefaultVideoFrameProcessorTextureOutputPixelTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/DefaultVideoFrameProcessorTextureOutputPixelTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.transformer.mh;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.ColorInfo.SDR_BT709_LIMITED;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.test.utils.BitmapPixelTestUtil.MAXIMUM_AVERAGE_PIXEL_ABSOLUTE_DIFFERENCE_DIFFERENT_DEVICE;
@@ -49,7 +50,6 @@ import androidx.media3.common.GlObjectsProvider;
 import androidx.media3.common.GlTextureInfo;
 import androidx.media3.common.VideoFrameProcessingException;
 import androidx.media3.common.util.GlUtil;
-import androidx.media3.common.util.Util;
 import androidx.media3.effect.BitmapOverlay;
 import androidx.media3.effect.DefaultGlObjectsProvider;
 import androidx.media3.effect.DefaultVideoFrameProcessor;
@@ -946,7 +946,7 @@ public final class DefaultVideoFrameProcessorTextureOutputPixelTest {
   }
 
   private void assumeDeviceSupportsUltraHdrEditing() throws JSONException, IOException {
-    if (Util.SDK_INT < 34) {
+    if (SDK_INT < 34) {
       recordTestSkipped(
           getApplicationContext(), testId, "Ultra HDR is not supported on this API level.");
       throw new AssumptionViolatedException("Ultra HDR is not supported on this API level.");

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/ExportTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/ExportTest.java
@@ -17,9 +17,9 @@ package androidx.media3.transformer.mh;
 
 import static android.media.MediaCodecInfo.CodecProfileLevel.AVCLevel41;
 import static android.media.MediaCodecInfo.CodecProfileLevel.AVCProfileHigh;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.MediaFormatUtil.createFormatFromMediaFormat;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static androidx.media3.exoplayer.mediacodec.MediaCodecUtil.getCodecProfileAndLevel;
 import static androidx.media3.transformer.AndroidTestUtil.FORCE_TRANSCODE_VIDEO_EFFECTS;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_ASSET;
@@ -48,7 +48,6 @@ import androidx.media3.common.Effect;
 import androidx.media3.common.Format;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MimeTypes;
-import androidx.media3.common.util.Util;
 import androidx.media3.effect.Presentation;
 import androidx.media3.effect.ScaleAndRotateTransformation;
 import androidx.media3.exoplayer.MediaExtractorCompat;
@@ -171,17 +170,17 @@ public class ExportTest {
     // Reference: b/262710361
     assumeFalse(
         "Skip due to over-reported encoder capabilities",
-        Util.SDK_INT == 29 && Ascii.equalsIgnoreCase(Build.MODEL, "pixel 3"));
+        SDK_INT == 29 && Ascii.equalsIgnoreCase(Build.MODEL, "pixel 3"));
     // Reference: b/347635026
     assumeFalse(
         "Skip due to decoder failing to queue input frames",
-        Util.SDK_INT == 29 && Ascii.equalsIgnoreCase(Build.MODEL, "pixel 3a"));
+        SDK_INT == 29 && Ascii.equalsIgnoreCase(Build.MODEL, "pixel 3a"));
     Transformer transformer =
         new Transformer.Builder(context)
             .setEncoderFactory(new ForceEncodeEncoderFactory(context))
             .build();
     MediaItem mediaItem = MediaItem.fromUri(Uri.parse(MP4_ASSET_4K60_PORTRAIT.uri));
-    boolean skipCalculateSsim = Util.SDK_INT < 30 && Build.DEVICE.equals("joyeuse");
+    boolean skipCalculateSsim = SDK_INT < 30 && Build.DEVICE.equals("joyeuse");
 
     ExportTestResult result =
         new TransformerAndroidTestRunner.Builder(context, transformer)
@@ -457,7 +456,7 @@ public class ExportTest {
   public void export_setEncodingProfileLevel_changesProfileAndLevel() throws Exception {
     assumeTrue(
         "Android encoding guidelines recommend H.264 baseline profile prior to API 25",
-        Util.SDK_INT >= 25);
+        SDK_INT >= 25);
     Context context = ApplicationProvider.getApplicationContext();
     Transformer transformer =
         new Transformer.Builder(context)

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/ForceInterpretHdrVideoAsSdrTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/ForceInterpretHdrVideoAsSdrTest.java
@@ -15,7 +15,7 @@
  */
 package androidx.media3.transformer.mh;
 
-import static androidx.media3.common.util.Util.SDK_INT;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.test.utils.TestUtil.retrieveTrackFormat;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_ASSET_1080P_5_SECOND_HLG10;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_ASSET_720P_4_SECOND_HDR10;

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/FrameExtractorHdrTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/FrameExtractorHdrTest.java
@@ -18,7 +18,7 @@ package androidx.media3.transformer.mh;
 import static android.graphics.Bitmap.Config.RGBA_1010102;
 import static android.graphics.Bitmap.Config.RGBA_F16;
 import static android.graphics.ColorSpace.Named.BT2020_HLG;
-import static androidx.media3.common.util.Util.SDK_INT;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.test.utils.BitmapPixelTestUtil.maybeSaveTestBitmap;
 import static androidx.media3.test.utils.BitmapPixelTestUtil.readBitmap;
 import static androidx.media3.test.utils.TestUtil.assertBitmapsAreSimilar;

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/HdrCapabilitiesUtil.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/HdrCapabilitiesUtil.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.transformer.mh;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.Assertions.checkStateNotNull;
 import static androidx.media3.transformer.AndroidTestUtil.assumeFormatsSupported;
@@ -27,7 +28,6 @@ import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
 import androidx.media3.common.util.GlUtil;
 import androidx.media3.common.util.GlUtil.GlException;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.mediacodec.MediaCodecUtil;
 import androidx.media3.transformer.EncoderUtil;
 import java.io.IOException;
@@ -48,7 +48,7 @@ public final class HdrCapabilitiesUtil {
   public static void assumeDeviceSupportsOpenGlToneMapping(String testId, Format inputFormat)
       throws JSONException, IOException, MediaCodecUtil.DecoderQueryException {
     Context context = getApplicationContext();
-    if (Util.SDK_INT < 29) {
+    if (SDK_INT < 29) {
       recordTestSkipped(context, testId, SKIP_REASON_NO_OPENGL_UNDER_API_29);
       throw new AssumptionViolatedException(SKIP_REASON_NO_OPENGL_UNDER_API_29);
     }

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/HdrEditingTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/HdrEditingTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.transformer.mh;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.effect.DefaultVideoFrameProcessor.WORKING_COLOR_SPACE_ORIGINAL;
 import static androidx.media3.test.utils.DecodeOneFrameUtil.decodeOneMediaItemFrame;
 import static androidx.media3.test.utils.TestUtil.retrieveTrackFormat;
@@ -42,7 +43,6 @@ import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MimeTypes;
-import androidx.media3.common.util.Util;
 import androidx.media3.effect.DefaultVideoFrameProcessor;
 import androidx.media3.exoplayer.video.PlaceholderSurface;
 import androidx.media3.test.utils.DecodeOneFrameUtil;
@@ -99,7 +99,7 @@ public final class HdrEditingTest {
   public void export_transmuxHdr10File() throws Exception {
     Context context = ApplicationProvider.getApplicationContext();
 
-    if (Util.SDK_INT < 24) {
+    if (SDK_INT < 24) {
       // TODO: b/285543404 - Remove suppression once we can transmux H.265/HEVC before API 24.
       recordTestSkipped(context, testId, /* reason= */ "Can't transmux H.265/HEVC before API 24");
       return;
@@ -130,7 +130,7 @@ public final class HdrEditingTest {
   public void export_transmuxHlg10File() throws Exception {
     Context context = ApplicationProvider.getApplicationContext();
 
-    if (Util.SDK_INT < 24) {
+    if (SDK_INT < 24) {
       // TODO: b/285543404 - Remove suppression once we can transmux H.265/HEVC before API 24.
       recordTestSkipped(context, testId, /* reason= */ "Can't transmux H.265/HEVC before API 24");
       return;

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/PlaybackVideoGraphWrapperTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/PlaybackVideoGraphWrapperTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.transformer.mh;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_ASSET_720P_4_SECOND_HDR10;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_ASSET_BT2020_SDR;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_ASSET_COLOR_TEST_1080P_HLG10;
@@ -30,7 +31,6 @@ import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
 import androidx.media3.common.VideoGraph;
 import androidx.media3.common.util.GlUtil;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.video.PlaybackVideoGraphWrapper;
 import androidx.media3.exoplayer.video.VideoFrameReleaseControl;
 import androidx.media3.exoplayer.video.VideoSink;
@@ -99,7 +99,7 @@ public class PlaybackVideoGraphWrapperTest {
 
     ColorInfo expectedColorInfo;
     // HLG is converted to PQ on API 33.
-    if (Util.SDK_INT < 34 && GlUtil.isBt2020PqExtensionSupported()) {
+    if (SDK_INT < 34 && GlUtil.isBt2020PqExtensionSupported()) {
       expectedColorInfo =
           inputFormat.colorInfo.buildUpon().setColorTransfer(C.COLOR_TRANSFER_ST2084).build();
     } else {

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TranscodeQualityTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TranscodeQualityTest.java
@@ -16,6 +16,7 @@
 
 package androidx.media3.transformer.mh;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.transformer.AndroidTestUtil.assumeFormatsSupported;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assume.assumeFalse;
@@ -65,8 +66,8 @@ public final class TranscodeQualityTest {
             .setSampleMimeType(MimeTypes.VIDEO_H265)
             .build());
     assumeFalse(
-        (Util.SDK_INT < 33 && (Build.MODEL.equals("SM-F711U1") || Build.MODEL.equals("SM-F926U1")))
-            || (Util.SDK_INT == 33 && Build.MODEL.equals("LE2121")));
+        (SDK_INT < 33 && (Build.MODEL.equals("SM-F711U1") || Build.MODEL.equals("SM-F926U1")))
+            || (SDK_INT == 33 && Build.MODEL.equals("LE2121")));
     Transformer transformer =
         new Transformer.Builder(context).setVideoMimeType(MimeTypes.VIDEO_H265).build();
     MediaItem mediaItem =

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TranscodeSpeedTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TranscodeSpeedTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.transformer.mh;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.MimeTypes.VIDEO_H264;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.transformer.AndroidTestUtil.JPG_ULTRA_HDR_ASSET;
@@ -32,7 +33,6 @@ import androidx.media3.common.Format;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Clock;
-import androidx.media3.common.util.Util;
 import androidx.media3.effect.Presentation;
 import androidx.media3.transformer.AndroidTestUtil.ForceEncodeEncoderFactory;
 import androidx.media3.transformer.AssetLoader;
@@ -122,7 +122,7 @@ public class TranscodeSpeedTest {
                 || Ascii.toLowerCase(Build.MODEL).contains("8")
                 || Ascii.toLowerCase(Build.MODEL).contains("fold")
                 || Ascii.toLowerCase(Build.MODEL).contains("tablet"));
-    if (Util.SDK_INT == 33 && Ascii.toLowerCase(Build.MODEL).contains("pixel 6")) {
+    if (SDK_INT == 33 && Ascii.toLowerCase(Build.MODEL).contains("pixel 6")) {
       // Pixel 6 is usually quick, unless it's on API 33. See b/358519058.
       isHighPerformance = false;
     }
@@ -167,7 +167,7 @@ public class TranscodeSpeedTest {
                 || Ascii.toLowerCase(Build.MODEL).contains("fold")
                 || Ascii.toLowerCase(Build.MODEL).contains("tablet")));
     // Pixel 6 is usually quick, unless it's on API 33. See b/358519058.
-    assumeFalse(Util.SDK_INT == 33 && Ascii.toLowerCase(Build.MODEL).contains("pixel 6"));
+    assumeFalse(SDK_INT == 33 && Ascii.toLowerCase(Build.MODEL).contains("pixel 6"));
     AtomicInteger videoFramesSeen = new AtomicInteger(/* initialValue= */ 0);
     MediaItem mediaItem =
         MediaItem.fromUri(Uri.parse(MP4_LONG_ASSET_WITH_INCREASING_TIMESTAMPS.uri))

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TransformerMhUltraHdrTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/TransformerMhUltraHdrTest.java
@@ -17,6 +17,7 @@
 
 package androidx.media3.transformer.mh;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.test.utils.TestUtil.retrieveTrackFormat;
 import static androidx.media3.transformer.AndroidTestUtil.JPG_ULTRA_HDR_ASSET;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_ASSET_1080P_5_SECOND_HLG10;
@@ -35,7 +36,6 @@ import static com.google.common.truth.Truth.assertThat;
 import android.content.Context;
 import androidx.media3.common.C;
 import androidx.media3.common.ColorInfo;
-import androidx.media3.common.util.Util;
 import androidx.media3.transformer.Composition;
 import androidx.media3.transformer.EditedMediaItem;
 import androidx.media3.transformer.EditedMediaItemSequence;
@@ -160,7 +160,7 @@ public final class TransformerMhUltraHdrTest {
   }
 
   private void assumeDeviceSupportsUltraHdrEditing() throws JSONException, IOException {
-    if (Util.SDK_INT < 34) {
+    if (SDK_INT < 34) {
       recordTestSkipped(
           getApplicationContext(), testId, "Ultra HDR is not supported on this API level.");
       throw new AssumptionViolatedException("Ultra HDR is not supported on this API level.");

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/analysis/EncoderCapabilityAnalysisTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/analysis/EncoderCapabilityAnalysisTest.java
@@ -20,6 +20,7 @@ import static android.media.MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_CBR;
 import static android.media.MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_CBR_FD;
 import static android.media.MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_CQ;
 import static android.media.MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_VBR;
+import static android.os.Build.VERSION.SDK_INT;
 
 import android.media.CamcorderProfile;
 import android.media.MediaCodecInfo;
@@ -151,23 +152,23 @@ public class EncoderCapabilityAnalysisTest {
 
         capabilities.put(
             "max_supported_instances",
-            Util.SDK_INT >= 23 ? EncoderUtil.getMaxSupportedInstances(encoderInfo, mimeType) : -1);
+            SDK_INT >= 23 ? EncoderUtil.getMaxSupportedInstances(encoderInfo, mimeType) : -1);
 
         capabilities.put(
             "supports_qp_bounds",
-            Util.SDK_INT >= 31
+            SDK_INT >= 31
                 && EncoderUtil.isFeatureSupported(
                     encoderInfo, mimeType, MediaCodecInfo.CodecCapabilities.FEATURE_QpBounds));
 
         capabilities.put(
             "supports_hdr_editing",
-            Util.SDK_INT >= 33
+            SDK_INT >= 33
                 && EncoderUtil.isFeatureSupported(
                     encoderInfo, mimeType, MediaCodecInfo.CodecCapabilities.FEATURE_HdrEditing));
 
         capabilities.put(
             "supports_encoding_statistics",
-            Util.SDK_INT >= 33
+            SDK_INT >= 33
                 && EncoderUtil.isFeatureSupported(
                     encoderInfo,
                     mimeType,

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/analysis/SsimMapperTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/mh/analysis/SsimMapperTest.java
@@ -16,6 +16,7 @@
 package androidx.media3.transformer.mh.analysis;
 
 import static android.media.MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_VBR;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.transformer.AndroidTestUtil.MP4_REMOTE_1280W_720H_30_SECOND_HIGHMOTION;
@@ -51,7 +52,6 @@ import androidx.annotation.Nullable;
 import androidx.media3.common.Format;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MimeTypes;
-import androidx.media3.common.util.Util;
 import androidx.media3.transformer.AndroidTestUtil.AssetInfo;
 import androidx.media3.transformer.DefaultEncoderFactory;
 import androidx.media3.transformer.EditedMediaItem;
@@ -119,7 +119,7 @@ public class SsimMapperTest {
     for (AssetInfo assetInfo : INPUT_ASSETS) {
       parameterList.add(new Object[] {assetInfo, MimeTypes.VIDEO_H264});
       // TODO: b/210593256 - Test pre 24 once in-app muxing implemented.
-      if (Util.SDK_INT >= 24) {
+      if (SDK_INT >= 24) {
         parameterList.add(new Object[] {assetInfo, MimeTypes.VIDEO_H265});
       }
     }

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultAssetLoaderFactory.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultAssetLoaderFactory.java
@@ -16,6 +16,7 @@
 
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.transformer.TransformerUtil.isImage;
 
@@ -31,7 +32,6 @@ import androidx.media3.common.util.BitmapLoader;
 import androidx.media3.common.util.Clock;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.datasource.DataSourceBitmapLoader;
 import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.exoplayer.source.MediaSource;
@@ -92,7 +92,7 @@ public final class DefaultAssetLoaderFactory implements AssetLoader.Factory {
     this.trackSelectorFactory = null;
     this.logSessionId = logSessionId;
     @Nullable BitmapFactory.Options options = null;
-    if (Util.SDK_INT >= 26) {
+    if (SDK_INT >= 26) {
       options = new BitmapFactory.Options();
       options.inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB);
     }

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultCodec.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultCodec.java
@@ -16,11 +16,11 @@
 
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.Assertions.checkStateNotNull;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static androidx.media3.effect.DebugTraceUtil.EVENT_ACCEPTED_INPUT;
 import static androidx.media3.effect.DebugTraceUtil.EVENT_INPUT_ENDED;
 import static androidx.media3.effect.DebugTraceUtil.EVENT_INPUT_FORMAT;

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultDecoderFactory.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultDecoderFactory.java
@@ -16,9 +16,9 @@
 
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.MediaFormatUtil.createMediaFormatFromFormat;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static java.lang.Math.max;
 
 import android.annotation.SuppressLint;

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultEncoderFactory.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/DefaultEncoderFactory.java
@@ -16,13 +16,13 @@
 
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.ColorInfo.isTransferHdr;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.Assertions.checkStateNotNull;
 import static androidx.media3.common.util.MediaFormatUtil.createMediaFormatFromFormat;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static androidx.media3.transformer.EncoderUtil.getCodecProfilesForHdrFormat;
 import static java.lang.Math.abs;
 import static java.lang.Math.floor;
@@ -42,7 +42,6 @@ import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.ArrayList;
@@ -318,7 +317,7 @@ public final class DefaultEncoderFactory implements Codec.EncoderFactory {
 
     if (supportedVideoEncoderSettings.profile != VideoEncoderSettings.NO_VALUE
         && supportedVideoEncoderSettings.level != VideoEncoderSettings.NO_VALUE
-        && Util.SDK_INT >= 24) {
+        && SDK_INT >= 24) {
       // For API levels below 24, setting profile and level can lead to failures in MediaCodec
       // configuration. The encoder selects the profile/level when we don't set them.
       // Set profile and level at the same time to maximize compatibility, or the encoder will pick
@@ -335,7 +334,7 @@ public final class DefaultEncoderFactory implements Codec.EncoderFactory {
       adjustMediaFormatForH264EncoderSettings(format.colorInfo, encoderInfo, mediaFormat);
     }
 
-    if (Util.SDK_INT >= 31 && ColorInfo.isTransferHdr(format.colorInfo)) {
+    if (SDK_INT >= 31 && ColorInfo.isTransferHdr(format.colorInfo)) {
       // TODO: b/260389841 - Validate the picked encoder supports HDR editing.
       if (EncoderUtil.getSupportedColorFormats(encoderInfo, mimeType)
           .contains(MediaCodecInfo.CodecCapabilities.COLOR_Format32bitABGR2101010)) {
@@ -352,7 +351,7 @@ public final class DefaultEncoderFactory implements Codec.EncoderFactory {
     }
 
     // Float I-frame intervals are only supported from API 25.
-    if (Util.SDK_INT >= 25) {
+    if (SDK_INT >= 25) {
       mediaFormat.setFloat(
           MediaFormat.KEY_I_FRAME_INTERVAL, supportedVideoEncoderSettings.iFrameIntervalSeconds);
     } else {
@@ -368,7 +367,7 @@ public final class DefaultEncoderFactory implements Codec.EncoderFactory {
     int operatingRate = supportedVideoEncoderSettings.operatingRate;
     int priority = supportedVideoEncoderSettings.priority;
     // Setting operating rate and priority is supported from API 23.
-    if (Util.SDK_INT >= 23) {
+    if (SDK_INT >= 23) {
       if (operatingRate == VideoEncoderSettings.NO_VALUE
           && priority == VideoEncoderSettings.NO_VALUE) {
         adjustMediaFormatForEncoderPerformanceSettings(mediaFormat);
@@ -389,7 +388,7 @@ public final class DefaultEncoderFactory implements Codec.EncoderFactory {
           MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, repeatPreviousFrameIntervalUs);
     }
 
-    if (Util.SDK_INT >= 35) {
+    if (SDK_INT >= 35) {
       mediaFormat.setInteger(MediaFormat.KEY_IMPORTANCE, max(0, -codecPriority));
       if (logSessionId != null) {
         TransformerUtil.Api35.setLogSessionIdToMediaCodecFormat(mediaFormat, logSessionId);
@@ -562,7 +561,7 @@ public final class DefaultEncoderFactory implements Codec.EncoderFactory {
    */
   private static ImmutableList<MediaCodecInfo> filterEncodersByHdrEditingSupport(
       List<MediaCodecInfo> encoders, String mimeType, @Nullable ColorInfo colorInfo) {
-    if (Util.SDK_INT < 33 || !ColorInfo.isTransferHdr(colorInfo)) {
+    if (SDK_INT < 33 || !ColorInfo.isTransferHdr(colorInfo)) {
       return ImmutableList.copyOf(encoders);
     }
     return filterEncoders(
@@ -641,14 +640,14 @@ public final class DefaultEncoderFactory implements Codec.EncoderFactory {
    * <p>The adjustment is applied in-place to {@code mediaFormat}.
    */
   private static void adjustMediaFormatForEncoderPerformanceSettings(MediaFormat mediaFormat) {
-    if (Util.SDK_INT < 25) {
+    if (SDK_INT < 25) {
       // Not setting priority and operating rate achieves better encoding performance.
       return;
     }
 
     mediaFormat.setInteger(MediaFormat.KEY_PRIORITY, PRIORITY_BEST_EFFORT);
 
-    if (Util.SDK_INT == 26) {
+    if (SDK_INT == 26) {
       mediaFormat.setInteger(MediaFormat.KEY_OPERATING_RATE, DEFAULT_FRAME_RATE);
     } else if (deviceNeedsLowerOperatingRateAvoidingOverflowWorkaround()) {
       mediaFormat.setInteger(MediaFormat.KEY_OPERATING_RATE, 1000);
@@ -662,8 +661,8 @@ public final class DefaultEncoderFactory implements Codec.EncoderFactory {
     // encoder to throw at configuration time. Setting the operating rate to 1000 avoids being close
     // to an integer overflow limit while being higher than a maximum feasible operating rate. See
     // [internal b/311206113, b/317297946, b/312299527].
-    return Util.SDK_INT >= 31
-        && Util.SDK_INT <= 34
+    return SDK_INT >= 31
+        && SDK_INT <= 34
         && (Build.SOC_MODEL.equals("SM8550")
             || Build.SOC_MODEL.equals("SM7450")
             || Build.SOC_MODEL.equals("SM6450")
@@ -686,7 +685,7 @@ public final class DefaultEncoderFactory implements Codec.EncoderFactory {
     // TODO: b/210593256 - Remove overriding profile/level (before API 29) after switching to in-app
     //  muxing.
     String mimeType = MimeTypes.VIDEO_H264;
-    if (Util.SDK_INT >= 29) {
+    if (SDK_INT >= 29) {
       int expectedEncodingProfile = MediaCodecInfo.CodecProfileLevel.AVCProfileHigh;
       if (colorInfo != null) {
         int colorTransfer = colorInfo.colorTransfer;
@@ -708,7 +707,7 @@ public final class DefaultEncoderFactory implements Codec.EncoderFactory {
           mediaFormat.setInteger(MediaFormat.KEY_LEVEL, supportedEncodingLevel);
         }
       }
-    } else if (Util.SDK_INT >= 26 && !deviceNeedsNoH264HighProfileWorkaround()) {
+    } else if (SDK_INT >= 26 && !deviceNeedsNoH264HighProfileWorkaround()) {
       int expectedEncodingProfile = MediaCodecInfo.CodecProfileLevel.AVCProfileHigh;
       int supportedEncodingLevel =
           EncoderUtil.findHighestSupportedEncodingLevel(
@@ -725,7 +724,7 @@ public final class DefaultEncoderFactory implements Codec.EncoderFactory {
         //  is the default and it supports B-frames.
         mediaFormat.setInteger(MediaFormat.KEY_LATENCY, 1);
       }
-    } else if (Util.SDK_INT >= 24) {
+    } else if (SDK_INT >= 24) {
       int expectedEncodingProfile = MediaCodecInfo.CodecProfileLevel.AVCProfileBaseline;
       int supportedLevel =
           EncoderUtil.findHighestSupportedEncodingLevel(
@@ -843,7 +842,6 @@ public final class DefaultEncoderFactory implements Codec.EncoderFactory {
     // The H.264/AVC encoder produces B-frames when high profile is chosen despite configuration to
     // turn them off, so force not using high profile on these devices (see b/306617392).
     // TODO: b/229420356 - Remove once the in-app muxer is the default and B-frames are supported.
-    return Util.SDK_INT == 27
-        && (Build.DEVICE.equals("ASUS_X00T_3") || Build.DEVICE.equals("TC77"));
+    return SDK_INT == 27 && (Build.DEVICE.equals("ASUS_X00T_3") || Build.DEVICE.equals("TC77"));
   }
 }

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/EncoderUtil.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/EncoderUtil.java
@@ -16,6 +16,7 @@
 
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static java.lang.Math.floor;
 import static java.lang.Math.max;
@@ -38,7 +39,6 @@ import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import com.google.common.base.Ascii;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
@@ -84,7 +84,7 @@ public final class EncoderUtil {
    */
   public static ImmutableList<MediaCodecInfo> getSupportedEncodersForHdrEditing(
       String mimeType, @Nullable ColorInfo colorInfo) {
-    if (Util.SDK_INT < 33 || colorInfo == null) {
+    if (SDK_INT < 33 || colorInfo == null) {
       return ImmutableList.of();
     }
 
@@ -123,7 +123,7 @@ public final class EncoderUtil {
           isFeatureSupported(
                   mediaCodecInfo, mimeType, MediaCodecInfo.CodecCapabilities.FEATURE_HdrEditing)
               || (colorInfo.colorTransfer == C.COLOR_TRANSFER_HLG
-                  && Util.SDK_INT >= 35
+                  && SDK_INT >= 35
                   && isFeatureSupported(
                       mediaCodecInfo,
                       mimeType,
@@ -406,7 +406,7 @@ public final class EncoderUtil {
   /** Checks if a {@linkplain MediaCodecInfo codec} is hardware-accelerated. */
   public static boolean isHardwareAccelerated(MediaCodecInfo encoderInfo, String mimeType) {
     // TODO: b/214964116 - Merge into MediaCodecUtil.
-    if (Util.SDK_INT >= 29) {
+    if (SDK_INT >= 29) {
       return Api29.isHardwareAccelerated(encoderInfo);
     }
     // codecInfo.isHardwareAccelerated() == !codecInfo.isSoftwareOnly() is not necessarily true.
@@ -427,7 +427,7 @@ public final class EncoderUtil {
   }
 
   private static boolean isSoftwareOnly(MediaCodecInfo encoderInfo, String mimeType) {
-    if (Util.SDK_INT >= 29) {
+    if (SDK_INT >= 29) {
       return Api29.isSoftwareOnly(encoderInfo);
     }
 

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/ExperimentalFrameExtractor.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/ExperimentalFrameExtractor.java
@@ -19,6 +19,7 @@ package androidx.media3.transformer;
 import static android.graphics.Bitmap.Config.ARGB_8888;
 import static android.graphics.Bitmap.Config.RGBA_1010102;
 import static android.graphics.ColorSpace.Named.BT2020_HLG;
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.C.COLOR_TRANSFER_HLG;
 import static androidx.media3.common.ColorInfo.SDR_BT709_LIMITED;
 import static androidx.media3.common.ColorInfo.isTransferHdr;
@@ -28,7 +29,6 @@ import static androidx.media3.common.PlaybackException.ERROR_CODE_SETUP_REQUIRED
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.GlUtil.createRgb10A2Texture;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static androidx.media3.common.util.Util.usToMs;
 import static com.google.common.util.concurrent.Futures.immediateCancelledFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/FrameworkMuxer.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/FrameworkMuxer.java
@@ -15,10 +15,10 @@
  */
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.CodecSpecificDataUtil.getCodecProfileAndLevel;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static androidx.media3.common.util.Util.castNonNull;
 import static java.lang.Integer.max;
 
@@ -183,7 +183,7 @@ import java.util.Locale;
       return;
     }
     if (!isStarted) {
-      if (Util.SDK_INT < 30 && presentationTimeUs < 0) {
+      if (SDK_INT < 30 && presentationTimeUs < 0) {
         trackIdToPresentationTimeOffsetUs.put(trackId, -presentationTimeUs);
       }
       startMuxer();
@@ -199,7 +199,7 @@ import java.util.Locale;
             : 0;
     // writeSampleData blocks on old API versions, so check here to avoid calling the method.
     checkState(
-        Util.SDK_INT > 24 || presentationTimeUs >= lastSamplePresentationTimeUs,
+        SDK_INT > 24 || presentationTimeUs >= lastSamplePresentationTimeUs,
         "Samples not in presentation order ("
             + presentationTimeUs
             + " < "

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/ImageAssetLoader.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/ImageAssetLoader.java
@@ -16,6 +16,7 @@
 
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.transformer.ExportException.ERROR_CODE_IO_UNSPECIFIED;
@@ -40,7 +41,6 @@ import androidx.media3.common.ParserException;
 import androidx.media3.common.util.BitmapLoader;
 import androidx.media3.common.util.ConstantRateTimestampIterator;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.transformer.SampleConsumer.InputResult;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.FutureCallback;
@@ -158,7 +158,7 @@ public final class ImageAssetLoader implements AssetLoader {
                     .setColorInfo(ColorInfo.SRGB_BT709_FULL)
                     .build();
             Format outputFormat =
-                retainHdrFromUltraHdrImage && Util.SDK_INT >= 34 && bitmap.hasGainmap()
+                retainHdrFromUltraHdrImage && SDK_INT >= 34 && bitmap.hasGainmap()
                     ? inputFormat.buildUpon().setSampleMimeType(MimeTypes.IMAGE_JPEG_R).build()
                     : inputFormat;
             try {

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/SequenceRenderersFactory.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/SequenceRenderersFactory.java
@@ -15,13 +15,13 @@
  */
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED;
 import static androidx.media3.common.PlaybackException.ERROR_CODE_VIDEO_FRAME_PROCESSING_FAILED;
 import static androidx.media3.common.PlaybackException.ERROR_CODE_VIDEO_FRAME_PROCESSOR_INIT_FAILED;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.Assertions.checkStateNotNull;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static androidx.media3.exoplayer.DefaultRenderersFactory.DEFAULT_ALLOWED_VIDEO_JOINING_TIME_MS;
 import static androidx.media3.exoplayer.DefaultRenderersFactory.MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY;
 import static androidx.media3.exoplayer.video.VideoSink.RELEASE_FIRST_FRAME_IMMEDIATELY;

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/Transformer.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/Transformer.java
@@ -16,10 +16,10 @@
 
 package androidx.media3.transformer;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.util.Assertions.checkArgument;
 import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
-import static androidx.media3.common.util.Util.SDK_INT;
 import static androidx.media3.common.util.Util.isRunningOnEmulator;
 import static androidx.media3.extractor.AacUtil.AAC_LC_AUDIO_SAMPLE_COUNT;
 import static androidx.media3.transformer.ExportException.ERROR_CODE_MUXING_APPEND;

--- a/libraries/ui/src/main/java/androidx/media3/ui/DefaultTimeBar.java
+++ b/libraries/ui/src/main/java/androidx/media3/ui/DefaultTimeBar.java
@@ -15,6 +15,8 @@
  */
 package androidx.media3.ui;
 
+import static android.os.Build.VERSION.SDK_INT;
+
 import android.animation.ValueAnimator;
 import android.content.Context;
 import android.content.res.Resources;
@@ -732,7 +734,7 @@ public class DefaultTimeBar extends View implements TimeBar {
         progressBarY,
         seekBounds.right - scrubberPadding,
         progressBarY + barHeight);
-    if (Util.SDK_INT >= 29) {
+    if (SDK_INT >= 29) {
       setSystemGestureExclusionRectsV29(width, height);
     }
     update();
@@ -983,11 +985,11 @@ public class DefaultTimeBar extends View implements TimeBar {
   }
 
   private boolean setDrawableLayoutDirection(Drawable drawable) {
-    return Util.SDK_INT >= 23 && setDrawableLayoutDirection(drawable, getLayoutDirection());
+    return SDK_INT >= 23 && setDrawableLayoutDirection(drawable, getLayoutDirection());
   }
 
   private static boolean setDrawableLayoutDirection(Drawable drawable, int layoutDirection) {
-    return Util.SDK_INT >= 23 && drawable.setLayoutDirection(layoutDirection);
+    return SDK_INT >= 23 && drawable.setLayoutDirection(layoutDirection);
   }
 
   private static int dpToPx(float density, int dps) {

--- a/libraries/ui/src/main/java/androidx/media3/ui/PlayerControlView.java
+++ b/libraries/ui/src/main/java/androidx/media3/ui/PlayerControlView.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.ui;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.Player.COMMAND_GET_CURRENT_MEDIA_ITEM;
 import static androidx.media3.common.Player.COMMAND_GET_TIMELINE;
 import static androidx.media3.common.Player.COMMAND_GET_TRACKS;
@@ -745,7 +746,7 @@ public class PlayerControlView extends FrameLayout {
     settingsView.setLayoutManager(new LinearLayoutManager(getContext()));
     settingsWindow =
         new PopupWindow(settingsView, LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT, true);
-    if (Util.SDK_INT < 23) {
+    if (SDK_INT < 23) {
       // Work around issue where tapping outside of the menu area or pressing the back button
       // doesn't dismiss the menu as expected. See: https://github.com/google/ExoPlayer/issues/8272.
       settingsWindow.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
@@ -2015,7 +2016,7 @@ public class PlayerControlView extends FrameLayout {
 
     public SettingViewHolder(View itemView) {
       super(itemView);
-      if (Util.SDK_INT < 26) {
+      if (SDK_INT < 26) {
         // Workaround for https://github.com/google/ExoPlayer/issues/9061.
         itemView.setFocusable(true);
       }
@@ -2326,7 +2327,7 @@ public class PlayerControlView extends FrameLayout {
 
     public SubSettingViewHolder(View itemView) {
       super(itemView);
-      if (Util.SDK_INT < 26) {
+      if (SDK_INT < 26) {
         // Workaround for https://github.com/google/ExoPlayer/issues/9061.
         itemView.setFocusable(true);
       }

--- a/libraries/ui/src/main/java/androidx/media3/ui/PlayerNotificationManager.java
+++ b/libraries/ui/src/main/java/androidx/media3/ui/PlayerNotificationManager.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.ui;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.Player.COMMAND_CHANGE_MEDIA_ITEMS;
 import static androidx.media3.common.Player.COMMAND_GET_CURRENT_MEDIA_ITEM;
 import static androidx.media3.common.Player.COMMAND_GET_TIMELINE;
@@ -1520,7 +1521,7 @@ public class PlayerNotificationManager {
     intent.putExtra(EXTRA_INSTANCE_ID, instanceId);
 
     int pendingFlags;
-    if (Util.SDK_INT >= 23) {
+    if (SDK_INT >= 23) {
       pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
     } else {
       pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT;

--- a/libraries/ui/src/main/java/androidx/media3/ui/PlayerView.java
+++ b/libraries/ui/src/main/java/androidx/media3/ui/PlayerView.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.ui;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.common.Player.COMMAND_GET_CURRENT_MEDIA_ITEM;
 import static androidx.media3.common.Player.COMMAND_GET_METADATA;
 import static androidx.media3.common.Player.COMMAND_GET_TEXT;
@@ -72,7 +73,6 @@ import androidx.media3.common.text.CueGroup;
 import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.RepeatModeUtil;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import androidx.media3.ui.AspectRatioFrameLayout.ResizeMode;
 import com.google.common.collect.ImmutableList;
 import java.lang.annotation.Documented;
@@ -373,7 +373,7 @@ public class PlayerView extends FrameLayout implements AdViewProvider {
       setImageOutputMethod = null;
       imageOutput = null;
       ImageView logo = new ImageView(context);
-      if (Util.SDK_INT >= 23) {
+      if (SDK_INT >= 23) {
         configureEditModeLogoV23(context, getResources(), logo);
       } else {
         configureEditModeLogo(context, getResources(), logo);
@@ -484,7 +484,7 @@ public class PlayerView extends FrameLayout implements AdViewProvider {
           break;
         default:
           SurfaceView view = new SurfaceView(context);
-          if (Util.SDK_INT >= 34) {
+          if (SDK_INT >= 34) {
             Api34.setSurfaceLifecycleToFollowsAttachment(view);
           }
           surfaceView = view;
@@ -501,7 +501,7 @@ public class PlayerView extends FrameLayout implements AdViewProvider {
       surfaceView = null;
     }
     this.surfaceViewIgnoresVideoAspectRatio = surfaceViewIgnoresVideoAspectRatio;
-    this.surfaceSyncGroupV34 = Util.SDK_INT == 34 ? new SurfaceSyncGroupCompatV34() : null;
+    this.surfaceSyncGroupV34 = SDK_INT == 34 ? new SurfaceSyncGroupCompatV34() : null;
 
     // Ad overlay frame layout.
     adOverlayFrameLayout = findViewById(R.id.exo_ad_overlay);
@@ -1795,7 +1795,7 @@ public class PlayerView extends FrameLayout implements AdViewProvider {
   @Override
   protected void dispatchDraw(Canvas canvas) {
     super.dispatchDraw(canvas);
-    if (Util.SDK_INT == 34 && surfaceSyncGroupV34 != null && enableComposeSurfaceSyncWorkaround) {
+    if (SDK_INT == 34 && surfaceSyncGroupV34 != null && enableComposeSurfaceSyncWorkaround) {
       surfaceSyncGroupV34.maybeMarkSyncReadyAndClear();
     }
   }
@@ -1867,7 +1867,7 @@ public class PlayerView extends FrameLayout implements AdViewProvider {
 
     @Override
     public void onSurfaceSizeChanged(int width, int height) {
-      if (Util.SDK_INT == 34
+      if (SDK_INT == 34
           && surfaceView instanceof SurfaceView
           && enableComposeSurfaceSyncWorkaround) {
         // Register a SurfaceSyncGroup to work around https://github.com/androidx/media/issues/1237

--- a/libraries/ui/src/test/java/androidx/media3/ui/WearUnsuitableOutputPlaybackSuppressionResolverListenerTest.java
+++ b/libraries/ui/src/test/java/androidx/media3/ui/WearUnsuitableOutputPlaybackSuppressionResolverListenerTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.ui;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static androidx.media3.test.utils.robolectric.TestPlayerRunHelper.advance;
 import static androidx.media3.test.utils.robolectric.TestPlayerRunHelper.runUntilPlayWhenReady;
 import static androidx.media3.test.utils.robolectric.TestPlayerRunHelper.runUntilPlaybackState;
@@ -38,7 +39,6 @@ import androidx.media3.common.FlagSet;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.Player;
 import androidx.media3.common.Player.PlayWhenReadyChangeReason;
-import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.ExoPlayer;
 import androidx.media3.test.utils.FakeClock;
 import androidx.media3.test.utils.FakeSuitableOutputChecker;
@@ -89,7 +89,7 @@ public class WearUnsuitableOutputPlaybackSuppressionResolverListenerTest {
     TestExoPlayerBuilder builder =
         new TestExoPlayerBuilder(ApplicationProvider.getApplicationContext())
             .setSuppressPlaybackOnUnsuitableOutput(true);
-    if (Util.SDK_INT >= 35) {
+    if (SDK_INT >= 35) {
       suitableMediaOutputChecker =
           new FakeSuitableOutputChecker.Builder()
               .setIsSuitableExternalOutputAvailable(/* isSuitableOutputAvailable= */ false)


### PR DESCRIPTION
`Util.SDK_INT` was introduced to be able to simulate any SDK version during tests. This is possible by using Robolectric's `@Config(sdk)` annotation.
All usages of `Util.SDK_INT` have been replaced by `Build.VERSION.SDK_INT`.

This is a similar change to what was done in #2107.