### PR TITLE
Fix bug in CEA-608 caption display

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/cea/CeaDecoder.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/cea/CeaDecoder.java
@@ -117,6 +117,14 @@ import java.util.ArrayDeque;
         return outputBuffer;
       }
 
+      // Cater for buffers out of sequence
+      CeaInputBuffer next = queuedInputBuffers.peek();
+      if (next != null &&  next.timeUs < inputBuffer.timeUs) {
+        queuedInputBuffers.poll(); // remove next from queue
+        queuedInputBuffers.addFirst(inputBuffer);
+        inputBuffer = next;
+      }
+
       decode(inputBuffer);
 
       if (isNewSubtitleDataAvailable()) {


### PR DESCRIPTION
I upgraded from 1.4.0 to 1.6.1. CEA-608 captions were displaying correctly in 1.4.0, but are now mangled. The correct letters are present but in the wrong order, for example see below (these are actual captions seen). The correct caption is in parentheses. This affects every caption, all are mangled.

    ybMae,ut b, still,ou y kno..w.    (Maybe, but still, you know...)
    Yeahyo, u t gotoe  bcarel.fu      (Yeah, you got to be careful.)
    I'gom nntea llat Prickha tt       (I'm gonna tell Patrick that)

The cause is that buffers are being processed out of order. I don't know why the ordering has changed between 1.4.0 and 1.6.1. Each buffer creates two characters, so pairs of characters are switched.

I made a simple change to fix it. If the buffer being processed and the next buffer are out of sequence, switch them. This fixes the problem in all of the above examples and others I have tested.

