### PR TITLE
[b/406437316] Remove `forAllSupportedMimeTypes()` and `withNoDefaultSupportedMimeTypes()` in `ShadowMediaCodecConfig`

### DIFF
--- a/libraries/test_utils_robolectric/src/main/java/androidx/media3/test/utils/robolectric/ShadowMediaCodecConfig.java
+++ b/libraries/test_utils_robolectric/src/main/java/androidx/media3/test/utils/robolectric/ShadowMediaCodecConfig.java
@@ -175,15 +175,6 @@ public final class ShadowMediaCodecConfig extends ExternalResource {
           CODEC_INFO_RAW);
 
   /**
-   * @deprecated Use {@link ShadowMediaCodecConfig#withAllDefaultSupportedCodecs()} instead.
-   */
-  // TODO(b/406437316): Remove in Media3 1.8.
-  @Deprecated
-  public static ShadowMediaCodecConfig forAllSupportedMimeTypes() {
-    return withAllDefaultSupportedCodecs();
-  }
-
-  /**
    * Returns a {@link ShadowMediaCodecConfig} instance populated with a default list of supported
    * decoders using a default codec configuration.
    *
@@ -193,15 +184,6 @@ public final class ShadowMediaCodecConfig extends ExternalResource {
   public static ShadowMediaCodecConfig withAllDefaultSupportedCodecs() {
     return new ShadowMediaCodecConfig(
         createDecoders(ALL_SUPPORTED_CODECS.asList(), /* forcePassthrough= */ false));
-  }
-
-  /**
-   * @deprecated Use {@link ShadowMediaCodecConfig#withNoDefaultSupportedCodecs()} instead.
-   */
-  // TODO(b/406437316): Remove in Media3 1.8.
-  @Deprecated
-  public static ShadowMediaCodecConfig withNoDefaultSupportedMimeTypes() {
-    return withNoDefaultSupportedCodecs();
   }
 
   /** Returns a {@link ShadowMediaCodecConfig} instance populated with no shadow codecs. */


### PR DESCRIPTION
These methods are deprecated and marked for removal in media3 1.8.0, which is currently in alpha.