### PR TITLE
Remove some unused dependencies

### DIFF
--- a/demos/composition/build.gradle
+++ b/demos/composition/build.gradle
@@ -69,8 +69,8 @@ dependencies {
     implementation project(modulePrefix + 'lib-ui')
     implementation project(modulePrefix + 'lib-ui-compose')
     implementation 'androidx.annotation:annotation:' + androidxAnnotationVersion
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.7'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7'
+    implementation 'androidx.lifecycle:lifecycle-livedata:' + androidxLifecycleVersion
+    implementation 'androidx.lifecycle:lifecycle-viewmodel:' + androidxLifecycleVersion
     implementation 'androidx.activity:activity-compose:1.9.0'
     implementation platform('androidx.compose:compose-bom:2024.12.01')
     implementation 'androidx.compose.ui:ui'

--- a/demos/session/build.gradle
+++ b/demos/session/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:' + leakCanaryVersion
     implementation 'androidx.core:core-ktx:' + androidxCoreVersion
     implementation 'androidx.lifecycle:lifecycle-common:' + androidxLifecycleVersion
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:' + androidxLifecycleVersion
+    implementation 'androidx.lifecycle:lifecycle-runtime:' + androidxLifecycleVersion
     implementation 'androidx.appcompat:appcompat:' + androidxAppCompatVersion
     implementation 'com.google.android.material:material:' + androidxMaterialVersion
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-guava:' + kotlinxCoroutinesVersion

--- a/demos/session_automotive/build.gradle
+++ b/demos/session_automotive/build.gradle
@@ -57,9 +57,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:' + androidxCoreVersion
-    implementation 'androidx.appcompat:appcompat:' + androidxAppCompatVersion
-    implementation 'com.google.android.material:material:' + androidxMaterialVersion
+    implementation 'androidx.annotation:annotation-experimental:' + androidxAnnotationExperimentalVersion
     implementation project(modulePrefix + 'lib-session')
     implementation project(modulePrefix + 'demo-session-service')
 }

