### PR TITLE
Better support for PCM audio formats around DefaultAudioSink

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/audio/AudioProcessorChain.java
+++ b/libraries/common/src/main/java/androidx/media3/common/audio/AudioProcessorChain.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.common.audio;
 
+import androidx.media3.common.Format;
 import androidx.media3.common.PlaybackParameters;
 import androidx.media3.common.util.UnstableApi;
 
@@ -33,7 +34,7 @@ public interface AudioProcessorChain {
    * during initialization, but audio processors may change state to become active/inactive during
    * playback.
    */
-  AudioProcessor[] getAudioProcessors();
+  AudioProcessor[] getAudioProcessors(Format inputFormat);
 
   /**
    * Configures audio processors to apply the specified playback parameters immediately, returning
@@ -50,7 +51,7 @@ public interface AudioProcessorChain {
    * value. Only called when processors have no input pending.
    *
    * @param skipSilenceEnabled Whether silences should be skipped in the audio stream.
-   * @return The new value.
+   * @return The value that was actually applied.
    */
   boolean applySkipSilenceEnabled(boolean skipSilenceEnabled);
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
@@ -120,7 +120,7 @@ public class DefaultRenderersFactory implements RenderersFactory {
   private long allowedVideoJoiningTimeMs;
   private boolean enableDecoderFallback;
   private MediaCodecSelector mediaCodecSelector;
-  private boolean enableFloatOutput;
+  private boolean enableHighResolutionPcmOutput;
   private boolean enableAudioOutputPlaybackParameters;
   private boolean enableMediaCodecVideoRendererPrewarming;
   private boolean parseAv1SampleDependencies;
@@ -231,19 +231,19 @@ public class DefaultRenderersFactory implements RenderersFactory {
   }
 
   /**
-   * Sets whether floating point audio should be output when possible.
+   * Sets whether to enable high resolution PCM output with more than 16 bits.
    *
-   * <p>Enabling floating point output disables audio processing, but may allow for higher quality
-   * audio output.
+   * <p>Parts of the default audio processing chain (for example, speed adjustment) will not be
+   * available when output formats other than 16-bit integer are in use.
    *
    * <p>The default value is {@code false}.
    *
-   * @param enableFloatOutput Whether to enable use of floating point audio output, if available.
    * @return This factory, for convenience.
    */
   @CanIgnoreReturnValue
-  public final DefaultRenderersFactory setEnableAudioFloatOutput(boolean enableFloatOutput) {
-    this.enableFloatOutput = enableFloatOutput;
+  public final DefaultRenderersFactory setEnableHighResolutionPcmOutput(
+      boolean enableHighResolutionPcmOutput) {
+    this.enableHighResolutionPcmOutput = enableHighResolutionPcmOutput;
     return this;
   }
 
@@ -436,7 +436,7 @@ public class DefaultRenderersFactory implements RenderersFactory {
         renderersList);
     @Nullable
     AudioSink audioSink =
-        buildAudioSink(context, enableFloatOutput, enableAudioOutputPlaybackParameters);
+        buildAudioSink(context, enableHighResolutionPcmOutput, enableAudioOutputPlaybackParameters);
     if (audioSink != null) {
       buildAudioRenderers(
           context,
@@ -884,7 +884,8 @@ public class DefaultRenderersFactory implements RenderersFactory {
    * Builds an {@link AudioSink} to which the audio renderers will output.
    *
    * @param context The {@link Context} associated with the player.
-   * @param enableFloatOutput Whether to enable use of floating point audio output, if available.
+   * @param enableHighResolutionPcmOutput Whether to enable high resolution PCM output with more
+   *     than 16 bits.
    * @param enableAudioOutputPlaybackParams Whether to enable setting playback speed via the {@link
    *     AudioOutput}, using {@link android.media.AudioTrack#setPlaybackParams(PlaybackParams)} by
    *     default, if supported. The {@link AudioOutput} speed adjustment is lower latency, but
@@ -895,9 +896,11 @@ public class DefaultRenderersFactory implements RenderersFactory {
    */
   @Nullable
   protected AudioSink buildAudioSink(
-      Context context, boolean enableFloatOutput, boolean enableAudioOutputPlaybackParams) {
+      Context context,
+      boolean enableHighResolutionPcmOutput,
+      boolean enableAudioOutputPlaybackParams) {
     return new DefaultAudioSink.Builder(context)
-        .setEnableFloatOutput(enableFloatOutput)
+        .setEnableHighResolutionPcmOutput(enableHighResolutionPcmOutput)
         .setEnableAudioOutputPlaybackParameters(enableAudioOutputPlaybackParams)
         .build();
   }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
@@ -236,8 +236,8 @@ public class DefaultRenderersFactory implements RenderersFactory {
   /**
    * Sets whether floating point audio should be output when possible.
    *
-   * <p>Enabling floating point output disables audio processing, but may allow for higher quality
-   * audio output.
+   * <p>Enabling floating point output disables the default audio processing chain, but may allow
+   * for higher quality audio output.
    *
    * <p>The default value is {@code false}.
    *

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/DefaultRenderersFactory.java
@@ -121,7 +121,7 @@ public class DefaultRenderersFactory implements RenderersFactory {
   private long allowedVideoJoiningTimeMs;
   private boolean enableDecoderFallback;
   private MediaCodecSelector mediaCodecSelector;
-  private boolean enableFloatOutput;
+  private boolean enableHighResolutionPcmOutput;
   private boolean enableAudioOutputPlaybackParameters;
   private boolean enableMediaCodecVideoRendererPrewarming;
   private boolean parseAv1SampleDependencies;
@@ -234,19 +234,19 @@ public class DefaultRenderersFactory implements RenderersFactory {
   }
 
   /**
-   * Sets whether floating point audio should be output when possible.
+   * Sets whether to enable high resolution PCM output with more than 16 bits.
    *
-   * <p>Enabling floating point output disables the default audio processing chain, but may allow
-   * for higher quality audio output.
+   * <p>Parts of the default audio processing chain (for example, speed adjustment) will not be
+   * available when output formats other than 16-bit integer are in use.
    *
    * <p>The default value is {@code false}.
    *
-   * @param enableFloatOutput Whether to enable use of floating point audio output, if available.
    * @return This factory, for convenience.
    */
   @CanIgnoreReturnValue
-  public final DefaultRenderersFactory setEnableAudioFloatOutput(boolean enableFloatOutput) {
-    this.enableFloatOutput = enableFloatOutput;
+  public final DefaultRenderersFactory setEnableHighResolutionPcmOutput(
+      boolean enableHighResolutionPcmOutput) {
+    this.enableHighResolutionPcmOutput = enableHighResolutionPcmOutput;
     return this;
   }
 
@@ -459,7 +459,7 @@ public class DefaultRenderersFactory implements RenderersFactory {
         renderersList);
     @Nullable
     AudioSink audioSink =
-        buildAudioSink(context, enableFloatOutput, enableAudioOutputPlaybackParameters);
+        buildAudioSink(context, enableHighResolutionPcmOutput, enableAudioOutputPlaybackParameters);
     if (audioSink != null) {
       buildAudioRenderers(
           context,
@@ -925,7 +925,8 @@ public class DefaultRenderersFactory implements RenderersFactory {
    * Builds an {@link AudioSink} to which the audio renderers will output.
    *
    * @param context The {@link Context} associated with the player.
-   * @param enableFloatOutput Whether to enable use of floating point audio output, if available.
+   * @param enableHighResolutionPcmOutput Whether to enable high resolution PCM output with more
+   *     than 16 bits.
    * @param enableAudioOutputPlaybackParams Whether to enable setting playback speed via the {@link
    *     AudioOutput}, using {@link android.media.AudioTrack#setPlaybackParams(PlaybackParams)} by
    *     default, if supported. The {@link AudioOutput} speed adjustment is lower latency, but
@@ -936,9 +937,11 @@ public class DefaultRenderersFactory implements RenderersFactory {
    */
   @Nullable
   protected AudioSink buildAudioSink(
-      Context context, boolean enableFloatOutput, boolean enableAudioOutputPlaybackParams) {
+      Context context,
+      boolean enableHighResolutionPcmOutput,
+      boolean enableAudioOutputPlaybackParams) {
     return new DefaultAudioSink.Builder(context)
-        .setEnableFloatOutput(enableFloatOutput)
+        .setEnableHighResolutionPcmOutput(enableHighResolutionPcmOutput)
         .setEnableAudioOutputPlaybackParameters(enableAudioOutputPlaybackParams)
         .build();
   }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -304,7 +304,7 @@ public final class DefaultAudioSink implements AudioSink {
     @Nullable private final Context context;
     private AudioCapabilities audioCapabilities;
     @Nullable private androidx.media3.common.audio.AudioProcessorChain audioProcessorChain;
-    private boolean enableFloatOutput;
+    private boolean enableHighResolutionPcmOutput;
     private boolean enableAudioOutputPlaybackParameters;
 
     private boolean buildCalled;
@@ -376,16 +376,16 @@ public final class DefaultAudioSink implements AudioSink {
     }
 
     /**
-     * Sets whether to enable 32-bit float output or integer output. Where possible, 32-bit float
-     * output will be used if the input is 32-bit float, and also if the input is high resolution
-     * (24-bit or 32-bit) integer PCM. Audio processing (for example, speed adjustment) will not be
-     * available when float output is in use.
+     * Sets whether to enable high resolution PCM output with more than 16 bits.
+     *
+     * <p>Parts of the default audio processing chain (for example, speed adjustment) will not be
+     * available when output formats other than 16-bit integer are in use.
      *
      * <p>The default value is {@code false}.
      */
     @CanIgnoreReturnValue
-    public Builder setEnableFloatOutput(boolean enableFloatOutput) {
-      this.enableFloatOutput = enableFloatOutput;
+    public Builder setEnableHighResolutionPcmOutput(boolean enableHighResolutionPcmOutput) {
+      this.enableHighResolutionPcmOutput = enableHighResolutionPcmOutput;
       return this;
     }
 
@@ -585,7 +585,7 @@ public final class DefaultAudioSink implements AudioSink {
 
   @Nullable private final Context context;
   private final androidx.media3.common.audio.AudioProcessorChain audioProcessorChain;
-  private final boolean enableFloatOutput;
+  private final boolean enableHighResolutionPcmOutput;
   private final ChannelMappingAudioProcessor channelMappingAudioProcessor;
   private final TrimmingAudioProcessor trimmingAudioProcessor;
   private final ToInt16PcmAudioProcessor toInt16PcmAudioProcessor;
@@ -655,7 +655,7 @@ public final class DefaultAudioSink implements AudioSink {
     context = builder.context == null ? null : builder.context.getApplicationContext();
     audioAttributes = AudioAttributes.DEFAULT;
     audioProcessorChain = builder.audioProcessorChain;
-    enableFloatOutput = builder.enableFloatOutput;
+    enableHighResolutionPcmOutput = builder.enableHighResolutionPcmOutput;
     preferAudioOutputPlaybackParameters = builder.enableAudioOutputPlaybackParameters;
     offloadMode = OFFLOAD_MODE_DISABLED;
     audioOutputProvider = builder.audioOutputProvider;
@@ -707,30 +707,25 @@ public final class DefaultAudioSink implements AudioSink {
 
   @Override
   public @SinkFormatSupport int getFormatSupport(Format format) {
-    // For PCM formats, convert the format to what our audio processors will produce.
-    boolean transcodingViaAudioProcessors = false;
-    if (Util.isEncodingLinearPcm(format.pcmEncoding)) {
-      boolean usesFloatPcm = shouldUseFloatOutput(format);
-      if (usesFloatPcm && format.pcmEncoding != C.ENCODING_PCM_FLOAT) {
-        format = format.buildUpon().setPcmEncoding(C.ENCODING_PCM_FLOAT).build();
-        transcodingViaAudioProcessors = true;
-      }
-      if (!usesFloatPcm && format.pcmEncoding != C.ENCODING_PCM_16BIT) {
-        format = format.buildUpon().setPcmEncoding(C.ENCODING_PCM_16BIT).build();
-        transcodingViaAudioProcessors = true;
-      }
-    }
     switch (audioOutputProvider.getFormatSupport(getFormatConfig(format)).supportLevel) {
       case AudioOutputProvider.FORMAT_SUPPORTED_DIRECTLY:
-        return transcodingViaAudioProcessors
-            ? SINK_FORMAT_SUPPORTED_WITH_TRANSCODING
-            : SINK_FORMAT_SUPPORTED_DIRECTLY;
+        return SINK_FORMAT_SUPPORTED_DIRECTLY;
       case AudioOutputProvider.FORMAT_SUPPORTED_WITH_TRANSCODING:
         return SINK_FORMAT_SUPPORTED_WITH_TRANSCODING;
       case AudioOutputProvider.FORMAT_UNSUPPORTED:
       default:
-        return SINK_FORMAT_UNSUPPORTED;
+        break;
     }
+    // Unsupported format.
+    if (MimeTypes.AUDIO_RAW.equals(format.sampleMimeType)
+        && Util.isEncodingLinearPcm(format.pcmEncoding)) {
+      @C.PcmEncoding int outputPcmEncoding = getOutputPcmEncoding(format);
+      if (outputPcmEncoding != C.ENCODING_INVALID) {
+        // We can convert this PCM format to something the output provider supports.
+        return SINK_FORMAT_SUPPORTED_WITH_TRANSCODING;
+      }
+    }
+    return SINK_FORMAT_UNSUPPORTED;
   }
 
   @Override
@@ -773,16 +768,20 @@ public final class DefaultAudioSink implements AudioSink {
       inputPcmFrameSize = Util.getPcmFrameSize(inputFormat.pcmEncoding, inputFormat.channelCount);
 
       ImmutableList.Builder<AudioProcessor> pipelineProcessors = new ImmutableList.Builder<>();
-      Format chainInputFormat;
       pipelineProcessors.addAll(availableAudioProcessors);
-      if (shouldUseFloatOutput(inputFormat)) {
-        pipelineProcessors.add(toFloatPcmAudioProcessor);
-        chainInputFormat = inputFormat.buildUpon().setPcmEncoding(C.ENCODING_PCM_FLOAT).build();
-      } else {
-        pipelineProcessors.add(toInt16PcmAudioProcessor);
-        chainInputFormat = inputFormat.buildUpon().setPcmEncoding(C.ENCODING_PCM_16BIT).build();
+      Format afterConversionFormat =
+          inputFormat.buildUpon().setPcmEncoding(getOutputPcmEncoding(inputFormat)).build();
+      checkState(Util.isEncodingLinearPcm(afterConversionFormat.pcmEncoding));
+      if (afterConversionFormat.pcmEncoding != inputFormat.pcmEncoding) {
+        // We need to convert sample formats either if the output provider doesn't support it, or if
+        // enableHighResolutionPcmOutput is set to false (which is reported as no support, too).
+        if (afterConversionFormat.pcmEncoding == C.ENCODING_PCM_FLOAT) {
+          pipelineProcessors.add(toFloatPcmAudioProcessor);
+        } else {
+          pipelineProcessors.add(toInt16PcmAudioProcessor);
+        }
       }
-      pipelineProcessors.add(audioProcessorChain.getAudioProcessors(chainInputFormat));
+      pipelineProcessors.add(audioProcessorChain.getAudioProcessors(afterConversionFormat));
       audioProcessingPipeline = new AudioProcessingPipeline(pipelineProcessors.build());
 
       // If the underlying processors of the new pipeline are the same as the existing pipeline,
@@ -1771,26 +1770,30 @@ public final class DefaultAudioSink implements AudioSink {
     return configuration != null && configuration.outputConfig.usePlaybackParameters;
   }
 
+  private boolean outputProviderSupportsFormat(Format inputFormat, @C.PcmEncoding int encoding) {
+    Format format = Util.getPcmFormat(encoding, inputFormat.channelCount, inputFormat.sampleRate);
+    return audioOutputProvider.getFormatSupport(getFormatConfig(format)).supportLevel
+        != AudioOutputProvider.FORMAT_UNSUPPORTED;
+  }
+
   /**
-   * Returns whether audio in the specified PCM format should be written to the audio output as
-   * float PCM.
+   * Returns the PCM encoding in which the audio in the specified PCM encoding should be written to
+   * the audio output, or {@link C#ENCODING_INVALID} if there is no strategy to output this format.
    */
-  private boolean shouldUseFloatOutput(Format format) {
-    boolean supportsFloat =
-        audioOutputProvider.getFormatSupport(
-                    getFormatConfig(
-                        format.buildUpon().setPcmEncoding(C.ENCODING_PCM_FLOAT).build()))
-                .supportLevel
-            != AudioOutputProvider.FORMAT_UNSUPPORTED;
-    boolean preferFloat = Util.isEncodingHighResolutionPcm(format.pcmEncoding);
-    // If the AudioOutputProvider cannot output 16-bit PCM, we should use float output.
-    boolean supportsInt16 =
-        audioOutputProvider.getFormatSupport(
-                    getFormatConfig(
-                        format.buildUpon().setPcmEncoding(C.ENCODING_PCM_16BIT).build()))
-                .supportLevel
-            != AudioOutputProvider.FORMAT_UNSUPPORTED;
-    return supportsFloat && enableFloatOutput && (preferFloat || !supportsInt16);
+  private @C.PcmEncoding int getOutputPcmEncoding(Format inputFormat) {
+    if (outputProviderSupportsFormat(inputFormat, inputFormat.pcmEncoding)) {
+      return inputFormat.pcmEncoding;
+    }
+    boolean preferFloatOverInt16 =
+        Util.isEncodingHighResolutionPcm(inputFormat.pcmEncoding)
+            || !outputProviderSupportsFormat(inputFormat, C.ENCODING_PCM_16BIT);
+    if (preferFloatOverInt16 && outputProviderSupportsFormat(inputFormat, C.ENCODING_PCM_FLOAT)) {
+      return C.ENCODING_PCM_FLOAT;
+    }
+    if (outputProviderSupportsFormat(inputFormat, C.ENCODING_PCM_16BIT)) {
+      return C.ENCODING_PCM_16BIT;
+    }
+    return C.ENCODING_INVALID;
   }
 
   /**
@@ -1892,7 +1895,7 @@ public final class DefaultAudioSink implements AudioSink {
   private FormatConfig getFormatConfig(Format format, int preferredBufferSize) {
     return new FormatConfig.Builder(format)
         .setAudioAttributes(audioAttributes)
-        .setEnableHighResolutionPcmOutput(enableFloatOutput)
+        .setEnableHighResolutionPcmOutput(enableHighResolutionPcmOutput)
         .setEnablePlaybackParameters(preferAudioOutputPlaybackParameters)
         .setEnableOffload(offloadMode != AudioSink.OFFLOAD_MODE_DISABLED)
         .setPreferredDevice(preferredDevice)

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -154,10 +154,14 @@ public final class DefaultAudioSink implements AudioSink {
   /**
    * The default audio processor chain, which applies a (possibly empty) chain of user-defined audio
    * processors followed by {@link SilenceSkippingAudioProcessor} and {@link SonicAudioProcessor}.
+   *
+   * <p>For backwards compatibility, no audio processors will be applied for PCM encodings other
+   * than 16-bit integer.
    */
   @SuppressWarnings("deprecation")
   public static class DefaultAudioProcessorChain implements AudioProcessorChain {
 
+    private boolean formatSupported = false;
     private final AudioProcessor[] audioProcessors;
     private final SilenceSkippingAudioProcessor silenceSkippingAudioProcessor;
     private final SonicAudioProcessor sonicAudioProcessor;
@@ -194,12 +198,22 @@ public final class DefaultAudioSink implements AudioSink {
     }
 
     @Override
-    public AudioProcessor[] getAudioProcessors() {
+    public AudioProcessor[] getAudioProcessors(Format inputFormat) {
+      if (inputFormat.pcmEncoding != C.ENCODING_PCM_16BIT) {
+        formatSupported = false;
+        return new AudioProcessor[0];
+      }
+      formatSupported = true;
       return audioProcessors;
     }
 
     @Override
     public PlaybackParameters applyPlaybackParameters(PlaybackParameters playbackParameters) {
+      if (!formatSupported) {
+        // We don't apply speed/pitch adjustment using an audio processor when outputting
+        // high-resolution PCM audio, because SonicAudioProcessor outputs 16-bit integer PCM.
+        return PlaybackParameters.DEFAULT;
+      }
       sonicAudioProcessor.setSpeed(playbackParameters.speed);
       sonicAudioProcessor.setPitch(playbackParameters.pitch);
       return playbackParameters;
@@ -207,6 +221,11 @@ public final class DefaultAudioSink implements AudioSink {
 
     @Override
     public boolean applySkipSilenceEnabled(boolean skipSilenceEnabled) {
+      if (!formatSupported) {
+        // We don't skip silence using an audio processor when outputting high-resolution PCM audio,
+        // because SilenceSkippingAudioProcessor only supports 16-bit integer PCM.
+        return false;
+      }
       silenceSkippingAudioProcessor.setEnabled(skipSilenceEnabled);
       return skipSilenceEnabled;
     }
@@ -754,13 +773,16 @@ public final class DefaultAudioSink implements AudioSink {
       inputPcmFrameSize = Util.getPcmFrameSize(inputFormat.pcmEncoding, inputFormat.channelCount);
 
       ImmutableList.Builder<AudioProcessor> pipelineProcessors = new ImmutableList.Builder<>();
+      Format chainInputFormat;
       pipelineProcessors.addAll(availableAudioProcessors);
       if (shouldUseFloatOutput(inputFormat.pcmEncoding)) {
         pipelineProcessors.add(toFloatPcmAudioProcessor);
+        chainInputFormat = inputFormat.buildUpon().setPcmEncoding(C.ENCODING_PCM_FLOAT).build();
       } else {
         pipelineProcessors.add(toInt16PcmAudioProcessor);
-        pipelineProcessors.add(audioProcessorChain.getAudioProcessors());
+        chainInputFormat = inputFormat.buildUpon().setPcmEncoding(C.ENCODING_PCM_16BIT).build();
       }
+      pipelineProcessors.add(audioProcessorChain.getAudioProcessors(chainInputFormat));
       audioProcessingPipeline = new AudioProcessingPipeline(pipelineProcessors.build());
 
       // If the underlying processors of the new pipeline are the same as the existing pipeline,
@@ -1739,13 +1761,10 @@ public final class DefaultAudioSink implements AudioSink {
     // We don't apply speed/pitch adjustment using an audio processor in the following cases:
     // - in tunneling mode, because audio processing can change the duration of audio yet the video
     //   frame presentation times are currently not modified (see also
-    //   https://github.com/google/ExoPlayer/issues/4803);
+    //   https://github.com/google/ExoPlayer/issues/4803); and
     // - when playing encoded audio via passthrough/offload, because modifying the audio stream
-    //   would require decoding/re-encoding; and
-    // - when outputting float PCM audio, because SonicAudioProcessor outputs 16-bit integer PCM.
-    return !tunneling
-        && configuration.isPcm()
-        && !shouldUseFloatOutput(configuration.inputFormat.pcmEncoding);
+    //   would require decoding/re-encoding.
+    return !tunneling && configuration.isPcm();
   }
 
   private boolean useAudioOutputPlaybackParams() {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -710,7 +710,7 @@ public final class DefaultAudioSink implements AudioSink {
     // For PCM formats, convert the format to what our audio processors will produce.
     boolean transcodingViaAudioProcessors = false;
     if (Util.isEncodingLinearPcm(format.pcmEncoding)) {
-      boolean usesFloatPcm = shouldUseFloatOutput(format.pcmEncoding);
+      boolean usesFloatPcm = shouldUseFloatOutput(format);
       if (usesFloatPcm && format.pcmEncoding != C.ENCODING_PCM_FLOAT) {
         format = format.buildUpon().setPcmEncoding(C.ENCODING_PCM_FLOAT).build();
         transcodingViaAudioProcessors = true;
@@ -775,7 +775,7 @@ public final class DefaultAudioSink implements AudioSink {
       ImmutableList.Builder<AudioProcessor> pipelineProcessors = new ImmutableList.Builder<>();
       Format chainInputFormat;
       pipelineProcessors.addAll(availableAudioProcessors);
-      if (shouldUseFloatOutput(inputFormat.pcmEncoding)) {
+      if (shouldUseFloatOutput(inputFormat)) {
         pipelineProcessors.add(toFloatPcmAudioProcessor);
         chainInputFormat = inputFormat.buildUpon().setPcmEncoding(C.ENCODING_PCM_FLOAT).build();
       } else {
@@ -1772,11 +1772,25 @@ public final class DefaultAudioSink implements AudioSink {
   }
 
   /**
-   * Returns whether audio in the specified PCM encoding should be written to the audio output as
+   * Returns whether audio in the specified PCM format should be written to the audio output as
    * float PCM.
    */
-  private boolean shouldUseFloatOutput(@C.PcmEncoding int pcmEncoding) {
-    return enableFloatOutput && Util.isEncodingHighResolutionPcm(pcmEncoding);
+  private boolean shouldUseFloatOutput(Format format) {
+    boolean supportsFloat =
+        audioOutputProvider.getFormatSupport(
+                    getFormatConfig(
+                        format.buildUpon().setPcmEncoding(C.ENCODING_PCM_FLOAT).build()))
+                .supportLevel
+            != AudioOutputProvider.FORMAT_UNSUPPORTED;
+    boolean preferFloat = Util.isEncodingHighResolutionPcm(format.pcmEncoding);
+    // If the AudioOutputProvider cannot output 16-bit PCM, we should use float output.
+    boolean supportsInt16 =
+        audioOutputProvider.getFormatSupport(
+                    getFormatConfig(
+                        format.buildUpon().setPcmEncoding(C.ENCODING_PCM_16BIT).build()))
+                .supportLevel
+            != AudioOutputProvider.FORMAT_UNSUPPORTED;
+    return supportsFloat && enableFloatOutput && (preferFloat || !supportsInt16);
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ToFloatPcmAudioProcessor.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ToFloatPcmAudioProcessor.java
@@ -47,7 +47,7 @@ public final class ToFloatPcmAudioProcessor extends BaseAudioProcessor {
   public AudioFormat onConfigure(AudioFormat inputAudioFormat)
       throws UnhandledAudioFormatException {
     @C.PcmEncoding int encoding = inputAudioFormat.encoding;
-    if (!Util.isEncodingHighResolutionPcm(encoding) && encoding != C.ENCODING_PCM_16BIT) {
+    if (!Util.isEncodingLinearPcm(encoding)) {
       throw new UnhandledAudioFormatException(inputAudioFormat);
     }
     return encoding != C.ENCODING_PCM_FLOAT
@@ -64,11 +64,26 @@ public final class ToFloatPcmAudioProcessor extends BaseAudioProcessor {
 
     ByteBuffer buffer;
     switch (inputAudioFormat.encoding) {
+      case C.ENCODING_PCM_8BIT:
+        buffer = replaceOutputBuffer(size * 4);
+        for (int i = position; i < limit; i++) {
+          int pcm32BitInteger = ((inputBuffer.get(i) & 0xFF) << 24);
+          writePcm32BitFloat(pcm32BitInteger, buffer);
+        }
+        break;
       case C.ENCODING_PCM_16BIT:
         buffer = replaceOutputBuffer(size * 2);
         for (int i = position; i < limit; i += 2) {
           int pcm32BitInteger =
               ((inputBuffer.get(i) & 0xFF) << 16) | ((inputBuffer.get(i + 1) & 0xFF) << 24);
+          writePcm32BitFloat(pcm32BitInteger, buffer);
+        }
+        break;
+      case C.ENCODING_PCM_16BIT_BIG_ENDIAN:
+        buffer = replaceOutputBuffer(size * 2);
+        for (int i = position; i < limit; i += 2) {
+          int pcm32BitInteger =
+              ((inputBuffer.get(i + 1) & 0xFF) << 16) | ((inputBuffer.get(i) & 0xFF) << 24);
           writePcm32BitFloat(pcm32BitInteger, buffer);
         }
         break;
@@ -120,8 +135,6 @@ public final class ToFloatPcmAudioProcessor extends BaseAudioProcessor {
           buffer.putFloat((float) inputBuffer.getDouble(i));
         }
         break;
-      case C.ENCODING_PCM_8BIT:
-      case C.ENCODING_PCM_16BIT_BIG_ENDIAN:
       case C.ENCODING_PCM_FLOAT:
       case C.ENCODING_INVALID:
       case Format.NO_VALUE:

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/AudioOffloadEndToEndTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/AudioOffloadEndToEndTest.java
@@ -80,7 +80,9 @@ public class AudioOffloadEndToEndTest {
         new DefaultRenderersFactory(applicationContext) {
           @Override
           protected AudioSink buildAudioSink(
-              Context context, boolean enableFloatOutput, boolean enableAudioOutputPlaybackParams) {
+              Context context,
+              boolean enableHighResolutionPcmOutput,
+              boolean enableAudioOutputPlaybackParams) {
             AudioOffloadListener audioOffloadListener =
                 new AudioOffloadListener() {
                   @Override
@@ -89,7 +91,7 @@ public class AudioOffloadEndToEndTest {
                   }
                 };
             return new DefaultAudioSink.Builder(applicationContext)
-                .setEnableFloatOutput(enableFloatOutput)
+                .setEnableAudioOutputPlaybackParameters(enableHighResolutionPcmOutput)
                 .setEnableAudioOutputPlaybackParameters(enableAudioOutputPlaybackParams)
                 .setExperimentalAudioOffloadListener(audioOffloadListener)
                 .build();

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/DefaultAudioSinkTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/DefaultAudioSinkTest.java
@@ -130,7 +130,7 @@ public final class DefaultAudioSinkTest {
             .setAudioProcessorChain(
                 new AudioProcessorChain() {
                   @Override
-                  public AudioProcessor[] getAudioProcessors() {
+                  public AudioProcessor[] getAudioProcessors(Format inputFormat) {
                     return new AudioProcessor[0];
                   }
 
@@ -347,7 +347,7 @@ public final class DefaultAudioSinkTest {
   }
 
   @Test
-  public void getFormatSupport_pcm16BitFloatOutputDisabled_supportedDirectly() {
+  public void getFormatSupport_pcm16BitHighResolutionPcmOutputDisabled_supportedDirectly() {
     defaultAudioSink =
         new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext()).build();
     Format floatFormat =
@@ -356,16 +356,15 @@ public final class DefaultAudioSinkTest {
             .setSampleMimeType(MimeTypes.AUDIO_RAW)
             .setPcmEncoding(C.ENCODING_PCM_16BIT)
             .build();
-
     assertThat(defaultAudioSink.getFormatSupport(floatFormat))
         .isEqualTo(SINK_FORMAT_SUPPORTED_DIRECTLY);
   }
 
   @Test
-  public void getFormatSupport_pcm16BitFloatOutputEnabled_supportedDirectly() {
+  public void getFormatSupport_pcm16BitHighResolutionPcmOutputEnabled_supportedDirectly() {
     defaultAudioSink =
         new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext())
-            .setEnableFloatOutput(true)
+            .setEnableHighResolutionPcmOutput(true)
             .build();
     Format floatFormat =
         STEREO_44_1_FORMAT
@@ -379,7 +378,7 @@ public final class DefaultAudioSinkTest {
   }
 
   @Test
-  public void getFormatSupport_pcm24BitFloatOutputDisabled_supportedWithTranscoding() {
+  public void getFormatSupport_pcm24BitHighResolutionPcmOutputDisabled_supportedWithTranscoding() {
     defaultAudioSink =
         new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext()).build();
     Format floatFormat =
@@ -394,10 +393,11 @@ public final class DefaultAudioSinkTest {
   }
 
   @Test
-  public void getFormatSupport_pcm24BitFloatOutputEnabled_supportedDirectly() {
+  @Config(maxSdk = 30)
+  public void getFormatSupport_pcm24BitHighResolutionPcmOutputEnabled_supportedDirectlyPreApi31() {
     defaultAudioSink =
         new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext())
-            .setEnableFloatOutput(true)
+            .setEnableHighResolutionPcmOutput(true)
             .build();
     Format floatFormat =
         STEREO_44_1_FORMAT
@@ -411,7 +411,61 @@ public final class DefaultAudioSinkTest {
   }
 
   @Test
-  public void getFormatSupport_floatPcmFloatOutputDisabled_supportedWithTranscoding() {
+  @Config(minSdk = 31)
+  public void getFormatSupport_pcm24BitHighResolutionPcmOutputEnabled_supportedDirectlyApi31() {
+    defaultAudioSink =
+        new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext())
+            .setEnableHighResolutionPcmOutput(true)
+            .build();
+    Format floatFormat =
+        STEREO_44_1_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_RAW)
+            .setPcmEncoding(C.ENCODING_PCM_24BIT)
+            .build();
+
+    assertThat(defaultAudioSink.getFormatSupport(floatFormat))
+        .isEqualTo(SINK_FORMAT_SUPPORTED_DIRECTLY);
+  }
+
+  @Test
+  @Config(maxSdk = 30)
+  public void getFormatSupport_pcm32BitHighResolutionPcmOutputEnabled_supportedDirectlyPreApi31() {
+    defaultAudioSink =
+        new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext())
+            .setEnableHighResolutionPcmOutput(true)
+            .build();
+    Format floatFormat =
+        STEREO_44_1_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_RAW)
+            .setPcmEncoding(C.ENCODING_PCM_32BIT)
+            .build();
+
+    assertThat(defaultAudioSink.getFormatSupport(floatFormat))
+        .isEqualTo(SINK_FORMAT_SUPPORTED_WITH_TRANSCODING);
+  }
+
+  @Test
+  @Config(minSdk = 31)
+  public void getFormatSupport_pcm32BitHighResolutionPcmOutputEnabled_supportedDirectlyApi31() {
+    defaultAudioSink =
+        new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext())
+            .setEnableHighResolutionPcmOutput(true)
+            .build();
+    Format floatFormat =
+        STEREO_44_1_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_RAW)
+            .setPcmEncoding(C.ENCODING_PCM_32BIT)
+            .build();
+
+    assertThat(defaultAudioSink.getFormatSupport(floatFormat))
+        .isEqualTo(SINK_FORMAT_SUPPORTED_DIRECTLY);
+  }
+
+  @Test
+  public void getFormatSupport_floatPcmHighResolutionPcmOutputDisabled_supportedWithTranscoding() {
     defaultAudioSink =
         new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext()).build();
     Format floatFormat =
@@ -426,10 +480,10 @@ public final class DefaultAudioSinkTest {
   }
 
   @Test
-  public void getFormatSupport_floatPcmFloatOutputEnabled_supportedDirectly() {
+  public void getFormatSupport_floatPcmHighResolutionPcmOutputEnabled_supportedDirectly() {
     defaultAudioSink =
         new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext())
-            .setEnableFloatOutput(true)
+            .setEnableHighResolutionPcmOutput(true)
             .build();
     Format floatFormat =
         STEREO_44_1_FORMAT

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/DefaultAudioSinkTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/DefaultAudioSinkTest.java
@@ -441,7 +441,7 @@ public final class DefaultAudioSinkTest {
   }
 
   @Test
-  public void getFormatSupport_pcm16BitFloatOutputDisabled_supportedDirectly() {
+  public void getFormatSupport_pcm16BitHighResolutionPcmOutputDisabled_supportedDirectly() {
     defaultAudioSink =
         new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext()).build();
     Format floatFormat =
@@ -450,16 +450,15 @@ public final class DefaultAudioSinkTest {
             .setSampleMimeType(MimeTypes.AUDIO_RAW)
             .setPcmEncoding(C.ENCODING_PCM_16BIT)
             .build();
-
     assertThat(defaultAudioSink.getFormatSupport(floatFormat))
         .isEqualTo(SINK_FORMAT_SUPPORTED_DIRECTLY);
   }
 
   @Test
-  public void getFormatSupport_pcm16BitFloatOutputEnabled_supportedDirectly() {
+  public void getFormatSupport_pcm16BitHighResolutionPcmOutputEnabled_supportedDirectly() {
     defaultAudioSink =
         new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext())
-            .setEnableFloatOutput(true)
+            .setEnableHighResolutionPcmOutput(true)
             .build();
     Format floatFormat =
         STEREO_44_1_FORMAT
@@ -473,7 +472,7 @@ public final class DefaultAudioSinkTest {
   }
 
   @Test
-  public void getFormatSupport_pcm24BitFloatOutputDisabled_supportedWithTranscoding() {
+  public void getFormatSupport_pcm24BitHighResolutionPcmOutputDisabled_supportedWithTranscoding() {
     defaultAudioSink =
         new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext()).build();
     Format floatFormat =
@@ -488,10 +487,11 @@ public final class DefaultAudioSinkTest {
   }
 
   @Test
-  public void getFormatSupport_pcm24BitFloatOutputEnabled_supportedDirectly() {
+  @Config(maxSdk = 30)
+  public void getFormatSupport_pcm24BitHighResolutionPcmOutputEnabled_supportedDirectlyPreApi31() {
     defaultAudioSink =
         new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext())
-            .setEnableFloatOutput(true)
+            .setEnableHighResolutionPcmOutput(true)
             .build();
     Format floatFormat =
         STEREO_44_1_FORMAT
@@ -505,7 +505,61 @@ public final class DefaultAudioSinkTest {
   }
 
   @Test
-  public void getFormatSupport_floatPcmFloatOutputDisabled_supportedWithTranscoding() {
+  @Config(minSdk = 31)
+  public void getFormatSupport_pcm24BitHighResolutionPcmOutputEnabled_supportedDirectlyApi31() {
+    defaultAudioSink =
+        new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext())
+            .setEnableHighResolutionPcmOutput(true)
+            .build();
+    Format floatFormat =
+        STEREO_44_1_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_RAW)
+            .setPcmEncoding(C.ENCODING_PCM_24BIT)
+            .build();
+
+    assertThat(defaultAudioSink.getFormatSupport(floatFormat))
+        .isEqualTo(SINK_FORMAT_SUPPORTED_DIRECTLY);
+  }
+
+  @Test
+  @Config(maxSdk = 30)
+  public void getFormatSupport_pcm32BitHighResolutionPcmOutputEnabled_supportedDirectlyPreApi31() {
+    defaultAudioSink =
+        new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext())
+            .setEnableHighResolutionPcmOutput(true)
+            .build();
+    Format floatFormat =
+        STEREO_44_1_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_RAW)
+            .setPcmEncoding(C.ENCODING_PCM_32BIT)
+            .build();
+
+    assertThat(defaultAudioSink.getFormatSupport(floatFormat))
+        .isEqualTo(SINK_FORMAT_SUPPORTED_WITH_TRANSCODING);
+  }
+
+  @Test
+  @Config(minSdk = 31)
+  public void getFormatSupport_pcm32BitHighResolutionPcmOutputEnabled_supportedDirectlyApi31() {
+    defaultAudioSink =
+        new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext())
+            .setEnableHighResolutionPcmOutput(true)
+            .build();
+    Format floatFormat =
+        STEREO_44_1_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_RAW)
+            .setPcmEncoding(C.ENCODING_PCM_32BIT)
+            .build();
+
+    assertThat(defaultAudioSink.getFormatSupport(floatFormat))
+        .isEqualTo(SINK_FORMAT_SUPPORTED_DIRECTLY);
+  }
+
+  @Test
+  public void getFormatSupport_floatPcmHighResolutionPcmOutputDisabled_supportedWithTranscoding() {
     defaultAudioSink =
         new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext()).build();
     Format floatFormat =
@@ -520,10 +574,10 @@ public final class DefaultAudioSinkTest {
   }
 
   @Test
-  public void getFormatSupport_floatPcmFloatOutputEnabled_supportedDirectly() {
+  public void getFormatSupport_floatPcmHighResolutionPcmOutputEnabled_supportedDirectly() {
     defaultAudioSink =
         new DefaultAudioSink.Builder(ApplicationProvider.getApplicationContext())
-            .setEnableFloatOutput(true)
+            .setEnableHighResolutionPcmOutput(true)
             .build();
     Format floatFormat =
         STEREO_44_1_FORMAT

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/DefaultAudioSinkTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/DefaultAudioSinkTest.java
@@ -158,7 +158,7 @@ public final class DefaultAudioSinkTest {
             .setAudioProcessorChain(
                 new AudioProcessorChain() {
                   @Override
-                  public AudioProcessor[] getAudioProcessors() {
+                  public AudioProcessor[] getAudioProcessors(Format inputFormat) {
                     return new AudioProcessor[0];
                   }
 

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/e2etest/EndToEndOffloadFailureRecoveryTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/e2etest/EndToEndOffloadFailureRecoveryTest.java
@@ -140,11 +140,13 @@ public class EndToEndOffloadFailureRecoveryTest {
 
     @Override
     protected AudioSink buildAudioSink(
-        Context context, boolean enableFloatOutput, boolean enableAudioOutputPlaybackParams) {
+        Context context,
+        boolean enableHighResolutionPcmOutput,
+        boolean enableAudioOutputPlaybackParams) {
       dumpingAudioSink =
           new DumpingAudioSinkWithOffloadInitFailure(
               new DefaultAudioSink.Builder(context)
-                  .setEnableFloatOutput(enableFloatOutput)
+                  .setEnableHighResolutionPcmOutput(enableHighResolutionPcmOutput)
                   .setEnableAudioOutputPlaybackParameters(enableAudioOutputPlaybackParams)
                   .build());
       return dumpingAudioSink;
@@ -170,11 +172,13 @@ public class EndToEndOffloadFailureRecoveryTest {
 
     @Override
     protected AudioSink buildAudioSink(
-        Context context, boolean enableFloatOutput, boolean enableAudioOutputPlaybackParams) {
+        Context context,
+        boolean enableHighResolutionPcmOutput,
+        boolean enableAudioOutputPlaybackParams) {
       dumpingAudioSink =
           new DumpingAudioSinkWithOffloadWriteFailure(
               new DefaultAudioSink.Builder(context)
-                  .setEnableFloatOutput(enableFloatOutput)
+                  .setEnableHighResolutionPcmOutput(enableHighResolutionPcmOutput)
                   .setEnableAudioOutputPlaybackParameters(enableAudioOutputPlaybackParams)
                   .build());
       return dumpingAudioSink;

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/e2etest/OggOpusPlaybackTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/e2etest/OggOpusPlaybackTest.java
@@ -130,11 +130,13 @@ public final class OggOpusPlaybackTest {
 
     @Override
     protected AudioSink buildAudioSink(
-        Context context, boolean enableFloatOutput, boolean enableAudioOutputPlaybackParams) {
+        Context context,
+        boolean enableHighResolutionPcmOutput,
+        boolean enableAudioOutputPlaybackParams) {
       dumpingAudioSink =
           new DumpingAudioSink(
               new DefaultAudioSink.Builder(context)
-                  .setEnableFloatOutput(enableFloatOutput)
+                  .setEnableHighResolutionPcmOutput(enableHighResolutionPcmOutput)
                   .setEnableAudioOutputPlaybackParameters(enableAudioOutputPlaybackParams)
                   .build());
       return dumpingAudioSink;

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/e2etest/OggOpusPlaybackTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/e2etest/OggOpusPlaybackTest.java
@@ -129,11 +129,13 @@ public final class OggOpusPlaybackTest {
 
     @Override
     protected AudioSink buildAudioSink(
-        Context context, boolean enableFloatOutput, boolean enableAudioOutputPlaybackParams) {
+        Context context,
+        boolean enableHighResolutionPcmOutput,
+        boolean enableAudioOutputPlaybackParams) {
       dumpingAudioSink =
           new DumpingAudioSink(
               new DefaultAudioSink.Builder(context)
-                  .setEnableFloatOutput(enableFloatOutput)
+                  .setEnableHighResolutionPcmOutput(enableHighResolutionPcmOutput)
                   .setEnableAudioOutputPlaybackParameters(enableAudioOutputPlaybackParams)
                   .build());
       return dumpingAudioSink;


### PR DESCRIPTION
This change:
- abstracts away the fact that SonicAudioProcessor does not support float PCM from the audio sink to the audio processor chain (easier to replace)
- makes the audio sink allow custom audio processors with any output format
- adds a new mode to DefaultAudioSink that allows any supported linear PCM format to be output into the AudioTrack

Issue: https://github.com/google/ExoPlayer/issues/10516
Issue: https://github.com/androidx/media/issues/1931