### PR TITLE
Allow `CmcdConfiguration.Factory` to return `null` to disable CMCD

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/CmcdConfiguration.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/CmcdConfiguration.java
@@ -127,8 +127,9 @@ public final class CmcdConfiguration {
      * Creates a {@link CmcdConfiguration} based on the provided {@link MediaItem}.
      *
      * @param mediaItem The {@link MediaItem} from which to create the CMCD configuration.
-     * @return A {@link CmcdConfiguration} instance.
+     * @return A {@link CmcdConfiguration} instance, or {@code null} to disable CMCD.
      */
+    @Nullable
     CmcdConfiguration createCmcdConfiguration(MediaItem mediaItem);
 
     /**

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/CmcdConfigurationTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/CmcdConfigurationTest.java
@@ -18,6 +18,7 @@ package androidx.media3.exoplayer.upstream;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.media3.common.MediaItem;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -133,5 +134,18 @@ public class CmcdConfigurationTest {
             cmcdConfiguration.requestConfig.getRequestedMaximumThroughputKbps(
                 /* throughputKbps= */ 100))
         .isEqualTo(200);
+  }
+
+  @Test
+  public void customFactory_returnsNull() {
+    CmcdConfiguration.Factory cmcdConfigurationFactory =
+        mediaItem -> null;
+    MediaItem mediaItem = new MediaItem.Builder().setMediaId(TEST_MEDIA_ID).build();
+
+    @Nullable
+    CmcdConfiguration cmcdConfiguration =
+        cmcdConfigurationFactory.createCmcdConfiguration(mediaItem);
+
+    assertThat(cmcdConfiguration).isNull();
   }
 }

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaSource.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaSource.java
@@ -113,7 +113,7 @@ public final class DashMediaSource extends BaseMediaSource {
     private final DashChunkSource.Factory chunkSourceFactory;
     @Nullable private final DataSource.Factory manifestDataSourceFactory;
 
-    private CmcdConfiguration.Factory cmcdConfigurationFactory;
+    @Nullable private CmcdConfiguration.Factory cmcdConfigurationFactory;
     private DrmSessionManagerProvider drmSessionManagerProvider;
     private CompositeSequenceableLoaderFactory compositeSequenceableLoaderFactory;
     private LoadErrorHandlingPolicy loadErrorHandlingPolicy;


### PR DESCRIPTION
We would like to enable or disable CMCD selectively for specific `MediaItem`s, while still using the same `MediaSource.Factory` instance. This already works today by returning `null` from `CmcdConfiguration.Factory.createCmcdConfiguration()`, however this behavior is not specified anywhere.

This PR updates the return type of `createCmcdConfiguration()` to be `@Nullable`, so this existing behavior is properly specified and better supported for Kotlin users.

We've considered a few alternative solutions, but we ultimately think allowing `null` is the most straightforward solution:
* Return a "dummy" `CmcdConfiguration` that doesn't report any CMCD keys. This is possible by passing a `requestConfig` to the `CmcdConfiguration` constructor whose `isKeyAllowed()` method always returns `false`. However, it's not very efficient to have ExoPlayer do all of the work of setting up a `CmcdData.Factory` and creating `CmcdData` objects and then to never actually use them.
* Make `MediaSource.Factory.setCmcdConfigurationFactory()` accept `null`, so you can revert it back to its initial state (with no CMCD configuration factory). However, none of the other methods on `MediaSource.Factory` accept `null`, so this would feel a bit out of place.
* Avoid using `MediaSource.Factory` at all, and instead manually create `MediaSource`s. We would then need to call `ExoPlayer.setMediaSource()` instead of `ExoPlayer.setMediaItem()`. This would work, but it would be unfortunate that we could no longer use `setMediaItem()` for our use case.

Supersedes #2183.