--- a/demos/session_service/build.gradle
+++ b/demos/session_service/build.gradle
@@ -68,7 +68,6 @@ protobuf {
 
 dependencies {
     implementation 'androidx.core:core-ktx:' + androidxCoreVersion
-    implementation 'androidx.appcompat:appcompat:' + androidxAppCompatVersion
     implementation 'androidx.datastore:datastore:1.1.5'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.9.0'
     implementation 'com.google.protobuf:protobuf-java:4.31.1'

--- a/demos/shortform/build.gradle
+++ b/demos/shortform/build.gradle
@@ -74,21 +74,10 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.9.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-
-    implementation 'androidx.core:core-ktx:' + androidxCoreVersion
     implementation 'androidx.appcompat:appcompat:' + androidxAppCompatVersion
     implementation 'com.google.android.material:material:' + androidxMaterialVersion
     implementation project(modulePrefix + 'lib-exoplayer')
     implementation project(modulePrefix + 'lib-exoplayer-dash')
     implementation project(modulePrefix + 'lib-exoplayer-hls')
     implementation project(modulePrefix + 'lib-ui')
-
-    testImplementation 'androidx.test:core:' + androidxTestCoreVersion
-    testImplementation 'androidx.test.ext:junit:' + androidxTestJUnitVersion
-    testImplementation 'junit:junit:' + junitVersion
-    testImplementation 'com.google.truth:truth:' + truthVersion
-    testImplementation 'org.robolectric:robolectric:' + robolectricVersion
-    testImplementation 'org.robolectric:robolectric:' + robolectricVersion
 }

--- a/demos/transformer/build.gradle
+++ b/demos/transformer/build.gradle
@@ -75,7 +75,6 @@ dependencies {
     implementation 'androidx.annotation:annotation:' + androidxAnnotationVersion
     implementation 'androidx.appcompat:appcompat:' + androidxAppCompatVersion
     implementation 'androidx.constraintlayout:constraintlayout:' + androidxConstraintLayoutVersion
-    implementation 'androidx.recyclerview:recyclerview:' + androidxRecyclerViewVersion
     implementation 'androidx.window:window:' + androidxWindowVersion
     implementation 'com.google.android.material:material:' + androidxMaterialVersion
     implementation project(modulePrefix + 'lib-effect')

--- a/libraries/common/build.gradle
+++ b/libraries/common/build.gradle
@@ -74,12 +74,7 @@ dependencies {
     compileOnly 'com.google.errorprone:error_prone_annotations:' + errorProneVersion
     compileOnly 'org.checkerframework:checker-qual:' + checkerframeworkVersion
     compileOnly 'org.jetbrains.kotlin:kotlin-annotations-jvm:' + kotlinAnnotationsVersion
-    androidTestImplementation 'androidx.test:runner:' + androidxTestRunnerVersion
-    androidTestImplementation 'com.linkedin.dexmaker:dexmaker:' + dexmakerVersion
-    androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:' + dexmakerVersion
-    androidTestImplementation(project(modulePrefix + 'test-utils')) {
-        exclude module: modulePrefix.substring(1) + 'library-core'
-    }
+
     testImplementation 'org.mockito:mockito-core:' + mockitoVersion
     testImplementation 'androidx.test:core:' + androidxTestCoreVersion
     testImplementation 'androidx.test.ext:junit:' + androidxTestJUnitVersion

--- a/libraries/muxer/build.gradle
+++ b/libraries/muxer/build.gradle
@@ -54,6 +54,13 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:' + robolectricVersion
     testImplementation 'com.google.truth:truth:' + truthVersion
     testImplementation project(modulePrefix + 'lib-exoplayer')
+
+    // These deps are used by internal-only instrumentation tests.
+    androidTestImplementation 'junit:junit:' + junitVersion
+    androidTestImplementation 'androidx.test:runner:' + androidxTestRunnerVersion
+    androidTestImplementation 'com.google.truth:truth:' + truthVersion
+    androidTestImplementation project(modulePrefix + 'test-utils')
+    androidTestImplementation project(modulePrefix + 'lib-extractor')
 }
 
 ext {

--- a/libraries/muxer/build.gradle
+++ b/libraries/muxer/build.gradle
@@ -54,11 +54,6 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:' + robolectricVersion
     testImplementation 'com.google.truth:truth:' + truthVersion
     testImplementation project(modulePrefix + 'lib-exoplayer')
-    androidTestImplementation 'junit:junit:' + junitVersion
-    androidTestImplementation 'androidx.test:runner:' + androidxTestRunnerVersion
-    androidTestImplementation 'com.google.truth:truth:' + truthVersion
-    androidTestImplementation project(modulePrefix + 'test-utils')
-    androidTestImplementation project(modulePrefix + 'lib-extractor')
 }
 
 ext {


### PR DESCRIPTION
This PR removes some unused dependencies in the project. I've used https://github.com/autonomousapps/dependency-analysis-gradle-plugin (not included here) to detect them, and I've addressed the simplest ones:
- [demo-composition] Use more specific AndroidX Lifecycle dependencies.
- [demo-composition] Replace the hardcoded AndroidX Lifecycle version with `androidxLifecycleVersion`.
- [demo-session] Use `lifecycle-runtime` instead of the `-ktx` variant, because it is empty since [AndroidX Lifecycle 2.8.0](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.0) (2.8.7 is used here).
- [demo-session-automotive] Remove AndroidX Core, AndroidX AppCompat and Material Components dependencies.
- [demo-session-automotive] Add AndroidX Annotation Experimental dependency.
- [demo-session-service] Remove AndroidX AppCompat dependency.
- [demo-shortform] Remove AndroidX ConstraintLayout and AndroidX Core dependencies.
- [demo-shortform] Remove duplicated Material Components dependency.
- [demo-shortform] Remove test dependencies since the module doesn't have any tests.
- [demo-transformer] Remove AndroidX RecyclerView dependency.
- [library-common] Remove Android Test dependencies since the module doesn't have any Android Tests.
- [library-muxer] Remove Android Test dependencies since the module doesn't have any Android Tests.