### PR TITLE
[LL-HLS] Prevent excessive reloads when `CAN-BLOCK-RELOAD=YES` is not respected

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -49,6 +49,9 @@
     *   Fix bug where track selection changes after loading low-latency parts
         and preload hints can cause playback to get stuck or freeze
         ([#2299](https://github.com/androidx/media/issues/2299)).
+    *   Prevent excessive reloads by waiting for half the target duration
+        when `CAN-BLOCK-RELOAD=YES` is not honored by the server
+        ([#2317](https://github.com/androidx/media/pull/2317)).
 *   DASH extension:
     *   Fix issue where trick-play adaptation set is merged with its main
         adaptation set to form an invalid `TrackGroup`

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/DefaultHlsPlaylistTracker.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/DefaultHlsPlaylistTracker.java
@@ -853,13 +853,14 @@ public final class DefaultHlsPlaylistTracker
             playlistSnapshot != oldPlaylist
                 ? playlistSnapshot.targetDurationUs
                 : (playlistSnapshot.targetDurationUs / 2);
-      } else if (
-          playlistSnapshot == oldPlaylist && playlistSnapshot.partTargetDurationUs != C.TIME_UNSET
-      ) {
+      } else if (playlistSnapshot == oldPlaylist) {
         // To prevent infinite requests when the server responds with CAN-BLOCK-RELOAD=YES but does
-        // not actually block until the playlist updates, wait for half the part target duration
-        // before retrying.
-        durationUntilNextLoadUs = playlistSnapshot.partTargetDurationUs / 2;
+        // not actually block until the playlist updates, wait for half the target duration before
+        // retrying.
+        durationUntilNextLoadUs =
+            playlistSnapshot.partTargetDurationUs != C.TIME_UNSET
+                ? playlistSnapshot.partTargetDurationUs / 2
+                : playlistSnapshot.targetDurationUs / 2;
       }
       earliestNextLoadTimeMs =
           currentTimeMs + Util.usToMs(durationUntilNextLoadUs) - loadEventInfo.loadDurationMs;

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/DefaultHlsPlaylistTracker.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/DefaultHlsPlaylistTracker.java
@@ -853,6 +853,13 @@ public final class DefaultHlsPlaylistTracker
             playlistSnapshot != oldPlaylist
                 ? playlistSnapshot.targetDurationUs
                 : (playlistSnapshot.targetDurationUs / 2);
+      } else if (
+          playlistSnapshot == oldPlaylist && playlistSnapshot.partTargetDurationUs != C.TIME_UNSET
+      ) {
+        // To prevent infinite requests when the server responds with CAN-BLOCK-RELOAD=YES but does
+        // not actually block until the playlist updates, wait for half the part target duration
+        // before retrying.
+        durationUntilNextLoadUs = playlistSnapshot.partTargetDurationUs / 2;
       }
       earliestNextLoadTimeMs =
           currentTimeMs + Util.usToMs(durationUntilNextLoadUs) - loadEventInfo.loadDurationMs;


### PR DESCRIPTION
In low-latency HLS playback, some servers may respond with `CAN-BLOCK-RELOAD=YES` but return the playlist before it has actually been updated. This can lead to repeated calls to `loadPlaylistImmediately()` until a new playlist version becomes available.

Although this server behavior is not ideal, the client should still avoid unnecessary polling and redundant requests. This pull request introduces a short wait duration before allowing the next load attempt in such cases, reducing excessive reloads.

The existing behavior—where playlist loading blocks until an update is available—is preserved when the server correctly delays its response, as the logic checks `playlistSnapshot == oldPlaylist` before deferring the next attempt.