### PR TITLE
#2426 Support updating HLS Interstitials according to the HLS spec

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -48,6 +48,8 @@
     *   Fix playlist parsing to accept `\f` (form feed) in quoted string
         attribute values
         ([#2420](https://github.com/androidx/media/issues/2420)).
+    *   Support updating interstitials with the same ID
+        ([#2427](https://github.com/androidx/media/pull/2427)).
 *   DASH extension:
 *   Smooth Streaming extension:
 *   RTSP extension:

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
@@ -613,31 +613,29 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
           clientDefinedAttributes);
     }
 
-    // If a Playlist contains two EXT-X-DATERANGE tags with the same ID
-    // attribute value, then any AttributeName that appears in both tags
-    // MUST have the same AttributeValue.  A Server MAY augment a Date Range
-    // with additional attributes by adding subsequent EXT-X-DATERANGE tags
-    // with the same ID attribute to a Playlist.  The client is responsible
-    // for consolidating the tags.  The subsequent EXT-X-DATERANGE tags can
-    // appear in a subsequent playlist update, in the case of live or event
-    // streams.
-    /** Builder for {@link Interstitial}. */
+
+    /**
+     * Builder for {@link Interstitial}.
+     *
+     * <p>See RFC 8216bis, section 4.4.5.1 for how to consolidate multiple interstitials with
+     * the same {@linkplain HlsMediaPlaylist.Interstitial#id ID}.
+     */
     public static final class Builder {
 
       private final String id;
       @Nullable private Uri assetUri;
       @Nullable private Uri assetListUri;
-      private long startDateUnixUs = C.TIME_UNSET;
-      private long endDateUnixUs = C.TIME_UNSET;
-      private long durationUs = C.TIME_UNSET;
-      private long plannedDurationUs = C.TIME_UNSET;
-      private List<@Interstitial.CueTriggerType String> cue = new ArrayList<>();
+      private long startDateUnixUs;
+      private long endDateUnixUs;
+      private long durationUs;
+      private long plannedDurationUs;
+      private List<@Interstitial.CueTriggerType String> cue;
       private boolean endOnNext;
-      private long resumeOffsetUs = C.TIME_UNSET;
-      private long playoutLimitUs = C.TIME_UNSET;
-      private List<@Interstitial.SnapType String> snapTypes = new ArrayList<>();
-      private List<@Interstitial.NavigationRestriction String> restrictions = new ArrayList<>();
-      private List<ClientDefinedAttribute> clientDefinedAttributes = new ArrayList<>();
+      private long resumeOffsetUs;
+      private long playoutLimitUs;
+      private List<@Interstitial.SnapType String> snapTypes;
+      private List<@Interstitial.NavigationRestriction String> restrictions;
+      private List<ClientDefinedAttribute> clientDefinedAttributes;
 
       /**
        * Creates the builder.
@@ -646,13 +644,25 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
        */
       public Builder(String id) {
         this.id = id;
+        this.startDateUnixUs = C.TIME_UNSET;
+        this.endDateUnixUs = C.TIME_UNSET;
+        this.durationUs = C.TIME_UNSET;
+        this.plannedDurationUs = C.TIME_UNSET;
+        this.cue = new ArrayList<>();
+        this.resumeOffsetUs = C.TIME_UNSET;
+        this.playoutLimitUs = C.TIME_UNSET;
+        this.snapTypes = new ArrayList<>();
+        this.restrictions = new ArrayList<>();
+        this.clientDefinedAttributes = new ArrayList<>();
       }
 
       /** Sets the {@code assetUri}. */
       public Builder setAssetUri(@Nullable Uri assetUri) {
-        if (assetUri == null) return this;
+        if (assetUri == null) {
+          return this;
+        }
         if (this.assetUri != null) {
-          Assertions.checkArgument(!this.assetUri.equals(assetUri),
+          checkArgument(this.assetUri.equals(assetUri),
               "Can't change assetUri from " + this.assetUri + " to " + assetUri);
         }
         this.assetUri = assetUri;
@@ -661,9 +671,11 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
 
       /** Sets the {@code assetListUri}. */
       public Builder setAssetListUri(@Nullable Uri assetListUri) {
-        if (assetListUri == null) return this;
+        if (assetListUri == null) {
+          return this;
+        }
         if (this.assetListUri != null) {
-          Assertions.checkArgument(!this.assetListUri.equals(assetListUri),
+          checkArgument(this.assetListUri.equals(assetListUri),
               "Can't change assetListUri from " + this.assetListUri + " to " + assetListUri);
         }
         this.assetListUri = assetListUri;
@@ -672,9 +684,11 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
 
       /** Sets the {@code startDateUnixUs}. */
       public Builder setStartDateUnixUs(long startDateUnixUs) {
-        if (startDateUnixUs == C.TIME_UNSET) return this;
+        if (startDateUnixUs == C.TIME_UNSET) {
+          return this;
+        }
         if (this.startDateUnixUs != C.TIME_UNSET) {
-          Assertions.checkArgument(this.startDateUnixUs != startDateUnixUs,
+          checkArgument(this.startDateUnixUs == startDateUnixUs,
               "Can't change startDateUnixUs from " + this.startDateUnixUs + " to " + startDateUnixUs);
         }
         this.startDateUnixUs = startDateUnixUs;
@@ -683,9 +697,11 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
 
       /** Sets the {@code endDateUnixUs}. */
       public Builder setEndDateUnixUs(long endDateUnixUs) {
-        if (endDateUnixUs == C.TIME_UNSET) return this;
+        if (endDateUnixUs == C.TIME_UNSET) {
+          return this;
+        }
         if (this.endDateUnixUs != C.TIME_UNSET) {
-          Assertions.checkArgument(this.endDateUnixUs != endDateUnixUs,
+          checkArgument(this.endDateUnixUs == endDateUnixUs,
               "Can't change endDateUnixUs from " + this.endDateUnixUs + " to " + endDateUnixUs);
         }
         this.endDateUnixUs = endDateUnixUs;
@@ -694,9 +710,11 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
 
       /** Sets the {@code durationUs}. */
       public Builder setDurationUs(long durationUs) {
-        if (durationUs == C.TIME_UNSET) return this;
+        if (durationUs == C.TIME_UNSET) {
+          return this;
+        }
         if (this.durationUs != C.TIME_UNSET) {
-          Assertions.checkArgument(this.durationUs != durationUs,
+          checkArgument(this.durationUs == durationUs,
               "Can't change durationUs from " + this.durationUs + " to " + durationUs);
         }
         this.durationUs = durationUs;
@@ -705,9 +723,11 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
 
       /** Sets the {@code plannedDurationUs}. */
       public Builder setPlannedDurationUs(long plannedDurationUs) {
-        if (plannedDurationUs == C.TIME_UNSET) return this;
+        if (plannedDurationUs == C.TIME_UNSET) {
+          return this;
+        }
         if (this.plannedDurationUs != C.TIME_UNSET) {
-          Assertions.checkArgument(this.plannedDurationUs != plannedDurationUs,
+          checkArgument(this.plannedDurationUs == plannedDurationUs,
               "Can't change plannedDurationUs from " + this.plannedDurationUs + " to " + plannedDurationUs);
         }
         this.plannedDurationUs = plannedDurationUs;
@@ -716,9 +736,11 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
 
       /** Sets the trigger {@code cue} types. */
       public Builder setCue(List<@Interstitial.CueTriggerType String> cue) {
-        if (cue.isEmpty()) return this;
+        if (cue.isEmpty()) {
+          return this;
+        }
         if (!this.cue.isEmpty()) {
-          Assertions.checkArgument(!this.cue.equals(cue),
+          checkArgument(this.cue.equals(cue),
               "Can't change cue from " + String.join(", ", this.cue) + " to " + String.join(", ", cue));
         }
         this.cue = cue;
@@ -727,16 +749,20 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
 
       /** Sets whether the interstitial {@code endOnNext}. */
       public Builder setEndOnNext(boolean endOnNext) {
-        if (!endOnNext) return this;
+        if (!endOnNext) {
+          return this;
+        }
         this.endOnNext = endOnNext;
         return this;
       }
 
       /** Sets the {@code resumeOffsetUs}. */
       public Builder setResumeOffsetUs(long resumeOffsetUs) {
-        if (resumeOffsetUs == C.TIME_UNSET) return this;
+        if (resumeOffsetUs == C.TIME_UNSET) {
+          return this;
+        }
         if (this.resumeOffsetUs != C.TIME_UNSET) {
-          Assertions.checkArgument(this.resumeOffsetUs != resumeOffsetUs,
+          checkArgument(this.resumeOffsetUs == resumeOffsetUs,
               "Can't change resumeOffsetUs from " + this.resumeOffsetUs + " to " + resumeOffsetUs);
         }
         this.resumeOffsetUs = resumeOffsetUs;
@@ -745,9 +771,11 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
 
       /** Sets the {@code playoutLimitUs}. */
       public Builder setPlayoutLimitUs(long playoutLimitUs) {
-        if (playoutLimitUs == C.TIME_UNSET) return this;
+        if (playoutLimitUs == C.TIME_UNSET) {
+          return this;
+        }
         if (this.playoutLimitUs != C.TIME_UNSET) {
-          Assertions.checkArgument(this.playoutLimitUs != playoutLimitUs,
+          checkArgument(this.playoutLimitUs == playoutLimitUs,
               "Can't change playoutLimitUs from " + this.playoutLimitUs + " to " + playoutLimitUs);
         }
         this.playoutLimitUs = playoutLimitUs;
@@ -756,9 +784,11 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
 
       /** Sets the {@code snapTypes}. */
       public Builder setSnapTypes(List<@Interstitial.SnapType String> snapTypes) {
-        if (snapTypes.isEmpty()) return this;
+        if (snapTypes.isEmpty()) {
+          return this;
+        }
         if (!this.snapTypes.isEmpty()) {
-          Assertions.checkArgument(!this.snapTypes.equals(snapTypes),
+          checkArgument(this.snapTypes.equals(snapTypes),
               "Can't change snapTypes from " + String.join(", ", this.snapTypes) + " to " + String.join(", ", snapTypes));
         }
         this.snapTypes = snapTypes;
@@ -767,9 +797,11 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
 
       /** Sets the {@code NavigationRestriction}. */
       public Builder setRestrictions(List<@Interstitial.NavigationRestriction String> restrictions) {
-        if (restrictions.isEmpty()) return this;
+        if (restrictions.isEmpty()) {
+          return this;
+        }
         if (!this.restrictions.isEmpty()) {
-          Assertions.checkArgument(!this.restrictions.equals(restrictions),
+          checkArgument(this.restrictions.equals(restrictions),
               "Can't change restrictions from " + String.join(", ", this.restrictions) + " to " + String.join(", ", restrictions));
         }
         this.restrictions = restrictions;
@@ -779,9 +811,11 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       /** Sets the {@code clientDefinedAttributes}. */
       public Builder setClientDefinedAttributes(
           List<HlsMediaPlaylist.ClientDefinedAttribute> clientDefinedAttributes) {
-        if (clientDefinedAttributes.isEmpty()) return this;
+        if (clientDefinedAttributes.isEmpty()) {
+          return this;
+        }
         if (!this.clientDefinedAttributes.isEmpty()) {
-          Assertions.checkArgument(!this.clientDefinedAttributes.equals(clientDefinedAttributes));
+          checkArgument(this.clientDefinedAttributes.equals(clientDefinedAttributes));
         }
         this.clientDefinedAttributes = clientDefinedAttributes;
         return this;

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
@@ -33,6 +33,7 @@ import androidx.media3.common.util.UnstableApi;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -687,6 +688,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       }
 
       /** Sets the {@code startDateUnixUs}. */
+      @CanIgnoreReturnValue
       public Builder setStartDateUnixUs(long startDateUnixUs) {
         if (startDateUnixUs == C.TIME_UNSET) {
           return this;
@@ -719,6 +721,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       }
 
       /** Sets the {@code durationUs}. */
+      @CanIgnoreReturnValue
       public Builder setDurationUs(long durationUs) {
         if (durationUs == C.TIME_UNSET) {
           return this;
@@ -733,6 +736,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       }
 
       /** Sets the {@code plannedDurationUs}. */
+      @CanIgnoreReturnValue
       public Builder setPlannedDurationUs(long plannedDurationUs) {
         if (plannedDurationUs == C.TIME_UNSET) {
           return this;
@@ -750,6 +754,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       }
 
       /** Sets the trigger {@code cue} types. */
+      @CanIgnoreReturnValue
       public Builder setCue(List<@Interstitial.CueTriggerType String> cue) {
         if (cue.isEmpty()) {
           return this;
@@ -767,6 +772,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       }
 
       /** Sets whether the interstitial {@code endOnNext}. */
+      @CanIgnoreReturnValue
       public Builder setEndOnNext(boolean endOnNext) {
         if (!endOnNext) {
           return this;
@@ -776,6 +782,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       }
 
       /** Sets the {@code resumeOffsetUs}. */
+      @CanIgnoreReturnValue
       public Builder setResumeOffsetUs(long resumeOffsetUs) {
         if (resumeOffsetUs == C.TIME_UNSET) {
           return this;
@@ -790,6 +797,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       }
 
       /** Sets the {@code playoutLimitUs}. */
+      @CanIgnoreReturnValue
       public Builder setPlayoutLimitUs(long playoutLimitUs) {
         if (playoutLimitUs == C.TIME_UNSET) {
           return this;
@@ -804,6 +812,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       }
 
       /** Sets the {@code snapTypes}. */
+      @CanIgnoreReturnValue
       public Builder setSnapTypes(List<@Interstitial.SnapType String> snapTypes) {
         if (snapTypes.isEmpty()) {
           return this;
@@ -821,6 +830,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       }
 
       /** Sets the {@code NavigationRestriction}. */
+      @CanIgnoreReturnValue
       public Builder setRestrictions(
           List<@Interstitial.NavigationRestriction String> restrictions) {
         if (restrictions.isEmpty()) {
@@ -839,6 +849,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       }
 
       /** Sets the {@code clientDefinedAttributes}. */
+      @CanIgnoreReturnValue
       public Builder setClientDefinedAttributes(
           Map<String, HlsMediaPlaylist.ClientDefinedAttribute> clientDefinedAttributes) {
         if (clientDefinedAttributes.isEmpty()) {
@@ -875,20 +886,20 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         if ((assetListUri == null && assetUri != null)
             || (assetListUri != null && assetUri == null) && startDateUnixUs != C.TIME_UNSET) {
           return new Interstitial(
-              this.id,
-              this.assetUri,
-              this.assetListUri,
-              this.startDateUnixUs,
-              this.endDateUnixUs,
-              this.durationUs,
-              this.plannedDurationUs,
-              this.cue,
-              this.endOnNext,
-              this.resumeOffsetUs,
-              this.playoutLimitUs,
-              this.snapTypes,
-              this.restrictions,
-              new ArrayList<>(this.clientDefinedAttributes.values()));
+              id,
+              assetUri,
+              assetListUri,
+              startDateUnixUs,
+              endDateUnixUs,
+              durationUs,
+              plannedDurationUs,
+              cue,
+              endOnNext,
+              resumeOffsetUs,
+              playoutLimitUs,
+              snapTypes,
+              restrictions,
+              new ArrayList<>(clientDefinedAttributes.values()));
         }
         return null;
       }

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /** Represents an HLS media playlist. */
 @UnstableApi
@@ -628,8 +629,8 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       private final String id;
       private final Map<String, ClientDefinedAttribute> clientDefinedAttributes;
 
-      @Nullable private Uri assetUri;
-      @Nullable private Uri assetListUri;
+      private @MonotonicNonNull Uri assetUri;
+      private @MonotonicNonNull Uri assetListUri;
       private long startDateUnixUs;
       private long endDateUnixUs;
       private long durationUs;
@@ -648,6 +649,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
        */
       public Builder(String id) {
         this.id = id;
+        clientDefinedAttributes = new HashMap<>();
         startDateUnixUs = C.TIME_UNSET;
         endDateUnixUs = C.TIME_UNSET;
         durationUs = C.TIME_UNSET;
@@ -657,10 +659,14 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         playoutLimitUs = C.TIME_UNSET;
         snapTypes = new ArrayList<>();
         restrictions = new ArrayList<>();
-        clientDefinedAttributes = new HashMap<>();
       }
 
-      /** Sets the {@code assetUri}. */
+      /**
+       * Sets the asset URI.
+       *
+       * @throws IllegalArgumentException if called with a non-null value that is different to the
+       *     value previously set.
+       */
       @CanIgnoreReturnValue
       public Builder setAssetUri(@Nullable Uri assetUri) {
         if (assetUri == null) {
@@ -675,7 +681,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
-      /** Sets the {@code assetListUri}. */
+      /**
+       * Sets the asset list URI.
+       *
+       * @throws IllegalArgumentException if called with a non-null value that is different to the
+       *     value previously set.
+       */
       @CanIgnoreReturnValue
       public Builder setAssetListUri(@Nullable Uri assetListUri) {
         if (assetListUri == null) {
@@ -690,7 +701,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
-      /** Sets the {@code startDateUnixUs}. */
+      /**
+       * Sets the start date as a unix epoch timestamp, in microseconds.
+       *
+       * @throws IllegalArgumentException if called with a value different to {@link C#TIME_UNSET}
+       *     and different to the value previously set.
+       */
       @CanIgnoreReturnValue
       public Builder setStartDateUnixUs(long startDateUnixUs) {
         if (startDateUnixUs == C.TIME_UNSET) {
@@ -708,7 +724,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
-      /** Sets the {@code endDateUnixUs}. */
+      /**
+       * Sets the end date as a unix epoch timestamp, in microseconds.
+       *
+       * @throws IllegalArgumentException if called with a value different to {@link C#TIME_UNSET}
+       *     and different to the value previously set.
+       */
       @CanIgnoreReturnValue
       public Builder setEndDateUnixUs(long endDateUnixUs) {
         if (endDateUnixUs == C.TIME_UNSET) {
@@ -723,7 +744,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
-      /** Sets the {@code durationUs}. */
+      /**
+       * Sets the duration, in microseconds.
+       *
+       * @throws IllegalArgumentException if called with a value different to {@link C#TIME_UNSET}
+       *     and different to the value previously set.
+       */
       @CanIgnoreReturnValue
       public Builder setDurationUs(long durationUs) {
         if (durationUs == C.TIME_UNSET) {
@@ -738,7 +764,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
-      /** Sets the {@code plannedDurationUs}. */
+      /**
+       * Sets the planned duration, in microseconds.
+       *
+       * @throws IllegalArgumentException if called with a value different to {@link C#TIME_UNSET}
+       *     and different to the value previously set.
+       */
       @CanIgnoreReturnValue
       public Builder setPlannedDurationUs(long plannedDurationUs) {
         if (plannedDurationUs == C.TIME_UNSET) {
@@ -756,7 +787,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
-      /** Sets the trigger {@code cue} types. */
+      /**
+       * Sets the {@linkplain Interstitial.CueTriggerType cue trigger types}.
+       *
+       * @throws IllegalArgumentException if called with a value different to {@link C#TIME_UNSET}
+       *     and different to the value previously set.
+       */
       @CanIgnoreReturnValue
       public Builder setCue(List<@Interstitial.CueTriggerType String> cue) {
         if (cue.isEmpty()) {
@@ -774,7 +810,11 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
-      /** Sets whether the interstitial {@code endOnNext}. */
+      /**
+       * Sets whether the interstitial ends on the start time of the next interstitial.
+       *
+       * <p>Once set to true, it can't be reset to false and doing so would be ignored.
+       */
       @CanIgnoreReturnValue
       public Builder setEndOnNext(boolean endOnNext) {
         if (!endOnNext) {
@@ -784,7 +824,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
-      /** Sets the {@code resumeOffsetUs}. */
+      /**
+       * Sets the resume offset, in microseconds.
+       *
+       * @throws IllegalArgumentException if called with a value different to {@link C#TIME_UNSET}
+       *     and different to the value previously set.
+       */
       @CanIgnoreReturnValue
       public Builder setResumeOffsetUs(long resumeOffsetUs) {
         if (resumeOffsetUs == C.TIME_UNSET) {
@@ -799,7 +844,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
-      /** Sets the {@code playoutLimitUs}. */
+      /**
+       * Sets the play out limit, in microseconds.
+       *
+       * @throws IllegalArgumentException if called with a value different to {@link C#TIME_UNSET}
+       *     and different to the value previously set.
+       */
       @CanIgnoreReturnValue
       public Builder setPlayoutLimitUs(long playoutLimitUs) {
         if (playoutLimitUs == C.TIME_UNSET) {
@@ -814,7 +864,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
-      /** Sets the {@code snapTypes}. */
+      /**
+       * Sets the {@linkplain Interstitial.SnapType snap types}.
+       *
+       * @throws IllegalArgumentException if called with a non-empty list of snap types that is not
+       *     equal to the non-empty list that was previously set.
+       */
       @CanIgnoreReturnValue
       public Builder setSnapTypes(List<@Interstitial.SnapType String> snapTypes) {
         if (snapTypes.isEmpty()) {
@@ -832,7 +887,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
-      /** Sets the {@code NavigationRestriction}. */
+      /**
+       * Sets the {@link NavigationRestriction navigation restrictions}.
+       *
+       * @throws IllegalArgumentException if called with a non-empty list of restrictions that is
+       *     not equal to the non-empty list that was previously set.
+       */
       @CanIgnoreReturnValue
       public Builder setRestrictions(
           List<@Interstitial.NavigationRestriction String> restrictions) {
@@ -851,7 +911,15 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
-      /** Sets the {@code clientDefinedAttributes}. */
+      /**
+       * Sets the {@linkplain ClientDefinedAttribute client defined attributes}.
+       *
+       * <p>Equal duplicates are ignored, new attributes are added to those already set.
+       *
+       * @throws IllegalArgumentException if called with a list containing a client defined
+       *     attribute that is not equal with an attribute previously set with the same {@linkplain
+       *     ClientDefinedAttribute#name name}.
+       */
       @CanIgnoreReturnValue
       public Builder setClientDefinedAttributes(
           List<HlsMediaPlaylist.ClientDefinedAttribute> clientDefinedAttributes) {
@@ -881,10 +949,16 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
+      /**
+       * Builds and returns a new {@link Interstitial} instance or null if validation of the
+       * properties fails. The properties are considered invalid, if the start date is missing or
+       * both asset URI and asset list URI are set at the same time.
+       */
       @Nullable
       public Interstitial build() {
         if (((assetListUri == null && assetUri != null)
-            || (assetListUri != null && assetUri == null)) && startDateUnixUs != C.TIME_UNSET) {
+                || (assetListUri != null && assetUri == null))
+            && startDateUnixUs != C.TIME_UNSET) {
           return new Interstitial(
               id,
               assetUri,

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
@@ -613,12 +613,11 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
           clientDefinedAttributes);
     }
 
-
     /**
      * Builder for {@link Interstitial}.
      *
-     * <p>See RFC 8216bis, section 4.4.5.1 for how to consolidate multiple interstitials with
-     * the same {@linkplain HlsMediaPlaylist.Interstitial#id ID}.
+     * <p>See RFC 8216bis, section 4.4.5.1 for how to consolidate multiple interstitials with the
+     * same {@linkplain HlsMediaPlaylist.Interstitial#id ID}.
      */
     public static final class Builder {
 
@@ -662,7 +661,8 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
           return this;
         }
         if (this.assetUri != null) {
-          checkArgument(this.assetUri.equals(assetUri),
+          checkArgument(
+              this.assetUri.equals(assetUri),
               "Can't change assetUri from " + this.assetUri + " to " + assetUri);
         }
         this.assetUri = assetUri;
@@ -675,7 +675,8 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
           return this;
         }
         if (this.assetListUri != null) {
-          checkArgument(this.assetListUri.equals(assetListUri),
+          checkArgument(
+              this.assetListUri.equals(assetListUri),
               "Can't change assetListUri from " + this.assetListUri + " to " + assetListUri);
         }
         this.assetListUri = assetListUri;
@@ -688,8 +689,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
           return this;
         }
         if (this.startDateUnixUs != C.TIME_UNSET) {
-          checkArgument(this.startDateUnixUs == startDateUnixUs,
-              "Can't change startDateUnixUs from " + this.startDateUnixUs + " to " + startDateUnixUs);
+          checkArgument(
+              this.startDateUnixUs == startDateUnixUs,
+              "Can't change startDateUnixUs from "
+                  + this.startDateUnixUs
+                  + " to "
+                  + startDateUnixUs);
         }
         this.startDateUnixUs = startDateUnixUs;
         return this;
@@ -701,7 +706,8 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
           return this;
         }
         if (this.endDateUnixUs != C.TIME_UNSET) {
-          checkArgument(this.endDateUnixUs == endDateUnixUs,
+          checkArgument(
+              this.endDateUnixUs == endDateUnixUs,
               "Can't change endDateUnixUs from " + this.endDateUnixUs + " to " + endDateUnixUs);
         }
         this.endDateUnixUs = endDateUnixUs;
@@ -714,7 +720,8 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
           return this;
         }
         if (this.durationUs != C.TIME_UNSET) {
-          checkArgument(this.durationUs == durationUs,
+          checkArgument(
+              this.durationUs == durationUs,
               "Can't change durationUs from " + this.durationUs + " to " + durationUs);
         }
         this.durationUs = durationUs;
@@ -727,8 +734,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
           return this;
         }
         if (this.plannedDurationUs != C.TIME_UNSET) {
-          checkArgument(this.plannedDurationUs == plannedDurationUs,
-              "Can't change plannedDurationUs from " + this.plannedDurationUs + " to " + plannedDurationUs);
+          checkArgument(
+              this.plannedDurationUs == plannedDurationUs,
+              "Can't change plannedDurationUs from "
+                  + this.plannedDurationUs
+                  + " to "
+                  + plannedDurationUs);
         }
         this.plannedDurationUs = plannedDurationUs;
         return this;
@@ -740,8 +751,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
           return this;
         }
         if (!this.cue.isEmpty()) {
-          checkArgument(this.cue.equals(cue),
-              "Can't change cue from " + String.join(", ", this.cue) + " to " + String.join(", ", cue));
+          checkArgument(
+              this.cue.equals(cue),
+              "Can't change cue from "
+                  + String.join(", ", this.cue)
+                  + " to "
+                  + String.join(", ", cue));
         }
         this.cue = cue;
         return this;
@@ -762,7 +777,8 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
           return this;
         }
         if (this.resumeOffsetUs != C.TIME_UNSET) {
-          checkArgument(this.resumeOffsetUs == resumeOffsetUs,
+          checkArgument(
+              this.resumeOffsetUs == resumeOffsetUs,
               "Can't change resumeOffsetUs from " + this.resumeOffsetUs + " to " + resumeOffsetUs);
         }
         this.resumeOffsetUs = resumeOffsetUs;
@@ -775,7 +791,8 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
           return this;
         }
         if (this.playoutLimitUs != C.TIME_UNSET) {
-          checkArgument(this.playoutLimitUs == playoutLimitUs,
+          checkArgument(
+              this.playoutLimitUs == playoutLimitUs,
               "Can't change playoutLimitUs from " + this.playoutLimitUs + " to " + playoutLimitUs);
         }
         this.playoutLimitUs = playoutLimitUs;
@@ -788,21 +805,30 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
           return this;
         }
         if (!this.snapTypes.isEmpty()) {
-          checkArgument(this.snapTypes.equals(snapTypes),
-              "Can't change snapTypes from " + String.join(", ", this.snapTypes) + " to " + String.join(", ", snapTypes));
+          checkArgument(
+              this.snapTypes.equals(snapTypes),
+              "Can't change snapTypes from "
+                  + String.join(", ", this.snapTypes)
+                  + " to "
+                  + String.join(", ", snapTypes));
         }
         this.snapTypes = snapTypes;
         return this;
       }
 
       /** Sets the {@code NavigationRestriction}. */
-      public Builder setRestrictions(List<@Interstitial.NavigationRestriction String> restrictions) {
+      public Builder setRestrictions(
+          List<@Interstitial.NavigationRestriction String> restrictions) {
         if (restrictions.isEmpty()) {
           return this;
         }
         if (!this.restrictions.isEmpty()) {
-          checkArgument(this.restrictions.equals(restrictions),
-              "Can't change restrictions from " + String.join(", ", this.restrictions) + " to " + String.join(", ", restrictions));
+          checkArgument(
+              this.restrictions.equals(restrictions),
+              "Can't change restrictions from "
+                  + String.join(", ", this.restrictions)
+                  + " to "
+                  + String.join(", ", restrictions));
         }
         this.restrictions = restrictions;
         return this;
@@ -814,17 +840,26 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         if (clientDefinedAttributes.isEmpty()) {
           return this;
         }
-        for (Map.Entry<String, HlsMediaPlaylist.ClientDefinedAttribute> newEntry : clientDefinedAttributes.entrySet()) {
+        for (Map.Entry<String, HlsMediaPlaylist.ClientDefinedAttribute> newEntry :
+            clientDefinedAttributes.entrySet()) {
           String newKey = newEntry.getKey();
           HlsMediaPlaylist.ClientDefinedAttribute newValue = newEntry.getValue();
           if (this.clientDefinedAttributes.containsKey(newKey)) {
-            HlsMediaPlaylist.ClientDefinedAttribute existingValue = this.clientDefinedAttributes.get(newKey);
+            HlsMediaPlaylist.ClientDefinedAttribute existingValue =
+                this.clientDefinedAttributes.get(newKey);
             if (existingValue != null) {
               checkArgument(
                   existingValue.equals(newValue),
-                  "Can't change " + newKey + " from "
-                      + existingValue.textValue + " " + existingValue.doubleValue + " to "
-                      + newValue.textValue + " " + newValue.doubleValue);
+                  "Can't change "
+                      + newKey
+                      + " from "
+                      + existingValue.textValue
+                      + " "
+                      + existingValue.doubleValue
+                      + " to "
+                      + newValue.textValue
+                      + " "
+                      + newValue.doubleValue);
             }
           }
           this.clientDefinedAttributes.put(newKey, newValue);
@@ -834,8 +869,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
 
       public @Nullable Interstitial build() {
         if ((assetListUri == null && assetUri != null)
-            || (assetListUri != null && assetUri == null)
-            && startDateUnixUs != C.TIME_UNSET) {
+            || (assetListUri != null && assetUri == null) && startDateUnixUs != C.TIME_UNSET) {
           return new Interstitial(
               this.id,
               this.assetUri,
@@ -850,8 +884,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
               this.playoutLimitUs,
               this.snapTypes,
               this.restrictions,
-              new ArrayList<>(this.clientDefinedAttributes.values())
-          );
+              new ArrayList<>(this.clientDefinedAttributes.values()));
         }
         return null;
       }

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
@@ -662,8 +662,8 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
 
       /** Sets the {@code assetUri}. */
       @CanIgnoreReturnValue
-      public Builder setAssetUri(@Nullable Uri a1ssetUri) {
-        if (assetUri == null) {
+      public Builder setAssetUri(@Nullable Uri assetUri) {
+        if (assetUri == null) { 
           return this;
         }
         if (this.assetUri != null) {

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
@@ -29,6 +29,7 @@ import androidx.annotation.StringDef;
 import androidx.media3.common.C;
 import androidx.media3.common.DrmInitData;
 import androidx.media3.common.StreamKey;
+import androidx.media3.common.util.Assertions;
 import androidx.media3.common.util.UnstableApi;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -610,6 +611,205 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
           snapTypes,
           restrictions,
           clientDefinedAttributes);
+    }
+
+    // If a Playlist contains two EXT-X-DATERANGE tags with the same ID
+    // attribute value, then any AttributeName that appears in both tags
+    // MUST have the same AttributeValue.  A Server MAY augment a Date Range
+    // with additional attributes by adding subsequent EXT-X-DATERANGE tags
+    // with the same ID attribute to a Playlist.  The client is responsible
+    // for consolidating the tags.  The subsequent EXT-X-DATERANGE tags can
+    // appear in a subsequent playlist update, in the case of live or event
+    // streams.
+    /** Builder for {@link Interstitial}. */
+    public static final class Builder {
+
+      private final String id;
+      @Nullable private Uri assetUri;
+      @Nullable private Uri assetListUri;
+      private long startDateUnixUs = C.TIME_UNSET;
+      private long endDateUnixUs = C.TIME_UNSET;
+      private long durationUs = C.TIME_UNSET;
+      private long plannedDurationUs = C.TIME_UNSET;
+      private List<@Interstitial.CueTriggerType String> cue = new ArrayList<>();
+      private boolean endOnNext;
+      private long resumeOffsetUs = C.TIME_UNSET;
+      private long playoutLimitUs = C.TIME_UNSET;
+      private List<@Interstitial.SnapType String> snapTypes = new ArrayList<>();
+      private List<@Interstitial.NavigationRestriction String> restrictions = new ArrayList<>();
+      private List<ClientDefinedAttribute> clientDefinedAttributes = new ArrayList<>();
+
+      /**
+       * Creates the builder.
+       *
+       * @param id The id.
+       */
+      public Builder(String id) {
+        this.id = id;
+      }
+
+      /** Sets the {@code assetUri}. */
+      public Builder setAssetUri(@Nullable Uri assetUri) {
+        if (assetUri == null) return this;
+        if (this.assetUri != null) {
+          Assertions.checkArgument(!this.assetUri.equals(assetUri),
+              "Can't change assetUri from " + this.assetUri + " to " + assetUri);
+        }
+        this.assetUri = assetUri;
+        return this;
+      }
+
+      /** Sets the {@code assetListUri}. */
+      public Builder setAssetListUri(@Nullable Uri assetListUri) {
+        if (assetListUri == null) return this;
+        if (this.assetListUri != null) {
+          Assertions.checkArgument(!this.assetListUri.equals(assetListUri),
+              "Can't change assetListUri from " + this.assetListUri + " to " + assetListUri);
+        }
+        this.assetListUri = assetListUri;
+        return this;
+      }
+
+      /** Sets the {@code startDateUnixUs}. */
+      public Builder setStartDateUnixUs(long startDateUnixUs) {
+        if (startDateUnixUs == C.TIME_UNSET) return this;
+        if (this.startDateUnixUs != C.TIME_UNSET) {
+          Assertions.checkArgument(this.startDateUnixUs != startDateUnixUs,
+              "Can't change startDateUnixUs from " + this.startDateUnixUs + " to " + startDateUnixUs);
+        }
+        this.startDateUnixUs = startDateUnixUs;
+        return this;
+      }
+
+      /** Sets the {@code endDateUnixUs}. */
+      public Builder setEndDateUnixUs(long endDateUnixUs) {
+        if (endDateUnixUs == C.TIME_UNSET) return this;
+        if (this.endDateUnixUs != C.TIME_UNSET) {
+          Assertions.checkArgument(this.endDateUnixUs != endDateUnixUs,
+              "Can't change endDateUnixUs from " + this.endDateUnixUs + " to " + endDateUnixUs);
+        }
+        this.endDateUnixUs = endDateUnixUs;
+        return this;
+      }
+
+      /** Sets the {@code durationUs}. */
+      public Builder setDurationUs(long durationUs) {
+        if (durationUs == C.TIME_UNSET) return this;
+        if (this.durationUs != C.TIME_UNSET) {
+          Assertions.checkArgument(this.durationUs != durationUs,
+              "Can't change durationUs from " + this.durationUs + " to " + durationUs);
+        }
+        this.durationUs = durationUs;
+        return this;
+      }
+
+      /** Sets the {@code plannedDurationUs}. */
+      public Builder setPlannedDurationUs(long plannedDurationUs) {
+        if (plannedDurationUs == C.TIME_UNSET) return this;
+        if (this.plannedDurationUs != C.TIME_UNSET) {
+          Assertions.checkArgument(this.plannedDurationUs != plannedDurationUs,
+              "Can't change plannedDurationUs from " + this.plannedDurationUs + " to " + plannedDurationUs);
+        }
+        this.plannedDurationUs = plannedDurationUs;
+        return this;
+      }
+
+      /** Sets the trigger {@code cue} types. */
+      public Builder setCue(List<@Interstitial.CueTriggerType String> cue) {
+        if (cue.isEmpty()) return this;
+        if (!this.cue.isEmpty()) {
+          Assertions.checkArgument(!this.cue.equals(cue),
+              "Can't change cue from " + String.join(", ", this.cue) + " to " + String.join(", ", cue));
+        }
+        this.cue = cue;
+        return this;
+      }
+
+      /** Sets whether the interstitial {@code endOnNext}. */
+      public Builder setEndOnNext(boolean endOnNext) {
+        if (!endOnNext) return this;
+        this.endOnNext = endOnNext;
+        return this;
+      }
+
+      /** Sets the {@code resumeOffsetUs}. */
+      public Builder setResumeOffsetUs(long resumeOffsetUs) {
+        if (resumeOffsetUs == C.TIME_UNSET) return this;
+        if (this.resumeOffsetUs != C.TIME_UNSET) {
+          Assertions.checkArgument(this.resumeOffsetUs != resumeOffsetUs,
+              "Can't change resumeOffsetUs from " + this.resumeOffsetUs + " to " + resumeOffsetUs);
+        }
+        this.resumeOffsetUs = resumeOffsetUs;
+        return this;
+      }
+
+      /** Sets the {@code playoutLimitUs}. */
+      public Builder setPlayoutLimitUs(long playoutLimitUs) {
+        if (playoutLimitUs == C.TIME_UNSET) return this;
+        if (this.playoutLimitUs != C.TIME_UNSET) {
+          Assertions.checkArgument(this.playoutLimitUs != playoutLimitUs,
+              "Can't change playoutLimitUs from " + this.playoutLimitUs + " to " + playoutLimitUs);
+        }
+        this.playoutLimitUs = playoutLimitUs;
+        return this;
+      }
+
+      /** Sets the {@code snapTypes}. */
+      public Builder setSnapTypes(List<@Interstitial.SnapType String> snapTypes) {
+        if (snapTypes.isEmpty()) return this;
+        if (!this.snapTypes.isEmpty()) {
+          Assertions.checkArgument(!this.snapTypes.equals(snapTypes),
+              "Can't change snapTypes from " + String.join(", ", this.snapTypes) + " to " + String.join(", ", snapTypes));
+        }
+        this.snapTypes = snapTypes;
+        return this;
+      }
+
+      /** Sets the {@code NavigationRestriction}. */
+      public Builder setRestrictions(List<@Interstitial.NavigationRestriction String> restrictions) {
+        if (restrictions.isEmpty()) return this;
+        if (!this.restrictions.isEmpty()) {
+          Assertions.checkArgument(!this.restrictions.equals(restrictions),
+              "Can't change restrictions from " + String.join(", ", this.restrictions) + " to " + String.join(", ", restrictions));
+        }
+        this.restrictions = restrictions;
+        return this;
+      }
+
+      /** Sets the {@code clientDefinedAttributes}. */
+      public Builder setClientDefinedAttributes(
+          List<HlsMediaPlaylist.ClientDefinedAttribute> clientDefinedAttributes) {
+        if (clientDefinedAttributes.isEmpty()) return this;
+        if (!this.clientDefinedAttributes.isEmpty()) {
+          Assertions.checkArgument(!this.clientDefinedAttributes.equals(clientDefinedAttributes));
+        }
+        this.clientDefinedAttributes = clientDefinedAttributes;
+        return this;
+      }
+
+      public @Nullable Interstitial build() {
+        if ((assetListUri == null && assetUri != null)
+            || (assetListUri != null && assetUri == null)
+            && startDateUnixUs != C.TIME_UNSET) {
+          return new Interstitial(
+              this.id,
+              this.assetUri,
+              this.assetListUri,
+              this.startDateUnixUs,
+              this.endDateUnixUs,
+              this.durationUs,
+              this.plannedDurationUs,
+              this.cue,
+              this.endOnNext,
+              this.resumeOffsetUs,
+              this.playoutLimitUs,
+              this.snapTypes,
+              this.restrictions,
+              this.clientDefinedAttributes
+          );
+        }
+        return null;
+      }
     }
   }
 

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
@@ -663,7 +663,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       /** Sets the {@code assetUri}. */
       @CanIgnoreReturnValue
       public Builder setAssetUri(@Nullable Uri assetUri) {
-        if (assetUri == null) { 
+        if (assetUri == null) {
           return this;
         }
         if (this.assetUri != null) {
@@ -780,7 +780,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         if (!endOnNext) {
           return this;
         }
-        this.endOnNext = endOnNext;
+        this.endOnNext = true;
         return this;
       }
 
@@ -881,9 +881,10 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         return this;
       }
 
-      public @Nullable Interstitial build() {
-        if ((assetListUri == null && assetUri != null)
-            || (assetListUri != null && assetUri == null) && startDateUnixUs != C.TIME_UNSET) {
+      @Nullable
+      public Interstitial build() {
+        if (((assetListUri == null && assetUri != null)
+            || (assetListUri != null && assetUri == null)) && startDateUnixUs != C.TIME_UNSET) {
           return new Interstitial(
               id,
               assetUri,

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
@@ -567,7 +567,10 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       this.playoutLimitUs = playoutLimitUs;
       this.snapTypes = ImmutableList.copyOf(snapTypes);
       this.restrictions = ImmutableList.copyOf(restrictions);
-      this.clientDefinedAttributes = ImmutableList.copyOf(clientDefinedAttributes);
+      // Sort to ensure equality decoupled from how exactly parsing is implemented.
+      this.clientDefinedAttributes =
+          ImmutableList.sortedCopyOf(
+              (o1, o2) -> o1.name.compareTo(o2.name), clientDefinedAttributes);
     }
 
     @Override
@@ -851,33 +854,29 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       /** Sets the {@code clientDefinedAttributes}. */
       @CanIgnoreReturnValue
       public Builder setClientDefinedAttributes(
-          Map<String, HlsMediaPlaylist.ClientDefinedAttribute> clientDefinedAttributes) {
+          List<HlsMediaPlaylist.ClientDefinedAttribute> clientDefinedAttributes) {
         if (clientDefinedAttributes.isEmpty()) {
           return this;
         }
-        for (Map.Entry<String, HlsMediaPlaylist.ClientDefinedAttribute> newEntry :
-            clientDefinedAttributes.entrySet()) {
-          String newKey = newEntry.getKey();
-          HlsMediaPlaylist.ClientDefinedAttribute newValue = newEntry.getValue();
-          if (this.clientDefinedAttributes.containsKey(newKey)) {
-            HlsMediaPlaylist.ClientDefinedAttribute existingValue =
-                this.clientDefinedAttributes.get(newKey);
-            if (existingValue != null) {
-              checkArgument(
-                  existingValue.equals(newValue),
-                  "Can't change "
-                      + newKey
-                      + " from "
-                      + existingValue.textValue
-                      + " "
-                      + existingValue.doubleValue
-                      + " to "
-                      + newValue.textValue
-                      + " "
-                      + newValue.doubleValue);
-            }
+        for (int i = 0; i < clientDefinedAttributes.size(); i++) {
+          ClientDefinedAttribute newAttribute = clientDefinedAttributes.get(i);
+          String newName = newAttribute.name;
+          ClientDefinedAttribute existingAttribute = this.clientDefinedAttributes.get(newName);
+          if (existingAttribute != null) {
+            checkArgument(
+                existingAttribute.equals(newAttribute),
+                "Can't change "
+                    + newName
+                    + " from "
+                    + existingAttribute.textValue
+                    + " "
+                    + existingAttribute.doubleValue
+                    + " to "
+                    + newAttribute.textValue
+                    + " "
+                    + newAttribute.doubleValue);
           }
-          this.clientDefinedAttributes.put(newKey, newValue);
+          this.clientDefinedAttributes.put(newName, newAttribute);
         }
         return this;
       }

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylist.java
@@ -622,6 +622,8 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
     public static final class Builder {
 
       private final String id;
+      private final Map<String, ClientDefinedAttribute> clientDefinedAttributes;
+
       @Nullable private Uri assetUri;
       @Nullable private Uri assetListUri;
       private long startDateUnixUs;
@@ -634,7 +636,6 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       private long playoutLimitUs;
       private List<@Interstitial.SnapType String> snapTypes;
       private List<@Interstitial.NavigationRestriction String> restrictions;
-      private Map<String, ClientDefinedAttribute> clientDefinedAttributes;
 
       /**
        * Creates the builder.
@@ -643,20 +644,21 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
        */
       public Builder(String id) {
         this.id = id;
-        this.startDateUnixUs = C.TIME_UNSET;
-        this.endDateUnixUs = C.TIME_UNSET;
-        this.durationUs = C.TIME_UNSET;
-        this.plannedDurationUs = C.TIME_UNSET;
-        this.cue = new ArrayList<>();
-        this.resumeOffsetUs = C.TIME_UNSET;
-        this.playoutLimitUs = C.TIME_UNSET;
-        this.snapTypes = new ArrayList<>();
-        this.restrictions = new ArrayList<>();
-        this.clientDefinedAttributes = new HashMap<>();
+        startDateUnixUs = C.TIME_UNSET;
+        endDateUnixUs = C.TIME_UNSET;
+        durationUs = C.TIME_UNSET;
+        plannedDurationUs = C.TIME_UNSET;
+        cue = new ArrayList<>();
+        resumeOffsetUs = C.TIME_UNSET;
+        playoutLimitUs = C.TIME_UNSET;
+        snapTypes = new ArrayList<>();
+        restrictions = new ArrayList<>();
+        clientDefinedAttributes = new HashMap<>();
       }
 
       /** Sets the {@code assetUri}. */
-      public Builder setAssetUri(@Nullable Uri assetUri) {
+      @CanIgnoreReturnValue
+      public Builder setAssetUri(@Nullable Uri a1ssetUri) {
         if (assetUri == null) {
           return this;
         }
@@ -670,6 +672,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       }
 
       /** Sets the {@code assetListUri}. */
+      @CanIgnoreReturnValue
       public Builder setAssetListUri(@Nullable Uri assetListUri) {
         if (assetListUri == null) {
           return this;
@@ -701,6 +704,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       }
 
       /** Sets the {@code endDateUnixUs}. */
+      @CanIgnoreReturnValue
       public Builder setEndDateUnixUs(long endDateUnixUs) {
         if (endDateUnixUs == C.TIME_UNSET) {
           return this;

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsPlaylistParser.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsPlaylistParser.java
@@ -50,7 +50,6 @@ import androidx.media3.exoplayer.hls.playlist.HlsMultivariantPlaylist.Rendition;
 import androidx.media3.exoplayer.hls.playlist.HlsMultivariantPlaylist.Variant;
 import androidx.media3.exoplayer.upstream.ParsingLoadable;
 import androidx.media3.extractor.mp4.PsshAtomUtil;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -1193,22 +1192,24 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
           }
         }
 
-        Interstitial.Builder interstitialBuilder = (interstitialBuilderMap.containsKey(id) ?
-            interstitialBuilderMap.get(id) : new Interstitial.Builder(id))
-              .setAssetUri(assetUri)
-              .setAssetListUri(assetListUri)
-              .setStartDateUnixUs(startDateUnixUs)
-              .setEndDateUnixUs(endDateUnixUs)
-              .setDurationUs(durationUs)
-              .setPlannedDurationUs(plannedDurationUs)
-              .setCue(cue)
-              .setEndOnNext(endOnNext)
-              .setResumeOffsetUs(resumeOffsetUs)
-              .setPlayoutLimitUs(playoutLimitUs)
-              .setSnapTypes(snapTypes)
-              .setRestrictions(restrictions)
-              .setClientDefinedAttributes(clientDefinedAttributes);
-          interstitialBuilderMap.put(id, interstitialBuilder);
+        Interstitial.Builder interstitialBuilder =
+            (interstitialBuilderMap.containsKey(id)
+                    ? interstitialBuilderMap.get(id)
+                    : new Interstitial.Builder(id))
+                .setAssetUri(assetUri)
+                .setAssetListUri(assetListUri)
+                .setStartDateUnixUs(startDateUnixUs)
+                .setEndDateUnixUs(endDateUnixUs)
+                .setDurationUs(durationUs)
+                .setPlannedDurationUs(plannedDurationUs)
+                .setCue(cue)
+                .setEndOnNext(endOnNext)
+                .setResumeOffsetUs(resumeOffsetUs)
+                .setPlayoutLimitUs(playoutLimitUs)
+                .setSnapTypes(snapTypes)
+                .setRestrictions(restrictions)
+                .setClientDefinedAttributes(clientDefinedAttributes);
+        interstitialBuilderMap.put(id, interstitialBuilder);
       } else if (!line.startsWith("#")) {
         @Nullable
         String segmentEncryptionIV =

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsPlaylistParser.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsPlaylistParser.java
@@ -1166,8 +1166,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
           }
         }
 
-        Map<String, HlsMediaPlaylist.ClientDefinedAttribute> clientDefinedAttributes =
-            new HashMap<>();
+        List<HlsMediaPlaylist.ClientDefinedAttribute> clientDefinedAttributes = new ArrayList<>();
         String attributes = line.substring("#EXT-X-DATERANGE:".length());
         Matcher matcher = REGEX_CLIENT_DEFINED_ATTRIBUTE_PREFIX.matcher(attributes);
         while (matcher.find()) {
@@ -1182,8 +1181,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
               // ignore interstitial attributes
               break;
             default:
-              clientDefinedAttributes.put(
-                  attributePrefix,
+              clientDefinedAttributes.add(
                   parseClientDefinedAttribute(
                       attributes,
                       attributePrefix.substring(0, attributePrefix.length() - 1),

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsPlaylistParser.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsPlaylistParser.java
@@ -1167,8 +1167,8 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
           }
         }
 
-        ImmutableList.Builder<HlsMediaPlaylist.ClientDefinedAttribute> clientDefinedAttributes =
-            new ImmutableList.Builder<>();
+        Map<String, HlsMediaPlaylist.ClientDefinedAttribute> clientDefinedAttributes =
+            new HashMap<>();
         String attributes = line.substring("#EXT-X-DATERANGE:".length());
         Matcher matcher = REGEX_CLIENT_DEFINED_ATTRIBUTE_PREFIX.matcher(attributes);
         while (matcher.find()) {
@@ -1183,7 +1183,8 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
               // ignore interstitial attributes
               break;
             default:
-              clientDefinedAttributes.add(
+              clientDefinedAttributes.put(
+                  attributePrefix,
                   parseClientDefinedAttribute(
                       attributes,
                       attributePrefix.substring(0, attributePrefix.length() - 1),
@@ -1206,7 +1207,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
               .setPlayoutLimitUs(playoutLimitUs)
               .setSnapTypes(snapTypes)
               .setRestrictions(restrictions)
-              .setClientDefinedAttributes(clientDefinedAttributes.build());
+              .setClientDefinedAttributes(clientDefinedAttributes);
           interstitialBuilderMap.put(id, interstitialBuilder);
       } else if (!line.startsWith("#")) {
         @Nullable

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsPlaylistParser.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsPlaylistParser.java
@@ -62,6 +62,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -758,7 +759,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
     @Nullable Part preloadPart = null;
     List<RenditionReport> renditionReports = new ArrayList<>();
     List<String> tags = new ArrayList<>();
-    List<Interstitial> interstitials = new ArrayList<>();
+    LinkedHashMap<String, Interstitial> interstitialMap = new LinkedHashMap<>();
 
     long segmentDurationUs = 0;
     String segmentTitle = "";
@@ -1079,8 +1080,13 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
         if (assetListUriString != null) {
           assetListUri = Uri.parse(assetListUriString);
         }
-        long startDateUnixUs =
-            msToUs(parseXsDateTime(parseStringAttr(line, REGEX_START_DATE, variableDefinitions)));
+        long startDateUnixUs = C.TIME_UNSET;
+        @Nullable
+        String startDateUnixMsString =
+            parseOptionalStringAttr(line, REGEX_START_DATE, variableDefinitions);
+        if (startDateUnixMsString != null) {
+          startDateUnixUs = msToUs(parseXsDateTime(startDateUnixMsString));
+        }
         long endDateUnixUs = C.TIME_UNSET;
         @Nullable
         String endDateUnixMsString =
@@ -1185,24 +1191,50 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
               break;
           }
         }
-        if ((assetListUri == null && assetUri != null)
-            || (assetListUri != null && assetUri == null)) {
-          interstitials.add(
-              new Interstitial(
-                  id,
-                  assetUri,
-                  assetListUri,
-                  startDateUnixUs,
-                  endDateUnixUs,
-                  durationUs,
-                  plannedDurationUs,
-                  cue,
-                  endOnNext,
-                  resumeOffsetUs,
-                  playoutLimitUs,
-                  snapTypes,
-                  restrictions,
-                  clientDefinedAttributes.build()));
+
+        if (interstitialMap.containsKey(id)) {
+          Interstitial interstitial = interstitialMap.get(id);
+          interstitialMap.put(id, getUpdatedInterstitial(
+              interstitial,
+              assetUri,
+              assetListUri,
+              startDateUnixUs,
+              endDateUnixUs,
+              durationUs,
+              plannedDurationUs,
+              cue,
+              endOnNext,
+              resumeOffsetUs,
+              playoutLimitUs,
+              snapTypes,
+              restrictions,
+              clientDefinedAttributes.build()
+          ));
+        } else {
+          if ((assetListUri == null && assetUri != null)
+              || (assetListUri != null && assetUri == null)) {
+            if (startDateUnixUs == C.TIME_UNSET) {
+              throw ParserException.createForMalformedManifest(
+                  "Couldn't match " + REGEX_START_DATE.pattern() + " in " + line, /* cause= */
+                  null);
+            }
+            Interstitial interstitial = new Interstitial(
+                id,
+                assetUri,
+                assetListUri,
+                startDateUnixUs,
+                endDateUnixUs,
+                durationUs,
+                plannedDurationUs,
+                cue,
+                endOnNext,
+                resumeOffsetUs,
+                playoutLimitUs,
+                snapTypes,
+                restrictions,
+                clientDefinedAttributes.build());
+            interstitialMap.put(id, interstitial);
+          }
         }
       } else if (!line.startsWith("#")) {
         @Nullable
@@ -1310,7 +1342,71 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
         trailingParts,
         serverControl,
         renditionReportMap,
-        interstitials);
+        new ArrayList<>(interstitialMap.values()));
+  }
+
+  private static Interstitial getUpdatedInterstitial(
+      Interstitial oldInterstitial,
+      Uri assetUri,
+      Uri assetListUri,
+      long startDateUnixUs,
+      long endDateUnixUs,
+      long durationUs,
+      long plannedDurationUs,
+      List<String> cue,
+      boolean endOnNext,
+      long resumeOffsetUs,
+      long playoutLimitUs,
+      List<String> snapTypes,
+      List<String> restrictions,
+      ImmutableList<HlsMediaPlaylist.ClientDefinedAttribute> clientDefinedAttributes) {
+
+    // If a Playlist contains two EXT-X-DATERANGE tags with the same ID
+    // attribute value, then any AttributeName that appears in both tags
+    // MUST have the same AttributeValue.  A Server MAY augment a Date Range
+    // with additional attributes by adding subsequent EXT-X-DATERANGE tags
+    // with the same ID attribute to a Playlist.  The client is responsible
+    // for consolidating the tags.  The subsequent EXT-X-DATERANGE tags can
+    // appear in a subsequent playlist update, in the case of live or event
+    // streams.
+    Uri newAssetUri = (assetUri != null) ? assetUri : oldInterstitial.assetUri;
+    Uri newAssetListUri = (assetListUri != null) ? assetListUri : oldInterstitial.assetListUri;
+    long newStartDateUnixUs =
+        (startDateUnixUs != C.TIME_UNSET) ? startDateUnixUs : oldInterstitial.startDateUnixUs;
+    long newEndDateUnixUs =
+        (endDateUnixUs != C.TIME_UNSET) ? endDateUnixUs : oldInterstitial.endDateUnixUs;
+    long newDurationUs = (durationUs != C.TIME_UNSET) ? durationUs : oldInterstitial.durationUs;
+    long newPlannedDurationUs =
+        (plannedDurationUs != C.TIME_UNSET) ? plannedDurationUs : oldInterstitial.plannedDurationUs;
+    List<String> newCue = (cue != null && !cue.isEmpty()) ? cue : oldInterstitial.cue;
+    boolean newEndOnNext = oldInterstitial.endOnNext || endOnNext;
+    long newResumeOffsetUs =
+        (resumeOffsetUs != C.TIME_UNSET) ? resumeOffsetUs : oldInterstitial.resumeOffsetUs;
+    long newPlayoutLimitUs =
+        (playoutLimitUs != C.TIME_UNSET) ? playoutLimitUs : oldInterstitial.playoutLimitUs;
+    List<String> newSnapTypes =
+        (snapTypes != null && !snapTypes.isEmpty()) ? snapTypes : oldInterstitial.snapTypes;
+    List<String> newRestrictions = (restrictions != null && !restrictions.isEmpty()) ? restrictions
+        : oldInterstitial.restrictions;
+    ImmutableList<HlsMediaPlaylist.ClientDefinedAttribute> newClientDefinedAttributes =
+        (clientDefinedAttributes != null && !clientDefinedAttributes.isEmpty())
+            ? clientDefinedAttributes : oldInterstitial.clientDefinedAttributes;
+
+    return new Interstitial(
+        oldInterstitial.id,
+        newAssetUri,
+        newAssetListUri,
+        newStartDateUnixUs,
+        newEndDateUnixUs,
+        newDurationUs,
+        newPlannedDurationUs,
+        newCue,
+        newEndOnNext,
+        newResumeOffsetUs,
+        newPlayoutLimitUs,
+        newSnapTypes,
+        newRestrictions,
+        newClientDefinedAttributes);
   }
 
   private static DrmInitData getPlaylistProtectionSchemes(

--- a/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylistParserTest.java
+++ b/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylistParserTest.java
@@ -1638,7 +1638,7 @@ public class HlsMediaPlaylistParserTest {
             new HlsPlaylistParser()
                 .parse(playlistUri, new ByteArrayInputStream(Util.getUtf8Bytes(playlistString)));
 
-    assertThat(playlist.interstitials.size()).isEqualTo(1);
+    assertThat(playlist.interstitials).hasSize(1);
     assertThat(playlist.interstitials.get(0).resumeOffsetUs).isEqualTo(24953741L);
     assertThat(playlist.interstitials.get(0).endDateUnixUs).isEqualTo(1726846189006000L);
     assertThat(playlist.interstitials.get(0).playoutLimitUs).isEqualTo(24953741L);
@@ -1737,10 +1737,10 @@ public class HlsMediaPlaylistParserTest {
             new HlsPlaylistParser()
                 .parse(playlistUri, new ByteArrayInputStream(Util.getUtf8Bytes(playlistString)));
 
-    assertThat(playlist.interstitials.size()).isEqualTo(1);
+    assertThat(playlist.interstitials).hasSize(1);
     ImmutableList<HlsMediaPlaylist.ClientDefinedAttribute> clientDefinedAttributes =
         playlist.interstitials.get(0).clientDefinedAttributes;
-    assertThat(clientDefinedAttributes.size()).isEqualTo(1);
+    assertThat(clientDefinedAttributes).hasSize(1);
     HlsMediaPlaylist.ClientDefinedAttribute clientDefinedAttribute = clientDefinedAttributes.get(0);
     assertThat(clientDefinedAttribute.name).isEqualTo("X-CONTENT-MAY-VARY");
     assertThat(clientDefinedAttribute.getTextValue()).isEqualTo("YES");

--- a/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylistParserTest.java
+++ b/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylistParserTest.java
@@ -1445,8 +1445,7 @@ public class HlsMediaPlaylistParserTest {
   }
 
   @Test
-  public void parseMediaPlaylist_interstitialWithoutStartDate_ignored()
-      throws IOException {
+  public void parseMediaPlaylist_interstitialWithoutStartDate_ignored() throws IOException {
     Uri playlistUri = Uri.parse("https://example.com/test.m3u8");
     String playlistString =
         "#EXTM3U\n"
@@ -1612,9 +1611,7 @@ public class HlsMediaPlaylistParserTest {
   }
 
   @Test
-  public void
-  parseMediaPlaylist_withInterstitialWithUpdatingDateRange()
-      throws IOException {
+  public void parseMediaPlaylist_withInterstitialWithUpdatingDateRange() throws IOException {
     Uri playlistUri = Uri.parse("https://example.com/test.m3u8");
     String playlistString =
         "#EXTM3U\n"
@@ -1649,7 +1646,7 @@ public class HlsMediaPlaylistParserTest {
 
   @Test
   public void
-  parseMediaPlaylist_withInterstitiaStartDateInvalidUpdate_throwsIllegalArgumentException() {
+      parseMediaPlaylist_withInterstitiaStartDateInvalidUpdate_throwsIllegalArgumentException() {
     Uri playlistUri = Uri.parse("https://example.com/test.m3u8");
     String playlistString =
         "#EXTM3U\n"

--- a/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylistParserTest.java
+++ b/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylistParserTest.java
@@ -1620,18 +1620,26 @@ public class HlsMediaPlaylistParserTest {
             + "#EXT-X-MEDIA-SEQUENCE:0\n"
             + "#EXT-X-PROGRAM-DATE-TIME:2024-09-20T15:29:20.000Z\n"
             + "#EXTINF:10.007800,\n"
-            + "audio0000.ts\n"
+            + "audio0000.ts"
+            + "\n"
             + "#EXT-X-DATERANGE:ID=\"15943\","
             + "CLASS=\"com.apple.hls.interstitial\","
-            + "START-DATE=\"2024-09-20T15:29:24.006Z\",PLANNED-DURATION=25,"
+            + "START-DATE=\"2024-09-20T15:29:24.006Z\","
+            + "PLANNED-DURATION=25,"
             + "X-ASSET-LIST=\"myapp://interstitial/req?_HLS_interstitial_id=15943\","
-            + "X-SNAP=\"OUT,IN\",X-TIMELINE-OCCUPIES=\"RANGE\","
-            + "X-TIMELINE-STYLE=\"HIGHLIGHT\",X-CONTENT-MAY-VARY=\"YES\"\n"
+            + "X-SNAP=\"OUT,IN\","
+            + "X-TIMELINE-OCCUPIES=\"RANGE\","
+            + "X-TIMELINE-STYLE=\"HIGHLIGHT\","
+            + "X-CONTENT-MAY-VARY=\"YES\""
+            + "\n"
             + "#EXTINF:10.007800,\n"
-            + "audio0001.ts\n"
-            + "#EXT-X-DATERANGE:ID=\"15943\",CLASS=\"com.apple.hls.interstitial\","
-            + "END-DATE=\"2024-09-20T15:29:49.006Z\",X-PLAYOUT-LIMIT=24.953741497,"
-            + "X-RESUME-OFFSET=24.953741497";
+            + "audio0001.ts"
+            + "\n"
+            + "#EXT-X-DATERANGE:ID=\"15943\","
+            + "CLASS=\"com.apple.hls.interstitial\","
+            + "END-DATE=\"2024-09-20T15:29:49.006Z\","
+            + "X-PLAYOUT-LIMIT=24.953741497,"
+            + "X-RESUME-OFFSET=24.953741497\n";
 
     HlsMediaPlaylist playlist =
         (HlsMediaPlaylist)
@@ -1646,7 +1654,7 @@ public class HlsMediaPlaylistParserTest {
 
   @Test
   public void
-      parseMediaPlaylist_withInterstitiaStartDateInvalidUpdate_throwsIllegalArgumentException() {
+      parseMediaPlaylist_withInterstitialStartDateInvalidUpdate_throwsIllegalArgumentException() {
     Uri playlistUri = Uri.parse("https://example.com/test.m3u8");
     String playlistString =
         "#EXTM3U\n"
@@ -1655,20 +1663,27 @@ public class HlsMediaPlaylistParserTest {
             + "#EXT-X-MEDIA-SEQUENCE:0\n"
             + "#EXT-X-PROGRAM-DATE-TIME:2024-09-20T15:29:20.000Z\n"
             + "#EXTINF:10.007800,\n"
-            + "audio0000.ts\n"
+            + "audio0000.ts"
+            + "\n"
             + "#EXT-X-DATERANGE:ID=\"15943\","
             + "CLASS=\"com.apple.hls.interstitial\","
-            + "START-DATE=\"2024-09-20T15:29:24.006Z\",PLANNED-DURATION=25,"
+            + "START-DATE=\"2024-09-20T15:29:24.006Z\","
+            + "PLANNED-DURATION=25,"
             + "X-ASSET-LIST=\"myapp://interstitial/req?_HLS_interstitial_id=15943\","
-            + "X-SNAP=\"OUT,IN\",X-TIMELINE-OCCUPIES=\"RANGE\","
-            + "X-TIMELINE-STYLE=\"HIGHLIGHT\",X-CONTENT-MAY-VARY=\"YES\"\n"
+            + "X-SNAP=\"OUT,IN\","
+            + "X-TIMELINE-OCCUPIES=\"RANGE\","
+            + "X-TIMELINE-STYLE=\"HIGHLIGHT\","
+            + "X-CONTENT-MAY-VARY=\"YES\""
+            + "\n"
             + "#EXTINF:10.007800,\n"
-            + "audio0001.ts\n"
-            + "#EXT-X-DATERANGE:ID=\"15943\",CLASS=\"com.apple.hls.interstitial\","
+            + "audio0001.ts"
+            + "\n"
+            + "#EXT-X-DATERANGE:ID=\"15943\","
+            + "CLASS=\"com.apple.hls.interstitial\","
             + "START-DATE=\"2024-09-20T15:29:25.006Z\","
-            + "END-DATE=\"2024-09-20T15:29:49.006Z\",X-PLAYOUT-LIMIT=24.953741497,"
-            + "X-RESUME-OFFSET=24.953741497";
-
+            + "END-DATE=\"2024-09-20T15:29:49.006Z\","
+            + "X-PLAYOUT-LIMIT=24.953741497,"
+            + "X-RESUME-OFFSET=24.953741497\n";
     HlsPlaylistParser hlsPlaylistParser = new HlsPlaylistParser();
     ByteArrayInputStream inputStream = new ByteArrayInputStream(Util.getUtf8Bytes(playlistString));
 
@@ -1687,20 +1702,27 @@ public class HlsMediaPlaylistParserTest {
             + "#EXT-X-MEDIA-SEQUENCE:0\n"
             + "#EXT-X-PROGRAM-DATE-TIME:2024-09-20T15:29:20.000Z\n"
             + "#EXTINF:10.007800,\n"
-            + "audio0000.ts\n"
+            + "audio0000.ts"
+            + "\n"
             + "#EXT-X-DATERANGE:ID=\"15943\","
             + "CLASS=\"com.apple.hls.interstitial\","
-            + "START-DATE=\"2024-09-20T15:29:24.006Z\",PLANNED-DURATION=25,"
+            + "START-DATE=\"2024-09-20T15:29:24.006Z\","
+            + "PLANNED-DURATION=25,"
             + "X-ASSET-LIST=\"myapp://interstitial/req?_HLS_interstitial_id=15943\","
-            + "X-SNAP=\"OUT,IN\",X-TIMELINE-OCCUPIES=\"RANGE\","
-            + "X-TIMELINE-STYLE=\"HIGHLIGHT\",X-CONTENT-MAY-VARY=\"YES\"\n"
+            + "X-SNAP=\"OUT,IN\","
+            + "X-TIMELINE-OCCUPIES=\"RANGE\","
+            + "X-TIMELINE-STYLE=\"HIGHLIGHT\","
+            + "X-CONTENT-MAY-VARY=\"YES\""
+            + "\n"
             + "#EXTINF:10.007800,\n"
-            + "audio0001.ts\n"
-            + "#EXT-X-DATERANGE:ID=\"15943\",CLASS=\"com.apple.hls.interstitial\","
-            + "END-DATE=\"2024-09-20T15:29:49.006Z\",X-PLAYOUT-LIMIT=24.953741497,"
+            + "audio0001.ts"
+            + "\n"
+            + "#EXT-X-DATERANGE:ID=\"15943\","
+            + "CLASS=\"com.apple.hls.interstitial\","
+            + "END-DATE=\"2024-09-20T15:29:49.006Z\","
+            + "X-PLAYOUT-LIMIT=24.953741497,"
             + "X-CONTENT-MAY-VARY=\"NO\","
-            + "X-RESUME-OFFSET=24.953741497";
-
+            + "X-RESUME-OFFSET=24.953741497\n";
     HlsPlaylistParser hlsPlaylistParser = new HlsPlaylistParser();
     ByteArrayInputStream inputStream = new ByteArrayInputStream(Util.getUtf8Bytes(playlistString));
 
@@ -1721,16 +1743,21 @@ public class HlsMediaPlaylistParserTest {
             + "audio0000.ts\n"
             + "#EXT-X-DATERANGE:ID=\"15943\","
             + "CLASS=\"com.apple.hls.interstitial\","
-            + "START-DATE=\"2024-09-20T15:29:24.006Z\",PLANNED-DURATION=25,"
+            + "START-DATE=\"2024-09-20T15:29:24.006Z\","
+            + "PLANNED-DURATION=25,"
             + "X-ASSET-LIST=\"myapp://interstitial/req?_HLS_interstitial_id=15943\","
             + "X-SNAP=\"OUT,IN\","
-            + "X-CONTENT-MAY-VARY=\"YES\"\n"
+            + "X-CONTENT-MAY-VARY=\"YES\""
+            + "\n"
             + "#EXTINF:10.007800,\n"
-            + "audio0001.ts\n"
-            + "#EXT-X-DATERANGE:ID=\"15943\",CLASS=\"com.apple.hls.interstitial\","
-            + "END-DATE=\"2024-09-20T15:29:49.006Z\",X-PLAYOUT-LIMIT=24.953741497,"
+            + "audio0001.ts"
+            + "\n"
+            + "#EXT-X-DATERANGE:ID=\"15943\","
+            + "CLASS=\"com.apple.hls.interstitial\","
+            + "END-DATE=\"2024-09-20T15:29:49.006Z\","
+            + "X-PLAYOUT-LIMIT=24.953741497,"
             + "X-CONTENT-MAY-VARY=\"YES\","
-            + "X-RESUME-OFFSET=24.953741497";
+            + "X-RESUME-OFFSET=24.953741497\n";
 
     HlsMediaPlaylist playlist =
         (HlsMediaPlaylist)

--- a/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylistParserTest.java
+++ b/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylistParserTest.java
@@ -1197,12 +1197,12 @@ public class HlsMediaPlaylistParserTest {
             /* snapTypes= */ ImmutableList.of(),
             /* restrictions= */ ImmutableList.of(),
             /* clientDefinedAttributes= */ ImmutableList.of(
+                new HlsMediaPlaylist.ClientDefinedAttribute("X-GOOGLE-TEST-DOUBLE1", 12.123d),
+                new HlsMediaPlaylist.ClientDefinedAttribute("X-GOOGLE-TEST-DOUBLE2", 1d),
                 new HlsMediaPlaylist.ClientDefinedAttribute(
                     "X-GOOGLE-TEST-HEX",
                     "0XAB10A",
-                    HlsMediaPlaylist.ClientDefinedAttribute.TYPE_HEX_TEXT),
-                new HlsMediaPlaylist.ClientDefinedAttribute("X-GOOGLE-TEST-DOUBLE1", 12.123d),
-                new HlsMediaPlaylist.ClientDefinedAttribute("X-GOOGLE-TEST-DOUBLE2", 1d)));
+                    HlsMediaPlaylist.ClientDefinedAttribute.TYPE_HEX_TEXT)));
     InputStream inputStream = new ByteArrayInputStream(Util.getUtf8Bytes(playlistString));
 
     HlsMediaPlaylist playlist =

--- a/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylistParserTest.java
+++ b/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylistParserTest.java
@@ -1610,6 +1610,42 @@ public class HlsMediaPlaylistParserTest {
   }
 
   @Test
+  public void
+  parseMediaPlaylist_withInterstitialWithUpdatingDateRange()
+      throws IOException {
+    Uri playlistUri = Uri.parse("https://raw.githubusercontent.com/TomVarga/HLS-test-stream/refs/heads/main/ride/audio.m3u8");
+    String playlistString =
+        "#EXTM3U\n"
+            + "#EXT-X-VERSION:3\n"
+            + "#EXT-X-TARGETDURATION:10\n"
+            + "#EXT-X-MEDIA-SEQUENCE:0\n"
+            + "#EXT-X-PROGRAM-DATE-TIME:2024-09-20T15:29:20.000Z\n"
+            + "#EXTINF:10.007800,\n"
+            + "audio0000.ts\n"
+            + "#EXT-X-DATERANGE:ID=\"15943\","
+            + "CLASS=\"com.apple.hls.interstitial\","
+            + "START-DATE=\"2024-09-20T15:29:24.006Z\",PLANNED-DURATION=25,"
+            + "X-ASSET-LIST=\"myapp://interstitial/req?_HLS_interstitial_id=15943\","
+            + "X-SNAP=\"OUT,IN\",X-TIMELINE-OCCUPIES=\"RANGE\","
+            + "X-TIMELINE-STYLE=\"HIGHLIGHT\",X-CONTENT-MAY-VARY=\"YES\"\n"
+            + "#EXTINF:10.007800,\n"
+            + "audio0001.ts\n"
+            + "#EXT-X-DATERANGE:ID=\"15943\",CLASS=\"com.apple.hls.interstitial\","
+            + "END-DATE=\"2024-09-20T15:29:49.006Z\",X-PLAYOUT-LIMIT=24.953741497,"
+            + "X-RESUME-OFFSET=24.953741497";
+
+    HlsMediaPlaylist playlist =
+        (HlsMediaPlaylist)
+            new HlsPlaylistParser()
+                .parse(playlistUri, new ByteArrayInputStream(Util.getUtf8Bytes(playlistString)));
+
+    assertThat(playlist.interstitials.get(0).id).isEqualTo("15943");
+    assertThat(playlist.interstitials.get(0).resumeOffsetUs).isEqualTo(24953741L);
+    assertThat(playlist.interstitials.get(0).endDateUnixUs).isEqualTo(1726846189006000L);
+    assertThat(playlist.interstitials.get(0).playoutLimitUs).isEqualTo(24953741L);
+  }
+
+  @Test
   public void multipleExtXKeysForSingleSegment() throws Exception {
     Uri playlistUri = Uri.parse("https://example.com/test.m3u8");
     String playlistString =

--- a/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylistParserTest.java
+++ b/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/playlist/HlsMediaPlaylistParserTest.java
@@ -1445,7 +1445,8 @@ public class HlsMediaPlaylistParserTest {
   }
 
   @Test
-  public void parseMediaPlaylist_withInterstitialWithoutStartDate_throwsParserException() {
+  public void parseMediaPlaylist_withInterstitialWithoutStartDate_noInterstitial()
+      throws IOException {
     Uri playlistUri = Uri.parse("https://example.com/test.m3u8");
     String playlistString =
         "#EXTM3U\n"
@@ -1461,11 +1462,12 @@ public class HlsMediaPlaylistParserTest {
             + "X-ASSET-LIST=\"http://example.com/ad2-assets.json\"\n";
     HlsPlaylistParser hlsPlaylistParser = new HlsPlaylistParser();
 
-    assertThrows(
-        ParserException.class,
-        () ->
+    HlsMediaPlaylist playlist =
+        (HlsMediaPlaylist)
             hlsPlaylistParser.parse(
-                playlistUri, new ByteArrayInputStream(Util.getUtf8Bytes(playlistString))));
+                playlistUri, new ByteArrayInputStream(Util.getUtf8Bytes(playlistString)));
+
+    assertThat(playlist.interstitials).isEmpty();
   }
 
   @Test
@@ -1639,7 +1641,7 @@ public class HlsMediaPlaylistParserTest {
             new HlsPlaylistParser()
                 .parse(playlistUri, new ByteArrayInputStream(Util.getUtf8Bytes(playlistString)));
 
-    assertThat(playlist.interstitials.get(0).id).isEqualTo("15943");
+    assertThat(playlist.interstitials.size()).isEqualTo(1);
     assertThat(playlist.interstitials.get(0).resumeOffsetUs).isEqualTo(24953741L);
     assertThat(playlist.interstitials.get(0).endDateUnixUs).isEqualTo(1726846189006000L);
     assertThat(playlist.interstitials.get(0).playoutLimitUs).isEqualTo(24953741L);


### PR DESCRIPTION
### Use case description
According to the latest version of the HLS spec at https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.5.1

>  If a Playlist contains two EXT-X-DATERANGE tags with the same ID
>    attribute value, then any AttributeName that appears in both tags
>    MUST have the same AttributeValue.  A Server MAY augment a Date Range
>    with additional attributes by adding subsequent EXT-X-DATERANGE tags
>    with the same ID attribute to a Playlist.  The client is responsible
>    for consolidating the tags.  The subsequent EXT-X-DATERANGE tags can
>    appear in a subsequent playlist update, in the case of live or event
>    streams.


In a live stream scenario our system does updates to an interstitial according to the spec.

Here is simplified example stream:

https://raw.githubusercontent.com/TomVarga/HLS-test-stream/refs/heads/main/ride/audio.m3u8

### Proposed solution
I am creating a PR to show my proposed solution, which is going to allow updating the interstitial, but still require the START-DATE for the first appearance of the interstitial.






This is a naive solution:

- if an interstitial already appeared, then attempt to update it

Can use https://raw.githubusercontent.com/TomVarga/HLS-test-stream/refs/heads/main/ride/audio.m3u8 in the demo app to validate these changes