### PR TITLE
[b/306324391] Remove `try`/`catch` in `AudioCapabilities.Api33#getDefaultRoutedDeviceForAttributes()`

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -657,18 +657,10 @@ public final class AudioCapabilities {
     @Nullable
     public static AudioDeviceInfoApi23 getDefaultRoutedDeviceForAttributes(
         AudioManager audioManager, AudioAttributes audioAttributes) {
-      List<AudioDeviceInfo> audioDevices;
-      try {
-        audioDevices =
-            checkNotNull(audioManager)
-                .getAudioDevicesForAttributes(
-                    audioAttributes.getAudioAttributesV21().audioAttributes);
-      } catch (RuntimeException e) {
-        // Audio manager failed to retrieve devices.
-        // TODO: b/306324391 - Remove once https://github.com/robolectric/robolectric/commit/442dff
-        //  is released.
-        return null;
-      }
+      List<AudioDeviceInfo> audioDevices =
+          checkNotNull(audioManager)
+              .getAudioDevicesForAttributes(
+                  audioAttributes.getAudioAttributesV21().audioAttributes);
       if (audioDevices.isEmpty()) {
         // Can't find current device.
         return null;


### PR DESCRIPTION
This mentioned commit (https://github.com/robolectric/robolectric/commit/442dff) was released in Robolectric 4.12.
Media3 now uses Robolectric 4.14.1, so this `try`/`catch` is not needed anymore.