### PR TITLE
Fix DASH is not caching HTTP 302 redirection when CMCD is enabled in …

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -95,6 +95,8 @@
         when samples beyond the new duration have already been read by the
         rendering pipeline
         ([#2440](https://github.com/androidx/media/issues/2440)).
+    *   Fix bug where redirect wasn't followed when using CMCD query parameters
+        ([#2475](https://github.com/androidx/media/issues/2475)).
 *   Smooth Streaming extension:
 *   RTSP extension:
     *   Fix `RtspClient` to use the location uri as provided when processing an

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/CmcdData.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/CmcdData.java
@@ -538,10 +538,7 @@ public final class CmcdData {
   @CheckResult
   public static DataSpec removeFromDataSpec(DataSpec dataSpec) {
     if (dataSpec.uri.getQueryParameter(CmcdConfiguration.CMCD_QUERY_PARAMETER_KEY) != null) {
-      dataSpec =
-          dataSpec.withUri(
-              UriUtil.removeQueryParameter(
-                  dataSpec.uri, CmcdConfiguration.CMCD_QUERY_PARAMETER_KEY));
+      dataSpec = dataSpec.withUri(removeFromUri(dataSpec.uri));
     }
     if (dataSpec.httpRequestHeaders.containsKey(CmcdConfiguration.KEY_CMCD_OBJECT)
         || dataSpec.httpRequestHeaders.containsKey(CmcdConfiguration.KEY_CMCD_REQUEST)
@@ -559,6 +556,14 @@ public final class CmcdData {
       dataSpec = dataSpec.withRequestHeaders(httpRequestHeaders.build());
     }
     return dataSpec;
+  }
+
+  /** Removes Common Media Client Data (CMCD) related information from the provided {@link Uri}. */
+  @CheckResult
+  public static Uri removeFromUri(Uri uri) {
+    return uri.getQueryParameter(CmcdConfiguration.CMCD_QUERY_PARAMETER_KEY) != null
+        ? UriUtil.removeQueryParameter(uri, CmcdConfiguration.CMCD_QUERY_PARAMETER_KEY)
+        : uri;
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/CmcdData.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/CmcdData.java
@@ -531,13 +531,17 @@ public final class CmcdData {
     }
   }
 
-  /** Removes Common Media Client Data (CMCD) related information from the provided {@link DataSpec}
-   * object. */
+  /**
+   * Removes Common Media Client Data (CMCD) related information from the provided {@link DataSpec}
+   * object.
+   */
   @CheckResult
   public static DataSpec removeFromDataSpec(DataSpec dataSpec) {
     if (dataSpec.uri.getQueryParameter(CmcdConfiguration.CMCD_QUERY_PARAMETER_KEY) != null) {
-      dataSpec = dataSpec.withUri(
-          UriUtil.removeQueryParameter(dataSpec.uri, CmcdConfiguration.CMCD_QUERY_PARAMETER_KEY));
+      dataSpec =
+          dataSpec.withUri(
+              UriUtil.removeQueryParameter(
+                  dataSpec.uri, CmcdConfiguration.CMCD_QUERY_PARAMETER_KEY));
     }
     if (dataSpec.httpRequestHeaders.containsKey(CmcdConfiguration.KEY_CMCD_OBJECT)
         || dataSpec.httpRequestHeaders.containsKey(CmcdConfiguration.KEY_CMCD_REQUEST)

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/CmcdData.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/upstream/CmcdData.java
@@ -553,7 +553,7 @@ public final class CmcdData {
           httpRequestHeaders.put(header);
         }
       }
-      dataSpec = dataSpec.withRequestHeaders(httpRequestHeaders.build());
+      dataSpec = dataSpec.withRequestHeaders(httpRequestHeaders.buildOrThrow());
     }
     return dataSpec;
   }

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/CmcdDataTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/CmcdDataTest.java
@@ -29,6 +29,7 @@ import androidx.media3.datasource.DataSpec;
 import androidx.media3.exoplayer.trackselection.ExoTrackSelection;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -552,5 +553,44 @@ public class CmcdDataTest {
 
     assertThat(dataSpec.uri.getQueryParameter(CmcdConfiguration.CMCD_QUERY_PARAMETER_KEY))
         .isEmpty();
+  }
+
+  @Test
+  public void removeFromDataSpec_noCmcdData_returnsUnmodifiedDataSpec() {
+    DataSpec dataSpec = new DataSpec.Builder().setUri("https://test.test/test.mp4?key=value&cMcD=test&key2=value2").setHttpRequestHeaders(
+        ImmutableMap.of("headerKey1", "headerValue1")).build();
+
+    DataSpec updatedDataSpec = CmcdData.removeFromDataSpec(dataSpec);
+
+    assertThat(updatedDataSpec).isEqualTo(dataSpec);
+  }
+
+  @Test
+  public void removeFromDataSpec_cmcdDataQueryParameter_removesQueryParameter() {
+    DataSpec dataSpec = new DataSpec.Builder().setUri("https://test.test/test.mp4?key=value&CMCD=bl%3D1800%2Cbr%3D840%2Cbs&key2=value2").setHttpRequestHeaders(
+        ImmutableMap.of("headerKey1", "headerValue1")).build();
+
+    DataSpec updatedDataSpec = CmcdData.removeFromDataSpec(dataSpec);
+
+    assertThat(updatedDataSpec.uri.toString()).isEqualTo("https://test.test/test.mp4?key=value&key2=value2");
+    assertThat(updatedDataSpec.httpRequestHeaders).isEqualTo(
+        ImmutableMap.of("headerKey1", "headerValue1"));
+  }
+
+  @Test
+  public void removeFromDataSpec_cmcdHttpHeaders_removesHttpHeaders() {
+    DataSpec dataSpec = new DataSpec.Builder().setUri("https://test.test/test.mp4").setHttpRequestHeaders(
+        ImmutableMap.of("headerKey1", "headerValue1",
+            "CMCD-Object", "br=840",
+            "CMCD-Request", "bl=500",
+            "CMCD-Session", "cid=\"mediaId\"",
+            "CMCD-Status", "bs",
+            "headerKey2", "headerValue2")).build();
+
+    DataSpec updatedDataSpec = CmcdData.removeFromDataSpec(dataSpec);
+
+    assertThat(updatedDataSpec.uri.toString()).isEqualTo("https://test.test/test.mp4");
+    assertThat(updatedDataSpec.httpRequestHeaders).isEqualTo(
+        ImmutableMap.of("headerKey1", "headerValue1", "headerKey2", "headerValue2"));
   }
 }

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/CmcdDataTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/CmcdDataTest.java
@@ -581,8 +581,7 @@ public class CmcdDataTest {
 
     assertThat(updatedDataSpec.uri.toString())
         .isEqualTo("https://test.test/test.mp4?key=value&key2=value2");
-    assertThat(updatedDataSpec.httpRequestHeaders)
-        .isEqualTo(ImmutableMap.of("headerKey1", "headerValue1"));
+    assertThat(updatedDataSpec.httpRequestHeaders).containsExactly("headerKey1", "headerValue1");
   }
 
   @Test
@@ -610,7 +609,7 @@ public class CmcdDataTest {
 
     assertThat(updatedDataSpec.uri.toString()).isEqualTo("https://test.test/test.mp4");
     assertThat(updatedDataSpec.httpRequestHeaders)
-        .isEqualTo(ImmutableMap.of("headerKey1", "headerValue1", "headerKey2", "headerValue2"));
+        .containsExactly("headerKey1", "headerValue1", "headerKey2", "headerValue2");
   }
 
   @Test

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/CmcdDataTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/CmcdDataTest.java
@@ -557,8 +557,11 @@ public class CmcdDataTest {
 
   @Test
   public void removeFromDataSpec_noCmcdData_returnsUnmodifiedDataSpec() {
-    DataSpec dataSpec = new DataSpec.Builder().setUri("https://test.test/test.mp4?key=value&cMcD=test&key2=value2").setHttpRequestHeaders(
-        ImmutableMap.of("headerKey1", "headerValue1")).build();
+    DataSpec dataSpec =
+        new DataSpec.Builder()
+            .setUri("https://test.test/test.mp4?key=value&cMcD=test&key2=value2")
+            .setHttpRequestHeaders(ImmutableMap.of("headerKey1", "headerValue1"))
+            .build();
 
     DataSpec updatedDataSpec = CmcdData.removeFromDataSpec(dataSpec);
 
@@ -567,30 +570,46 @@ public class CmcdDataTest {
 
   @Test
   public void removeFromDataSpec_cmcdDataQueryParameter_removesQueryParameter() {
-    DataSpec dataSpec = new DataSpec.Builder().setUri("https://test.test/test.mp4?key=value&CMCD=bl%3D1800%2Cbr%3D840%2Cbs&key2=value2").setHttpRequestHeaders(
-        ImmutableMap.of("headerKey1", "headerValue1")).build();
+    DataSpec dataSpec =
+        new DataSpec.Builder()
+            .setUri(
+                "https://test.test/test.mp4?key=value&CMCD=bl%3D1800%2Cbr%3D840%2Cbs&key2=value2")
+            .setHttpRequestHeaders(ImmutableMap.of("headerKey1", "headerValue1"))
+            .build();
 
     DataSpec updatedDataSpec = CmcdData.removeFromDataSpec(dataSpec);
 
-    assertThat(updatedDataSpec.uri.toString()).isEqualTo("https://test.test/test.mp4?key=value&key2=value2");
-    assertThat(updatedDataSpec.httpRequestHeaders).isEqualTo(
-        ImmutableMap.of("headerKey1", "headerValue1"));
+    assertThat(updatedDataSpec.uri.toString())
+        .isEqualTo("https://test.test/test.mp4?key=value&key2=value2");
+    assertThat(updatedDataSpec.httpRequestHeaders)
+        .isEqualTo(ImmutableMap.of("headerKey1", "headerValue1"));
   }
 
   @Test
   public void removeFromDataSpec_cmcdHttpHeaders_removesHttpHeaders() {
-    DataSpec dataSpec = new DataSpec.Builder().setUri("https://test.test/test.mp4").setHttpRequestHeaders(
-        ImmutableMap.of("headerKey1", "headerValue1",
-            "CMCD-Object", "br=840",
-            "CMCD-Request", "bl=500",
-            "CMCD-Session", "cid=\"mediaId\"",
-            "CMCD-Status", "bs",
-            "headerKey2", "headerValue2")).build();
+    DataSpec dataSpec =
+        new DataSpec.Builder()
+            .setUri("https://test.test/test.mp4")
+            .setHttpRequestHeaders(
+                ImmutableMap.of(
+                    "headerKey1",
+                    "headerValue1",
+                    "CMCD-Object",
+                    "br=840",
+                    "CMCD-Request",
+                    "bl=500",
+                    "CMCD-Session",
+                    "cid=\"mediaId\"",
+                    "CMCD-Status",
+                    "bs",
+                    "headerKey2",
+                    "headerValue2"))
+            .build();
 
     DataSpec updatedDataSpec = CmcdData.removeFromDataSpec(dataSpec);
 
     assertThat(updatedDataSpec.uri.toString()).isEqualTo("https://test.test/test.mp4");
-    assertThat(updatedDataSpec.httpRequestHeaders).isEqualTo(
-        ImmutableMap.of("headerKey1", "headerValue1", "headerKey2", "headerValue2"));
+    assertThat(updatedDataSpec.httpRequestHeaders)
+        .isEqualTo(ImmutableMap.of("headerKey1", "headerValue1", "headerKey2", "headerValue2"));
   }
 }

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/CmcdDataTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/upstream/CmcdDataTest.java
@@ -612,4 +612,24 @@ public class CmcdDataTest {
     assertThat(updatedDataSpec.httpRequestHeaders)
         .isEqualTo(ImmutableMap.of("headerKey1", "headerValue1", "headerKey2", "headerValue2"));
   }
+
+  @Test
+  public void removeFromUri_noCmcdData_returnsUnmodifiedUri() {
+    Uri uri = Uri.parse("https://test.test/test.mp4?key=value&cMcD=test&key2=value2");
+
+    Uri updatedUri = CmcdData.removeFromUri(uri);
+
+    assertThat(updatedUri).isEqualTo(uri);
+  }
+
+  @Test
+  public void removeFromUri_cmcdDataQueryParameter_removesQueryParameter() {
+    Uri uri =
+        Uri.parse(
+            "https://test.test/test.mp4?key=value&CMCD=bl%3D1800%2Cbr%3D840%2Cbs&key2=value2");
+
+    Uri updatedUri = CmcdData.removeFromUri(uri);
+
+    assertThat(updatedUri.toString()).isEqualTo("https://test.test/test.mp4?key=value&key2=value2");
+  }
 }

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaSource.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaSource.java
@@ -731,14 +731,19 @@ public final class DashMediaSource extends BaseMediaSource {
       // Checks whether replaceManifestUri(Uri) was called to manually replace the URI between the
       // start and end of this load. If it was then useUriFromPreviousRequest evaluates to false,
       // and we prefer the manual replacement to one derived from the previous request.
-      boolean useUriFromPreviousRequest = loadable.dataSpec.uri.equals(manifestUri) ||
-          (cmcdConfiguration != null && CmcdData.removeFromDataSpec(loadable.dataSpec).uri.equals(manifestUri));
+      boolean useUriFromPreviousRequest =
+          loadable.dataSpec.uri.equals(manifestUri)
+              || (cmcdConfiguration != null
+                  && CmcdData.removeFromDataSpec(loadable.dataSpec).uri.equals(manifestUri));
 
       if (useUriFromPreviousRequest) {
         // Replace the manifest URI with one specified by a manifest Location element (if present),
         // or with the final (possibly redirected) URI. This follows the recommendation in
         // DASH-IF-IOP 4.3, section 3.2.15.3. See: https://dashif.org/docs/DASH-IF-IOP-v4.3.pdf.
-        manifestUri = manifest.location != null ? manifest.location : removeCmcdQueryParameter(loadable.getUri());
+        manifestUri =
+            manifest.location != null
+                ? manifest.location
+                : removeCmcdQueryParameter(loadable.getUri());
       }
     }
 
@@ -756,7 +761,7 @@ public final class DashMediaSource extends BaseMediaSource {
 
   private static Uri removeCmcdQueryParameter(Uri uri) {
     Set<String> queryParameterNames = uri.getQueryParameterNames();
-    if(!queryParameterNames.contains(CmcdConfiguration.CMCD_QUERY_PARAMETER_KEY)) {
+    if (!queryParameterNames.contains(CmcdConfiguration.CMCD_QUERY_PARAMETER_KEY)) {
       return uri;
     }
     Uri.Builder builder = uri.buildUpon();

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaSource.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaSource.java
@@ -94,7 +94,6 @@ import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -734,7 +733,7 @@ public final class DashMediaSource extends BaseMediaSource {
       boolean useUriFromPreviousRequest =
           loadable.dataSpec.uri.equals(manifestUri)
               || (cmcdConfiguration != null
-                  && CmcdData.removeFromDataSpec(loadable.dataSpec).uri.equals(manifestUri));
+                  && CmcdData.removeFromUri(loadable.dataSpec.uri).equals(manifestUri));
 
       if (useUriFromPreviousRequest) {
         // Replace the manifest URI with one specified by a manifest Location element (if present),
@@ -743,7 +742,7 @@ public final class DashMediaSource extends BaseMediaSource {
         manifestUri =
             manifest.location != null
                 ? manifest.location
-                : removeCmcdQueryParameter(loadable.getUri());
+                : CmcdData.removeFromUri(loadable.getUri());
       }
     }
 
@@ -757,23 +756,6 @@ public final class DashMediaSource extends BaseMediaSource {
     } else {
       processManifest(true);
     }
-  }
-
-  private static Uri removeCmcdQueryParameter(Uri uri) {
-    Set<String> queryParameterNames = uri.getQueryParameterNames();
-    if (!queryParameterNames.contains(CmcdConfiguration.CMCD_QUERY_PARAMETER_KEY)) {
-      return uri;
-    }
-    Uri.Builder builder = uri.buildUpon();
-    builder.clearQuery();
-    for (String key : queryParameterNames) {
-      if (!key.equals(CmcdConfiguration.CMCD_QUERY_PARAMETER_KEY)) {
-        for (String value : uri.getQueryParameters(key)) {
-          builder.appendQueryParameter(key, value);
-        }
-      }
-    }
-    return builder.build();
   }
 
   /* package */ LoadErrorAction onManifestLoadError(

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaSource.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/DashMediaSource.java
@@ -729,12 +729,10 @@ public final class DashMediaSource extends BaseMediaSource {
 
     synchronized (manifestUriLock) {
       // Checks whether replaceManifestUri(Uri) was called to manually replace the URI between the
-      // start and end of this load. If it was then useUriFromPreviousRequest evaluates to false, and we
-      // prefer the manual replacement to one derived from the previous request.
-      // If CMCD is enabled in query parameter mode, then a new URI instance was created.
-      @SuppressWarnings("ReferenceEquality")
-      boolean useUriFromPreviousRequest = loadable.dataSpec.uri == manifestUri ||
-          (cmcdConfiguration != null && removeCmcdQueryParameter(loadable.dataSpec.uri).equals(manifestUri));
+      // start and end of this load. If it was then useUriFromPreviousRequest evaluates to false,
+      // and we prefer the manual replacement to one derived from the previous request.
+      boolean useUriFromPreviousRequest = loadable.dataSpec.uri.equals(manifestUri) ||
+          (cmcdConfiguration != null && CmcdData.removeFromDataSpec(loadable.dataSpec).uri.equals(manifestUri));
 
       if (useUriFromPreviousRequest) {
         // Replace the manifest URI with one specified by a manifest Location element (if present),


### PR DESCRIPTION
This should fix https://github.com/androidx/media/issues/2475

I left the reference equality check in place for consistency, although I don't like it.
I think this should be enough:
`boolean useUriFromPreviousRequest = removeCmcdQueryParameter(loadable.dataSpec.uri).equals(manifestUri);`
