### PR TITLE
[b/181312195] Make `CuesWithTimingSubtitle` package-private

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/CuesWithTimingSubtitle.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/CuesWithTimingSubtitle.java
@@ -20,7 +20,6 @@ import static androidx.media3.common.util.Assertions.checkArgument;
 import androidx.media3.common.C;
 import androidx.media3.common.text.Cue;
 import androidx.media3.common.util.Log;
-import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -30,9 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /** A {@link Subtitle} backed by a list of {@link CuesWithTiming} instances. */
-// TODO(b/181312195): Make this package-private when ExoplayerCuesDecoder is deleted.
-@UnstableApi
-public final class CuesWithTimingSubtitle implements Subtitle {
+/* package */ final class CuesWithTimingSubtitle implements Subtitle {
 
   private static final String TAG = "CuesWithTimingSubtitle";
 


### PR DESCRIPTION
`ExoplayerCuesDecoder` doesn't seem to exist anymore, so `CuesWithTimingSubtitle` can be made package-private.

> [!NOTE]
> - `CuesWithTimingSubtitle` was part of the public API, and not in an `internal` package. I don't know if making it package-private directly is how you want to proceed, or if it should be deprecated first?
> - Should the `@UnstableApi` annotation be kept for internal APIs?