### PR TITLE
Fix: Made cue builder setText accept null

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/text/Cue.java
+++ b/libraries/common/src/main/java/androidx/media3/common/text/Cue.java
@@ -481,11 +481,14 @@ public final class Cue {
      *
      * <p>Note that {@code text} may be decorated with styling spans.
      *
+     * <p>Note that this will also set the {@code bitmap} to null.
+     *
      * @see Cue#text
      */
     @CanIgnoreReturnValue
-    public Builder setText(@Nullable CharSequence text) {
+    public Builder setText(CharSequence text) {
       this.text = text;
+      this.bitmap = null;
       return this;
     }
 
@@ -503,11 +506,14 @@ public final class Cue {
     /**
      * Sets the cue image.
      *
+     * <p>Note that this will also set the {@code text} to null.
+     *
      * @see Cue#bitmap
      */
     @CanIgnoreReturnValue
     public Builder setBitmap(Bitmap bitmap) {
       this.bitmap = bitmap;
+      this.text = null;
       return this;
     }
 


### PR DESCRIPTION
The main problem that this PR solves it the ability to set Cues text to null, after it has been assigned. To illustrate the problematic API of no null currently, if you have a cue with text you can not in any way change it into a bitmap. You are forced to copy each and every field of the cue, making it a semver hazzard.

Alternatively make setBitmap also set text to null. 

```kotlin
val baseCue = Cue.Builder().setText("Hello, world!").build()
```
Case 1.
```kotlin
baseCue.buildUpon().setBitmap(bitmap).build() // will crash due to "Assertions.checkArgument(bitmap == null);"
```
Case 2.
```kotlin
baseCue.buildUpon().setBitmap(bitmap).setText(null).build() // will not compile due to "Null can not be a value of a non-null type CharSequence"
```