### PR TITLE
[b/353490583] Remove outdated TODO in `libraries/muxer/build.gradle`

### DIFF
--- a/libraries/muxer/build.gradle
+++ b/libraries/muxer/build.gradle
@@ -34,11 +34,6 @@ android {
         test.assets.srcDir '../test_data/src/test/assets/'
     }
 
-    lintOptions {
-        // TODO: b/353490583 - Enable this once the violations are fixed.
-        checkTestSources false
-    }
-
     publishing {
         singleVariant('release') {
             withSourcesJar()


### PR DESCRIPTION
I've ran `./gradlew :lib-muxer:lintDebug` locally, and it didn't report any issue.
So I've enabled Lint for the test source set and removed the corresponding TODO.