### PR TITLE
[b/399861060] Remove `ChannelMixingMatrix#create()`

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/audio/ChannelMixingMatrix.java
+++ b/libraries/common/src/main/java/androidx/media3/common/audio/ChannelMixingMatrix.java
@@ -63,27 +63,6 @@ public final class ChannelMixingMatrix {
    * @param outputChannelCount Number of output channels.
    * @throws UnsupportedOperationException If no default coefficients are available for the given
    *     input and output channel counts.
-   * @deprecated Use {@link #createForConstantGain} instead.
-   */
-  // TODO(b/399861060): Remove in Media3 1.8.
-  @Deprecated
-  public static ChannelMixingMatrix create(
-      @IntRange(from = 1, to = 2) int inputChannelCount,
-      @IntRange(from = 1, to = 2) int outputChannelCount) {
-    return createForConstantGain(inputChannelCount, outputChannelCount);
-  }
-
-  /**
-   * Returns a default constant gain channel mixing matrix that mixes {@code inputChannelCount}
-   * channels into {@code outputChannelCount} channels.
-   *
-   * <p>This method returns an identity matrix if {@code inputChannelCount} and {@code
-   * outputChannelCount} are equal.
-   *
-   * @param inputChannelCount Number of input channels.
-   * @param outputChannelCount Number of output channels.
-   * @throws UnsupportedOperationException If no default coefficients are available for the given
-   *     input and output channel counts.
    */
   public static ChannelMixingMatrix createForConstantGain(
       @IntRange(from = 1, to = 2) int inputChannelCount,


### PR DESCRIPTION
This method is deprecated and marked for removal in media3 1.8.0, which is currently in alpha.