### PR TITLE
Extend detached surface workaround to lenovo & motorola devices

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -16,6 +16,8 @@
 *   DataSource:
 *   Audio:
 *   Video:
+    *   Extend detached surface workaround to "lenovo" and "motorola" devices
+        ([#2059](https://github.com/androidx/media/issues/2059)).
 *   Text:
     *   Add support for VobSub tracks in MP4 files
         ([#2510](https://github.com/androidx/media/issues/2510)).
@@ -135,7 +137,7 @@ This release includes the following changes since the
 *   Video:
     *   Improve smooth video frame release at startup when audio samples don't
         start at exactly the requested position.
-    *   Extend detached surface workaround to "realme", "lenovo", "motorola" devices
+    *   Extend detached surface workaround to "realme" devices
         ([#2059](https://github.com/androidx/media/issues/2059)).
 *   Text:
     *   Fix a playback stall when a subtitle segment initially fails to load and

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -135,7 +135,7 @@ This release includes the following changes since the
 *   Video:
     *   Improve smooth video frame release at startup when audio samples don't
         start at exactly the requested position.
-    *   Extend detached surface workaround to "realme" devices
+    *   Extend detached surface workaround to "realme", "lenovo", "motorola" devices
         ([#2059](https://github.com/androidx/media/issues/2059)).
 *   Text:
     *   Fix a playback stall when a subtitle segment initially fails to load and

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
@@ -939,8 +939,11 @@ public final class MediaCodecInfo {
 
   /** Returns whether the device is known to have issues with the detached surface mode. */
   private static boolean needsDetachedSurfaceUnsupportedWorkaround() {
-    return Build.MANUFACTURER.equals("Xiaomi")
-        || Build.MANUFACTURER.equals("OPPO")
-        || Build.MANUFACTURER.equals("realme");
+    final String manufacturer = Build.MANUFACTURER.toLowerCase();
+    return manufacturer.equals("xiaomi")
+        || manufacturer.equals("oppo")
+        || manufacturer.equals("motorola")
+        || manufacturer.equals("realmi")
+        || manufacturer.equals("lenovo");
   }
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
@@ -939,11 +939,10 @@ public final class MediaCodecInfo {
 
   /** Returns whether the device is known to have issues with the detached surface mode. */
   private static boolean needsDetachedSurfaceUnsupportedWorkaround() {
-    final String manufacturer = Build.MANUFACTURER.toLowerCase();
-    return manufacturer.equals("xiaomi")
-        || manufacturer.equals("oppo")
-        || manufacturer.equals("motorola")
-        || manufacturer.equals("realme")
-        || manufacturer.equals("lenovo");
+    return Build.MANUFACTURER.equals("Xiaomi")
+        || Build.MANUFACTURER.equals("OPPO")
+        || Build.MANUFACTURER.equals("realme")
+        || Build.MANUFACTURER.equals("motorola")
+        || Build.MANUFACTURER.equals("LENOVO");
   }
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
@@ -943,7 +943,7 @@ public final class MediaCodecInfo {
     return manufacturer.equals("xiaomi")
         || manufacturer.equals("oppo")
         || manufacturer.equals("motorola")
-        || manufacturer.equals("realmi")
+        || manufacturer.equals("realme")
         || manufacturer.equals("lenovo");
   }
 }


### PR DESCRIPTION
In the Reddit Android app, we're seeing [more vendors affected by the issue related to detached surface improvements](https://github.com/androidx/media/issues/2059#issuecomment-2740618570).


**In this PR:**

* I've added Motorola & Lenovo (based on user feedback from devices updated from Android 14 to Android 15)
* Added a sanity lowercase check for  `Build.MANUFACTURER`