### PR TITLE
Fix CMCD sending `pr=0.00` even when key is not allowed

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/CmcdData.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/CmcdData.java
@@ -926,6 +926,7 @@ public final class CmcdData {
 
       /** Creates a new instance with default values. */
       public Builder() {
+        this.playbackRate = C.RATE_UNSET;
         this.customDataList = ImmutableList.of();
       }
 


### PR DESCRIPTION
We noticed that when you use a `CmcdConfiguration` whose `requestConfig` has a `isKeyAllowed()` method that always returns `false`, the resulting CMCD data would still include a `pr=0.00` key value pair.

The default value of `CmcdSession.playbackRate` is supposed to be `C.RATE_UNSET`, [as per documentation](https://github.com/androidx/media/blob/1.6.1/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/CmcdData.java#L1035-L1038). However, the `CmcdSession.Builder` constructor does not initialize its `playbackRate` field, so it has a default value of `0f` instead of `C.RATE_UNSET`. This means the `CmcdSession` always adds a `pr` key to the resulting CMCD session data, even when this is not allowed by the `CmcdConfiguration.RequestConfig`. This PR fixes that by adding a proper initializer for the `playbackRate` field.