### PR TITLE
[b/372449691] Remove `packagingOptions` from `build.gradle` files

### DIFF
--- a/libraries/decoder_av1/build.gradle
+++ b/libraries/decoder_av1/build.gradle
@@ -27,14 +27,6 @@ android {
             }
         }
     }
-
-    // TODO(Internal: b/372449691): Remove packagingOptions once AGP is updated
-    // to version 8.5.1 or higher.
-    packagingOptions {
-        jniLibs {
-            useLegacyPackaging true
-        }
-    }
 }
 
 // Configure the native build only if libgav1 is present to avoid gradle sync

--- a/libraries/decoder_dav1d/build.gradle
+++ b/libraries/decoder_dav1d/build.gradle
@@ -23,14 +23,6 @@ android {
             }
         }
     }
-
-    // TODO(Internal: b/372449691): Remove packagingOptions once AGP is updated
-    // to version 8.5.1 or higher.
-    packagingOptions {
-        jniLibs {
-            useLegacyPackaging true
-        }
-    }
 }
 
 // Configure the native build only if dav1d is present to avoid gradle sync

--- a/libraries/decoder_ffmpeg/build.gradle
+++ b/libraries/decoder_ffmpeg/build.gradle
@@ -15,14 +15,6 @@ apply from: "$gradle.ext.androidxMediaSettingsDir/common_library_config.gradle"
 
 android {
     namespace 'androidx.media3.decoder.ffmpeg'
-
-    // TODO(Internal: b/372449691): Remove packagingOptions once AGP is updated
-    // to version 8.5.1 or higher.
-    packagingOptions {
-        jniLibs {
-            useLegacyPackaging true
-        }
-    }
 }
 
 // Configure the native build only if ffmpeg is present to avoid gradle sync

--- a/libraries/decoder_flac/build.gradle
+++ b/libraries/decoder_flac/build.gradle
@@ -29,14 +29,6 @@ android {
             }
         }
     }
-
-    // TODO(Internal: b/372449691): Remove packagingOptions once AGP is updated
-    // to version 8.5.1 or higher.
-    packagingOptions {
-        jniLibs {
-            useLegacyPackaging true
-        }
-    }
 }
 
 // Configure the native build only if libflac is present to avoid gradle sync

--- a/libraries/decoder_iamf/build.gradle
+++ b/libraries/decoder_iamf/build.gradle
@@ -27,14 +27,6 @@ android {
             }
         }
     }
-
-    // TODO(Internal: b/372449691): Remove packagingOptions once AGP is updated
-    // to version 8.5.1 or higher.
-    packagingOptions {
-        jniLibs {
-            useLegacyPackaging true
-        }
-    }
 }
 
 // Configure the native build only if libiamf is present to avoid gradle sync

--- a/libraries/decoder_mpegh/build.gradle
+++ b/libraries/decoder_mpegh/build.gradle
@@ -27,14 +27,6 @@ android {
             }
         }
     }
-
-    // TODO(Internal: b/372449691): Remove packagingOptions once AGP is updated
-    // to version 8.5.1 or higher.
-    packagingOptions {
-        jniLibs {
-            useLegacyPackaging true
-        }
-    }
 }
 
 // Configure the native build only if libmpegh is present to avoid gradle sync

--- a/libraries/decoder_opus/build.gradle
+++ b/libraries/decoder_opus/build.gradle
@@ -27,14 +27,6 @@ android {
             }
         }
     }
-
-    // TODO(Internal: b/372449691): Remove packagingOptions once AGP is updated
-    // to version 8.5.1 or higher.
-    packagingOptions {
-        jniLibs {
-            useLegacyPackaging true
-        }
-    }
 }
 
 // Configure the native build only if libopus is present to avoid gradle sync

--- a/libraries/decoder_vp9/build.gradle
+++ b/libraries/decoder_vp9/build.gradle
@@ -23,14 +23,6 @@ android {
         }
         androidTest.assets.srcDir '../test_data/src/test/assets'
     }
-
-    // TODO(Internal: b/372449691): Remove packagingOptions once AGP is updated
-    // to version 8.5.1 or higher.
-    packagingOptions {
-        jniLibs {
-            useLegacyPackaging true
-        }
-    }
 }
 
 dependencies {


### PR DESCRIPTION
AGP is now set to 8.8.1, so the `packagingOptions` setup can be removed.