### PR TITLE
Should skip SEI payload when SEI type mismatch

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -22,6 +22,8 @@
         placeholder seek points), and fall back to binary search seeking if the
         duration of the file is known
         ([#2327]()https://github.com/androidx/media/issues/2327).
+    *   Fix parsing of H.265 SEI units to fully skip unrecognized SEI types
+        ([#2456]()https://github.com/androidx/media/issues/2456).
 *   DataSource:
 *   Audio:
     *   Add support for all linear PCM sample formats in

--- a/libraries/container/src/main/java/androidx/media3/container/NalUnitUtil.java
+++ b/libraries/container/src/main/java/androidx/media3/container/NalUnitUtil.java
@@ -1868,6 +1868,8 @@ public final class NalUnitUtil {
             mantissaRefDisplayWidth,
             exponentRefViewingDist,
             mantissaRefViewingDist);
+      } else {
+        data.skipBits(payloadSize * 8);
       }
     }
     return null;


### PR DESCRIPTION
This PR tries to fix  #2456

The function `parseH265Sei3dRefDisplayInfo` tries to find SEI of type 179 and extract 3d ref DisplayInfo from it. But when the SEI type does not match 179, it fails to properly skip the unprocessed SEI payload. Instead, it continues searching for the number 179 within the payload content. This may mistakenly treat payloads of other types SEI as the target type (179), leading to incorrect parsing and eventual through an exception.

The missing else branch is added to skip payload bytes.