### PR TITLE
Add PCM_DOUBLE and DSD format

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/C.java
+++ b/libraries/common/src/main/java/androidx/media3/common/C.java
@@ -181,10 +181,10 @@ public final class C {
    * {@link #ENCODING_INVALID}, {@link #ENCODING_PCM_8BIT}, {@link #ENCODING_PCM_16BIT}, {@link
    * #ENCODING_PCM_16BIT_BIG_ENDIAN}, {@link #ENCODING_PCM_24BIT}, {@link
    * #ENCODING_PCM_24BIT_BIG_ENDIAN}, {@link #ENCODING_PCM_32BIT}, {@link
-   * #ENCODING_PCM_32BIT_BIG_ENDIAN}, {@link #ENCODING_PCM_FLOAT}, {@link #ENCODING_MP3}, {@link
-   * #ENCODING_AC3}, {@link #ENCODING_E_AC3}, {@link #ENCODING_E_AC3_JOC}, {@link #ENCODING_AC4},
-   * {@link #ENCODING_DTS}, {@link #ENCODING_DTS_HD}, {@link #ENCODING_DOLBY_TRUEHD} or {@link
-   * #ENCODING_OPUS}.
+   * #ENCODING_PCM_32BIT_BIG_ENDIAN}, {@link #ENCODING_PCM_FLOAT}, {@link #ENCODING_PCM_DOUBLE},
+   * {@link #ENCODING_MP3}, {@link #ENCODING_AC3}, {@link #ENCODING_E_AC3}, {@link
+   * #ENCODING_E_AC3_JOC}, {@link #ENCODING_AC4}, {@link #ENCODING_DTS}, {@link #ENCODING_DTS_HD},
+   * {@link #ENCODING_DOLBY_TRUEHD}, {@link #ENCODING_OPUS} or {@link #ENCODING_DSD}.
    */
   @Documented
   @Retention(RetentionPolicy.SOURCE)
@@ -200,6 +200,7 @@ public final class C {
     ENCODING_PCM_32BIT,
     ENCODING_PCM_32BIT_BIG_ENDIAN,
     ENCODING_PCM_FLOAT,
+    ENCODING_PCM_DOUBLE,
     ENCODING_MP3,
     ENCODING_AAC_LC,
     ENCODING_AAC_HE_V1,
@@ -216,6 +217,7 @@ public final class C {
     ENCODING_DOLBY_TRUEHD,
     ENCODING_OPUS,
     ENCODING_DTS_UHD_P2,
+    ENCODING_DSD,
   })
   public @interface Encoding {}
 
@@ -224,7 +226,7 @@ public final class C {
    * {@link #ENCODING_INVALID}, {@link #ENCODING_PCM_8BIT}, {@link #ENCODING_PCM_16BIT}, {@link
    * #ENCODING_PCM_16BIT_BIG_ENDIAN}, {@link #ENCODING_PCM_24BIT}, {@link
    * #ENCODING_PCM_24BIT_BIG_ENDIAN}, {@link #ENCODING_PCM_32BIT}, {@link
-   * #ENCODING_PCM_32BIT_BIG_ENDIAN}, {@link #ENCODING_PCM_FLOAT}.
+   * #ENCODING_PCM_32BIT_BIG_ENDIAN}, {@link #ENCODING_PCM_FLOAT}, {@link #ENCODING_PCM_DOUBLE}.
    */
   @Documented
   @Retention(RetentionPolicy.SOURCE)
@@ -239,7 +241,8 @@ public final class C {
     ENCODING_PCM_24BIT_BIG_ENDIAN,
     ENCODING_PCM_32BIT,
     ENCODING_PCM_32BIT_BIG_ENDIAN,
-    ENCODING_PCM_FLOAT
+    ENCODING_PCM_FLOAT,
+    ENCODING_PCM_DOUBLE
   })
   public @interface PcmEncoding {}
 
@@ -269,6 +272,9 @@ public final class C {
 
   /** See {@link AudioFormat#ENCODING_PCM_FLOAT}. */
   public static final int ENCODING_PCM_FLOAT = AudioFormat.ENCODING_PCM_FLOAT;
+
+  /** PCM encoding with double-precision floating point samples. */
+  @UnstableApi public static final int ENCODING_PCM_DOUBLE = 0x70000000;
 
   /** See {@link AudioFormat#ENCODING_MP3}. */
   public static final int ENCODING_MP3 = AudioFormat.ENCODING_MP3;
@@ -317,6 +323,9 @@ public final class C {
 
   /** See {@link AudioFormat#ENCODING_OPUS}. */
   public static final int ENCODING_OPUS = AudioFormat.ENCODING_OPUS;
+
+  /** See {@link AudioFormat#ENCODING_DSD}. */
+  @UnstableApi public static final int ENCODING_DSD = AudioFormat.ENCODING_DSD;
 
   /**
    * Represents the behavior affecting whether spatialization will be used. One of {@link

--- a/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
@@ -89,7 +89,7 @@ public final class MimeTypes {
   public static final String AUDIO_E_AC3_JOC = BASE_TYPE_AUDIO + "/eac3-joc";
   public static final String AUDIO_AC4 = BASE_TYPE_AUDIO + "/ac4";
   public static final String AUDIO_TRUEHD = BASE_TYPE_AUDIO + "/true-hd";
-  public static final String AUDIO_DSD = BASE_TYPE_AUDIO + "/dsd";
+  @UnstableApi public static final String AUDIO_DSD = BASE_TYPE_AUDIO + "/dsd";
   public static final String AUDIO_DTS = BASE_TYPE_AUDIO + "/vnd.dts";
   public static final String AUDIO_DTS_HD = BASE_TYPE_AUDIO + "/vnd.dts.hd";
   public static final String AUDIO_DTS_EXPRESS = BASE_TYPE_AUDIO + "/vnd.dts.hd;profile=lbr";

--- a/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
@@ -89,6 +89,7 @@ public final class MimeTypes {
   public static final String AUDIO_E_AC3_JOC = BASE_TYPE_AUDIO + "/eac3-joc";
   public static final String AUDIO_AC4 = BASE_TYPE_AUDIO + "/ac4";
   public static final String AUDIO_TRUEHD = BASE_TYPE_AUDIO + "/true-hd";
+  public static final String AUDIO_DSD = BASE_TYPE_AUDIO + "/dsd";
   public static final String AUDIO_DTS = BASE_TYPE_AUDIO + "/vnd.dts";
   public static final String AUDIO_DTS_HD = BASE_TYPE_AUDIO + "/vnd.dts.hd";
   public static final String AUDIO_DTS_EXPRESS = BASE_TYPE_AUDIO + "/vnd.dts.hd;profile=lbr";
@@ -705,6 +706,8 @@ public final class MimeTypes {
         return C.ENCODING_DOLBY_TRUEHD;
       case MimeTypes.AUDIO_OPUS:
         return C.ENCODING_OPUS;
+      case MimeTypes.AUDIO_DSD:
+        return C.ENCODING_DSD;
       default:
         return C.ENCODING_INVALID;
     }

--- a/libraries/common/src/main/java/androidx/media3/common/util/MediaFormatUtil.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/MediaFormatUtil.java
@@ -505,6 +505,7 @@ public final class MediaFormatUtil {
       case C.ENCODING_PCM_16BIT_BIG_ENDIAN:
       case C.ENCODING_PCM_24BIT_BIG_ENDIAN:
       case C.ENCODING_PCM_32BIT_BIG_ENDIAN:
+      case C.ENCODING_PCM_DOUBLE:
       default:
         // No matching value. Do nothing.
         return;

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -1270,6 +1270,19 @@ public final class Util {
   }
 
   /**
+   * Constrains a value to the specified bounds.
+   *
+   * @param value The value to constrain.
+   * @param min The lower bound.
+   * @param max The upper bound.
+   * @return The constrained value {@code Math.max(min, Math.min(value, max))}.
+   */
+  @UnstableApi
+  public static double constrainValue(double value, double min, double max) {
+    return max(min, min(value, max));
+  }
+
+  /**
    * Returns the sum of two arguments, or a third argument if the result overflows.
    *
    * @param x The first value.
@@ -2358,7 +2371,8 @@ public final class Util {
         || encoding == C.ENCODING_PCM_24BIT_BIG_ENDIAN
         || encoding == C.ENCODING_PCM_32BIT
         || encoding == C.ENCODING_PCM_32BIT_BIG_ENDIAN
-        || encoding == C.ENCODING_PCM_FLOAT;
+        || encoding == C.ENCODING_PCM_FLOAT
+        || encoding == C.ENCODING_PCM_DOUBLE;
   }
 
   /**
@@ -2373,7 +2387,8 @@ public final class Util {
         || encoding == C.ENCODING_PCM_24BIT_BIG_ENDIAN
         || encoding == C.ENCODING_PCM_32BIT
         || encoding == C.ENCODING_PCM_32BIT_BIG_ENDIAN
-        || encoding == C.ENCODING_PCM_FLOAT;
+        || encoding == C.ENCODING_PCM_FLOAT
+        || encoding == C.ENCODING_PCM_DOUBLE;
   }
 
   /**
@@ -2516,6 +2531,7 @@ public final class Util {
       case C.ENCODING_PCM_32BIT:
         return 31;
       case C.ENCODING_DTS_UHD_P2:
+      case C.ENCODING_DSD:
         return 34;
       default:
         return Integer.MAX_VALUE;
@@ -2555,6 +2571,8 @@ public final class Util {
       case C.ENCODING_PCM_32BIT_BIG_ENDIAN:
       case C.ENCODING_PCM_FLOAT:
         return 4;
+      case C.ENCODING_PCM_DOUBLE:
+        return 8;
       case C.ENCODING_INVALID:
       case Format.NO_VALUE:
       default:

--- a/libraries/common/src/test/java/androidx/media3/common/audio/ToInt16PcmAudioProcessorTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/audio/ToInt16PcmAudioProcessorTest.java
@@ -147,6 +147,8 @@ public class ToInt16PcmAudioProcessorTest {
             });
       case C.ENCODING_PCM_FLOAT:
         return createByteBuffer(new float[] {-1.0f, -0.5f, 0.0f, 0.5f, 1.0f});
+      case C.ENCODING_PCM_DOUBLE:
+        return createByteBuffer(new double[] {-1.0, -0.5, 0.0, 0.5, 1.0});
       default:
         throw new IllegalArgumentException();
     }
@@ -156,7 +158,7 @@ public class ToInt16PcmAudioProcessorTest {
     if (pcmEncoding == C.ENCODING_PCM_8BIT) {
       return 256;
     }
-    if (pcmEncoding == C.ENCODING_PCM_FLOAT) {
+    if (pcmEncoding == C.ENCODING_PCM_FLOAT || pcmEncoding == C.ENCODING_PCM_DOUBLE) {
       return 1;
     }
     return 0;
@@ -172,7 +174,8 @@ public class ToInt16PcmAudioProcessorTest {
           value(C.ENCODING_PCM_24BIT_BIG_ENDIAN).withName("ENCODING_PCM_24BIT_BIG_ENDIAN"),
           value(C.ENCODING_PCM_32BIT).withName("ENCODING_PCM_32BIT"),
           value(C.ENCODING_PCM_32BIT_BIG_ENDIAN).withName("ENCODING_PCM_32BIT_BIG_ENDIAN"),
-          value(C.ENCODING_PCM_FLOAT).withName("ENCODING_PCM_FLOAT"));
+          value(C.ENCODING_PCM_FLOAT).withName("ENCODING_PCM_FLOAT"),
+          value(C.ENCODING_PCM_DOUBLE).withName("ENCODING_PCM_DOUBLE"));
     }
   }
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ChannelMappingAudioProcessor.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ChannelMappingAudioProcessor.java
@@ -113,6 +113,9 @@ public final class ChannelMappingAudioProcessor extends BaseAudioProcessor {
           case C.ENCODING_PCM_FLOAT:
             buffer.putFloat(inputBuffer.getFloat(inputIndex));
             break;
+          case C.ENCODING_PCM_DOUBLE:
+            buffer.putDouble(inputBuffer.getDouble(inputIndex));
+            break;
           default:
             throw new IllegalStateException("Unexpected encoding: " + inputAudioFormat.encoding);
         }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -1821,7 +1821,9 @@ public final class DefaultAudioSink implements AudioSink {
       case C.ENCODING_PCM_32BIT_BIG_ENDIAN:
       case C.ENCODING_PCM_8BIT:
       case C.ENCODING_PCM_FLOAT:
+      case C.ENCODING_PCM_DOUBLE:
       case C.ENCODING_AAC_ER_BSAC:
+      case C.ENCODING_DSD:
       case C.ENCODING_INVALID:
       case Format.NO_VALUE:
       default:

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/PcmAudioUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/PcmAudioUtil.java
@@ -101,6 +101,13 @@ public final class PcmAudioUtil {
         } else {
           return (int) (floatValue * Integer.MAX_VALUE);
         }
+      case C.ENCODING_PCM_DOUBLE:
+        double doubleValue = Util.constrainValue(buffer.getDouble(), /* min= */ -1f, /* max= */ 1f);
+        if (doubleValue < 0) {
+          return (int) (-doubleValue * Integer.MIN_VALUE);
+        } else {
+          return (int) (doubleValue * Integer.MAX_VALUE);
+        }
       default:
         throw new IllegalStateException();
     }
@@ -154,6 +161,13 @@ public final class PcmAudioUtil {
           buffer.putFloat(-((float) pcm32bit) / Integer.MIN_VALUE);
         } else {
           buffer.putFloat((float) pcm32bit / Integer.MAX_VALUE);
+        }
+        return;
+      case C.ENCODING_PCM_DOUBLE:
+        if (pcm32bit < 0) {
+          buffer.putDouble(-((double) pcm32bit) / Integer.MIN_VALUE);
+        } else {
+          buffer.putDouble((double) pcm32bit / Integer.MAX_VALUE);
         }
         return;
       default:

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ToFloatPcmAudioProcessor.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ToFloatPcmAudioProcessor.java
@@ -34,6 +34,7 @@ import java.nio.ByteBuffer;
  *   <li>{@link C#ENCODING_PCM_32BIT}
  *   <li>{@link C#ENCODING_PCM_32BIT_BIG_ENDIAN}
  *   <li>{@link C#ENCODING_PCM_FLOAT} ({@link #isActive()} will return {@code false})
+ *   <li>{@link C#ENCODING_PCM_DOUBLE}
  * </ul>
  */
 @UnstableApi
@@ -111,6 +112,12 @@ public final class ToFloatPcmAudioProcessor extends BaseAudioProcessor {
                   | ((inputBuffer.get(i + 1) & 0xFF) << 16)
                   | ((inputBuffer.get(i) & 0xFF) << 24);
           writePcm32BitFloat(pcm32BitInteger, buffer);
+        }
+        break;
+      case C.ENCODING_PCM_DOUBLE:
+        buffer = replaceOutputBuffer(size / 2);
+        for (int i = position; i < limit; i += 8) {
+          buffer.putFloat((float) inputBuffer.getDouble(i));
         }
         break;
       case C.ENCODING_PCM_8BIT:

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/ToFloatPcmAudioProcessorTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/ToFloatPcmAudioProcessorTest.java
@@ -44,9 +44,10 @@ public class ToFloatPcmAudioProcessorTest {
    *   <li>{@link C#ENCODING_PCM_24BIT}
    *   <li>{@link C#ENCODING_PCM_32BIT_BIG_ENDIAN}
    *   <li>{@link C#ENCODING_PCM_24BIT_BIG_ENDIAN}
+   *   <li>{@link C#ENCODING_PCM_DOUBLE}
    * </ul>
    */
-  @TestParameter({"2", "22", "21", "1610612736", "1342177280"})
+  @TestParameter({"2", "22", "21", "1610612736", "1342177280", "1879048192"})
   private int pcmEncoding;
 
   @Test
@@ -94,6 +95,8 @@ public class ToFloatPcmAudioProcessorTest {
       case C.ENCODING_PCM_24BIT:
       case C.ENCODING_PCM_24BIT_BIG_ENDIAN:
         return 1f / 0x800000;
+      case C.ENCODING_PCM_DOUBLE:
+        return 0;
     }
     throw new IllegalArgumentException();
   }
@@ -152,6 +155,8 @@ public class ToFloatPcmAudioProcessorTest {
               0x00,
               0x00
             });
+      case C.ENCODING_PCM_DOUBLE:
+        return createByteBuffer(new double[] {1, -1, 0.5, -0.5});
     }
     throw new IllegalArgumentException();
   }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ExtractorUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ExtractorUtil.java
@@ -169,7 +169,9 @@ public final class ExtractorUtil {
       case C.ENCODING_PCM_32BIT_BIG_ENDIAN:
       case C.ENCODING_PCM_8BIT:
       case C.ENCODING_PCM_FLOAT:
+      case C.ENCODING_PCM_DOUBLE:
       case C.ENCODING_AAC_ER_BSAC:
+      case C.ENCODING_DSD:
       case C.ENCODING_INVALID:
       case Format.NO_VALUE:
       default:

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestUtil.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/TestUtil.java
@@ -240,6 +240,14 @@ public class TestUtil {
   }
 
   /** Creates a {@link ByteBuffer} containing the {@code data}. */
+  public static ByteBuffer createByteBuffer(double[] data) {
+    ByteBuffer buffer =
+        ByteBuffer.allocateDirect(data.length * Double.SIZE / 8).order(ByteOrder.nativeOrder());
+    buffer.asDoubleBuffer().put(data);
+    return buffer;
+  }
+
+  /** Creates a {@link ByteBuffer} containing the {@code data}. */
   public static ByteBuffer createByteBuffer(int[] data) {
     ByteBuffer buffer = ByteBuffer.allocateDirect(data.length * 4).order(ByteOrder.nativeOrder());
     buffer.asIntBuffer().put(data);


### PR DESCRIPTION
- PCM_DOUBLE is useful for signal processing, as it can contain both int32 and float32 losslessy.
- Add DSD format for parity with platform.