### PR TITLE
Add Player.setAudioPresentation API

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/Player.java
+++ b/libraries/common/src/main/java/androidx/media3/common/Player.java
@@ -21,6 +21,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 
+import android.media.AudioPresentation;
 import android.os.Bundle;
 import android.os.Looper;
 import android.view.Surface;
@@ -554,6 +555,7 @@ public interface Player {
         COMMAND_ADJUST_DEVICE_VOLUME,
         COMMAND_ADJUST_DEVICE_VOLUME_WITH_FLAGS,
         COMMAND_SET_AUDIO_ATTRIBUTES,
+        COMMAND_SET_AUDIO_PRESENTATION,
         COMMAND_SET_VIDEO_SURFACE,
         COMMAND_GET_TEXT,
         COMMAND_SET_TRACK_SELECTION_PARAMETERS,
@@ -1685,6 +1687,7 @@ public interface Player {
    *   <li>{@link #COMMAND_ADJUST_DEVICE_VOLUME}
    *   <li>{@link #COMMAND_ADJUST_DEVICE_VOLUME_WITH_FLAGS}
    *   <li>{@link #COMMAND_SET_AUDIO_ATTRIBUTES}
+   *   <li>{@link #COMMAND_SET_AUDIO_PRESENTATION}
    *   <li>{@link #COMMAND_SET_VIDEO_SURFACE}
    *   <li>{@link #COMMAND_GET_TEXT}
    *   <li>{@link #COMMAND_SET_TRACK_SELECTION_PARAMETERS}
@@ -1732,6 +1735,7 @@ public interface Player {
     COMMAND_ADJUST_DEVICE_VOLUME,
     COMMAND_ADJUST_DEVICE_VOLUME_WITH_FLAGS,
     COMMAND_SET_AUDIO_ATTRIBUTES,
+    COMMAND_SET_AUDIO_PRESENTATION,
     COMMAND_SET_VIDEO_SURFACE,
     COMMAND_GET_TEXT,
     COMMAND_SET_TRACK_SELECTION_PARAMETERS,
@@ -2091,6 +2095,14 @@ public interface Player {
    * command is {@linkplain #isCommandAvailable(int) available}.
    */
   int COMMAND_SET_AUDIO_ATTRIBUTES = 35;
+
+  /**
+   * Command to set the player's audio presentation.
+   *
+   * <p>The {@link #setAudioPresentation(AudioPresentation presentation)} method must only
+   * be called if this command is {@linkplain #isCommandAvailable(int) available}.
+   */
+  int COMMAND_SET_AUDIO_PRESENTATION = 36;
 
   /**
    * Command to set and clear the surface on which to render the video.
@@ -3508,4 +3520,18 @@ public interface Player {
    * @param handleAudioFocus True if the player should handle audio focus, false otherwise.
    */
   void setAudioAttributes(AudioAttributes audioAttributes, boolean handleAudioFocus);
+
+  /**
+   * Sets the {@link AudioPresentation} to be selected in the audio renderer on an active audio
+   * track. This audio presentation will be decoded by the supported audio decoders.
+   *
+   * <p>This method is supported only for direct/offload playback modes and on devices running a
+   * build platform API version 29 onwards.
+   *
+   * <p>This method must only be called if {@link #COMMAND_SET_AUDIO_PRESENTATION} is {@linkplain
+   * #getAvailableCommands() available}.
+   *
+   * @param presentation The audio presentation to select.
+   */
+  default void setAudioPresentation(AudioPresentation presentation) {}
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImpl.java
@@ -26,6 +26,7 @@ import static androidx.media3.common.util.Assertions.checkNotNull;
 import static androidx.media3.common.util.Assertions.checkState;
 import static androidx.media3.common.util.Util.castNonNull;
 import static androidx.media3.exoplayer.Renderer.MSG_SET_AUDIO_ATTRIBUTES;
+import static androidx.media3.exoplayer.Renderer.MSG_SET_AUDIO_PRESENTATION;
 import static androidx.media3.exoplayer.Renderer.MSG_SET_AUDIO_SESSION_ID;
 import static androidx.media3.exoplayer.Renderer.MSG_SET_AUX_EFFECT_INFO;
 import static androidx.media3.exoplayer.Renderer.MSG_SET_CAMERA_MOTION_LISTENER;
@@ -45,6 +46,7 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.graphics.SurfaceTexture;
 import android.media.AudioDeviceInfo;
+import android.media.AudioPresentation;
 import android.media.MediaFormat;
 import android.os.Handler;
 import android.os.Looper;
@@ -53,6 +55,7 @@ import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.TextureView;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.media3.common.AudioAttributes;
@@ -1942,6 +1945,12 @@ import java.util.concurrent.CopyOnWriteArraySet;
   public void setImageOutput(@Nullable ImageOutput imageOutput) {
     verifyApplicationThread();
     sendRendererMessage(TRACK_TYPE_IMAGE, MSG_SET_IMAGE_OUTPUT, imageOutput);
+  }
+
+  @Override
+  public void setAudioPresentation(AudioPresentation audioPresentation) {
+    verifyApplicationThread();
+    sendRendererMessage(TRACK_TYPE_AUDIO, MSG_SET_AUDIO_PRESENTATION, audioPresentation);
   }
 
   @SuppressWarnings("deprecation") // Calling deprecated methods.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/Renderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/Renderer.java
@@ -17,6 +17,7 @@ package androidx.media3.exoplayer;
 
 import static java.lang.annotation.ElementType.TYPE_USE;
 
+import android.media.AudioPresentation;
 import android.media.MediaCodec;
 import android.view.Surface;
 import androidx.annotation.IntDef;
@@ -186,8 +187,9 @@ public interface Renderer extends PlayerMessage.Target {
    * #MSG_SET_AUX_EFFECT_INFO}, {@link #MSG_SET_VIDEO_FRAME_METADATA_LISTENER}, {@link
    * #MSG_SET_CAMERA_MOTION_LISTENER}, {@link #MSG_SET_SKIP_SILENCE_ENABLED}, {@link
    * #MSG_SET_AUDIO_SESSION_ID}, {@link #MSG_SET_WAKEUP_LISTENER}, {@link #MSG_SET_VIDEO_EFFECTS},
-   * {@link #MSG_SET_VIDEO_OUTPUT_RESOLUTION} or {@link #MSG_SET_IMAGE_OUTPUT}. May also be an
-   * app-defined value (see {@link #MSG_CUSTOM_BASE}).
+   * {@link #MSG_SET_VIDEO_OUTPUT_RESOLUTION}, {@link #MSG_SET_IMAGE_OUTPUT} or
+   * {@link #MSG_SET_AUDIO_PRESENTATION}. May also be an app-defined value
+   * (see {@link #MSG_CUSTOM_BASE}).
    */
   @Documented
   @Retention(RetentionPolicy.SOURCE)
@@ -211,7 +213,8 @@ public interface Renderer extends PlayerMessage.Target {
         MSG_SET_IMAGE_OUTPUT,
         MSG_SET_PRIORITY,
         MSG_TRANSFER_RESOURCES,
-        MSG_SET_SCRUBBING_MODE
+        MSG_SET_SCRUBBING_MODE,
+        MSG_SET_AUDIO_PRESENTATION
       })
   public @interface MessageType {}
 
@@ -362,6 +365,13 @@ public interface Renderer extends PlayerMessage.Target {
    * enable or {@code null} to disable scrubbing mode.
    */
   int MSG_SET_SCRUBBING_MODE = 18;
+
+  /**
+   * The type of message that can be passed to an audio renderer to set a desired audio
+   * presentation. The message object should be an {@link AudioPresentation} instance that will
+   * configure the underlying audio track.
+   */
+  int MSG_SET_AUDIO_PRESENTATION = 19;
 
   /**
    * Applications or extensions may define custom {@code MSG_*} constants that can be passed to

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/RendererCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/RendererCapabilities.java
@@ -145,10 +145,11 @@ public interface RendererCapabilities {
   /**
    * Level of renderer support for audio offload.
    *
-   * <p>Speed change and gapless transition support with audio offload is represented by the bit
-   * mask flags {@link #AUDIO_OFFLOAD_SPEED_CHANGE_SUPPORTED} and {@link
-   * #AUDIO_OFFLOAD_GAPLESS_SUPPORTED} respectively. If neither feature is supported then the value
-   * will be either {@link #AUDIO_OFFLOAD_SUPPORTED} or {@link #AUDIO_OFFLOAD_NOT_SUPPORTED}.
+   * <p>Set presentation, speed change and gapless transition support with audio offload is
+   * represented by the bit mask flags {@link #AUDIO_OFFLOAD_SET_PRESENTATION_SUPPORTED},
+   * {@link #AUDIO_OFFLOAD_SPEED_CHANGE_SUPPORTED} and {@link #AUDIO_OFFLOAD_GAPLESS_SUPPORTED}
+   * respectively. If neither feature is supported then the value will be either
+   * {@link #AUDIO_OFFLOAD_SUPPORTED} or {@link #AUDIO_OFFLOAD_NOT_SUPPORTED}.
    *
    * <p>For non-audio renderers, the level of support is always {@link
    * #AUDIO_OFFLOAD_NOT_SUPPORTED}.
@@ -157,6 +158,7 @@ public interface RendererCapabilities {
   @Retention(RetentionPolicy.SOURCE)
   @Target(TYPE_USE)
   @IntDef({
+    AUDIO_OFFLOAD_SET_PRESENTATION_SUPPORTED,
     AUDIO_OFFLOAD_SPEED_CHANGE_SUPPORTED,
     AUDIO_OFFLOAD_GAPLESS_SUPPORTED,
     AUDIO_OFFLOAD_SUPPORTED,
@@ -165,7 +167,10 @@ public interface RendererCapabilities {
   @interface AudioOffloadSupport {}
 
   /** A mask to apply to {@link Capabilities} to obtain {@link AudioOffloadSupport} only. */
-  int AUDIO_OFFLOAD_SUPPORT_MASK = 0b111 << 9;
+  int AUDIO_OFFLOAD_SUPPORT_MASK = 0b1111 << 9;
+
+  /** The renderer supports audio offload and set presentation with this format. */
+  int AUDIO_OFFLOAD_SET_PRESENTATION_SUPPORTED = 0b1000 << 9;
 
   /** The renderer supports audio offload and speed changes with this format. */
   int AUDIO_OFFLOAD_SPEED_CHANGE_SUPPORTED = 0b100 << 9;
@@ -215,9 +220,10 @@ public interface RendererCapabilities {
    *   <li>{@link AudioOffloadSupport}: The level of offload support. Value will have the flag
    *       {@link #AUDIO_OFFLOAD_SUPPORTED} or be {@link #AUDIO_OFFLOAD_NOT_SUPPORTED}. In addition,
    *       if it is {@link #AUDIO_OFFLOAD_SUPPORTED}, then one can check for {@link
-   *       #AUDIO_OFFLOAD_SPEED_CHANGE_SUPPORTED} and {@link #AUDIO_OFFLOAD_GAPLESS_SUPPORTED}.
-   *       These represent speed change and gapless transition support with audio offload
-   *       respectively.
+   *       #AUDIO_OFFLOAD_SET_PRESENTATION_SUPPORTED}, {@link #AUDIO_OFFLOAD_SPEED_CHANGE_SUPPORTED}
+   *       and {@link #AUDIO_OFFLOAD_GAPLESS_SUPPORTED}.
+   *       These represent set presentation, speed change and gapless transition support with audio
+   *       offload respectively.
    * </ul>
    */
   @Documented

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioOffloadSupport.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioOffloadSupport.java
@@ -38,12 +38,16 @@ public final class AudioOffloadSupport {
     /** Whether playback of the format is supported with speed changes. */
     private boolean isSpeedChangeSupported;
 
+    /** Whether playback of the format is supported with audio presentation selection. */
+    private boolean isSetPresentationSupported;
+
     public Builder() {}
 
     public Builder(AudioOffloadSupport audioOffloadSupport) {
       isFormatSupported = audioOffloadSupport.isFormatSupported;
       isGaplessSupported = audioOffloadSupport.isGaplessSupported;
       isSpeedChangeSupported = audioOffloadSupport.isSpeedChangeSupported;
+      isSetPresentationSupported = audioOffloadSupport.isSetPresentationSupported;
     }
 
     /**
@@ -80,6 +84,17 @@ public final class AudioOffloadSupport {
     }
 
     /**
+     * Sets whether the format allows selection of different audio presentations during playback.
+     *
+     * <p>Default is {@code false}.
+     */
+    @CanIgnoreReturnValue
+    public Builder setIsPresentationSelectionSupported(boolean isSetPresentationSupported) {
+      this.isSetPresentationSupported = isSetPresentationSupported;
+      return this;
+    }
+
+    /**
      * Builds the {@link AudioOffloadSupport}.
      *
      * @throws IllegalStateException If either {@link #isGaplessSupported} or {@link
@@ -103,10 +118,14 @@ public final class AudioOffloadSupport {
   /** Whether playback of the format is supported with speed changes. */
   public final boolean isSpeedChangeSupported;
 
+  /** Whether the format allows selection of different audio presentations during playback. */
+  public final boolean isSetPresentationSupported;
+
   private AudioOffloadSupport(AudioOffloadSupport.Builder builder) {
     this.isFormatSupported = builder.isFormatSupported;
     this.isGaplessSupported = builder.isGaplessSupported;
     this.isSpeedChangeSupported = builder.isSpeedChangeSupported;
+    this.isSetPresentationSupported = builder.isSetPresentationSupported;
   }
 
   /** Creates a new {@link Builder}, copying the initial values from this instance. */
@@ -125,14 +144,16 @@ public final class AudioOffloadSupport {
     AudioOffloadSupport other = (AudioOffloadSupport) obj;
     return isFormatSupported == other.isFormatSupported
         && isGaplessSupported == other.isGaplessSupported
-        && isSpeedChangeSupported == other.isSpeedChangeSupported;
+        && isSpeedChangeSupported == other.isSpeedChangeSupported
+        && isSetPresentationSupported == other.isSetPresentationSupported;
   }
 
   @Override
   public int hashCode() {
-    int hashCode = (isFormatSupported ? 1 : 0) << 2;
-    hashCode += (isGaplessSupported ? 1 : 0) << 1;
-    hashCode += (isSpeedChangeSupported ? 1 : 0);
+    int hashCode = (isFormatSupported ? 1 : 0) << 3;
+    hashCode += (isGaplessSupported ? 1 : 0) << 2;
+    hashCode += (isSpeedChangeSupported ? 1 : 0) << 1;
+    hashCode += (isSetPresentationSupported ? 1 : 0);
     return hashCode;
   }
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioSink.java
@@ -18,6 +18,7 @@ package androidx.media3.exoplayer.audio;
 import static java.lang.annotation.ElementType.TYPE_USE;
 
 import android.media.AudioDeviceInfo;
+import android.media.AudioPresentation;
 import android.media.AudioTrack;
 import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
@@ -642,6 +643,15 @@ public interface AudioSink {
    */
   @RequiresApi(29)
   default void setOffloadDelayPadding(int delayInFrames, int paddingInFrames) {}
+
+  /**
+   * Sets the presentation of an audio program, delivered by Next Generation Audio streams.
+   * Also requires platform API version 29 onwards.
+   *
+   * @param presentation The audio presentation to set.
+   */
+  @RequiresApi(29)
+  default void setPresentation(AudioPresentation presentation) {}
 
   /**
    * Sets the playback volume.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -30,6 +30,7 @@ import android.content.Context;
 import android.media.AudioDeviceInfo;
 import android.media.AudioFormat;
 import android.media.AudioManager;
+import android.media.AudioPresentation;
 import android.media.AudioRouting;
 import android.media.AudioRouting.OnRoutingChangedListener;
 import android.media.AudioTrack;
@@ -1572,6 +1573,23 @@ public final class DefaultAudioSink implements AudioSink {
         && configuration != null
         && configuration.enableOffloadGapless) {
       audioTrack.setOffloadDelayPadding(delayInFrames, paddingInFrames);
+    }
+  }
+
+  @RequiresApi(29)
+  @Override
+  public void setPresentation(AudioPresentation presentation) {
+    if (audioTrack != null) {
+      try {
+        int status = audioTrack.setPresentation(presentation);
+        if (status != AudioTrack.SUCCESS) {
+          Log.e(TAG, "Failed to set audio presentation: " + status);
+        }
+      } catch (IllegalArgumentException e) {
+        Log.e(TAG, "audioTrack.setPresentation is not supported: ", e);
+      } catch (IllegalStateException e) {
+        Log.e(TAG, "Error applying audioTrack.setPresentation", e);
+      }
     }
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
@@ -27,6 +27,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.media.AudioDeviceInfo;
 import android.media.AudioFormat;
+import android.media.AudioPresentation;
 import android.media.MediaCodec;
 import android.media.MediaCrypto;
 import android.media.MediaFormat;
@@ -406,6 +407,9 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
     }
     if (audioSinkOffloadSupport.isSpeedChangeSupported) {
       audioOffloadSupport |= AUDIO_OFFLOAD_SPEED_CHANGE_SUPPORTED;
+    }
+    if (audioSinkOffloadSupport.isSetPresentationSupported) {
+      audioOffloadSupport |= AUDIO_OFFLOAD_SET_PRESENTATION_SUPPORTED;
     }
     return audioOffloadSupport;
   }
@@ -908,6 +912,11 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
         break;
       case MSG_SET_SKIP_SILENCE_ENABLED:
         audioSink.setSkipSilenceEnabled((Boolean) checkNotNull(message));
+        break;
+      case MSG_SET_AUDIO_PRESENTATION:
+        if (SDK_INT >= 29) {
+            audioSink.setPresentation((AudioPresentation) checkNotNull(message));
+        }
         break;
       case MSG_SET_AUDIO_SESSION_ID:
         setAudioSessionId((int) checkNotNull(message));

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/MappingTrackSelector.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/MappingTrackSelector.java
@@ -332,6 +332,8 @@ public abstract class MappingTrackSelector extends TrackSelector {
 
   @Nullable private MappedTrackInfo currentMappedTrackInfo;
 
+  private boolean setAudioPresentationSupported;
+
   /**
    * Returns the mapping information for the currently active track selection, or null if no
    * selection is currently active.
@@ -391,6 +393,15 @@ public abstract class MappingTrackSelector extends TrackSelector {
       rendererTrackGroups[rendererIndex][rendererTrackGroupCount] = group;
       rendererFormatSupports[rendererIndex][rendererTrackGroupCount] = rendererFormatSupport;
       rendererTrackGroupCounts[rendererIndex]++;
+      if (group.type == C.TRACK_TYPE_AUDIO) {
+        for (int formatSupport : rendererFormatSupport) {
+          if ((formatSupport &
+              RendererCapabilities.AUDIO_OFFLOAD_SET_PRESENTATION_SUPPORTED) != 0) {
+            setAudioPresentationSupported = true;
+            break;
+          }
+        }
+      }
     }
 
     // Create a track group array for each renderer, and trim each rendererFormatSupports entry.
@@ -436,6 +447,11 @@ public abstract class MappingTrackSelector extends TrackSelector {
     Tracks tracks = TrackSelectionUtil.buildTracks(mappedTrackInfo, result.second);
 
     return new TrackSelectorResult(result.first, result.second, tracks, mappedTrackInfo);
+  }
+
+  @Override
+  public boolean isSetAudioPresentationSupported() {
+    return setAudioPresentationSupported;
   }
 
   /**

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/TrackSelector.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/TrackSelector.java
@@ -209,6 +209,16 @@ public abstract class TrackSelector {
     return false;
   }
 
+  /**
+   * Returns if this {@code TrackSelector} supports {@link
+   * #setAudioPresentation(AudioPresentation)}.
+   *
+   * <p>The same value is always returned for a given {@code TrackSelector} instance.
+   */
+  public boolean isSetAudioPresentationSupported() {
+    return false;
+  }
+
   /** Called by the player to set the {@link AudioAttributes} that will be used for playback. */
   public void setAudioAttributes(AudioAttributes audioAttributes) {
     // Default implementation is no-op.

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/AudioOffloadSupportTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/AudioOffloadSupportTest.java
@@ -42,9 +42,10 @@ public final class AudioOffloadSupportTest {
             .setIsFormatSupported(true)
             .setIsGaplessSupported(true)
             .setIsSpeedChangeSupported(true)
+            .setIsPresentationSelectionSupported(true)
             .build();
 
-    assertThat(audioOffloadSupport.hashCode()).isEqualTo(7);
+    assertThat(audioOffloadSupport.hashCode()).isEqualTo(15);
   }
 
   @Test


### PR DESCRIPTION
* Set an available AudioPresentation via Player interface on an AudioSink that plays audio data using AudioTrack.
* Verify AudioManager.getParameters() using the key "isAc4PresentationSelectionByIndexSupported" before setting the audio presentation. Additionally, extend the Player command by incorporating Player.COMMAND_SET_AUDIO_PRESENTATION, allowing the app to check for this capability before configuring audio presentations

Change-Id: I8a37e3dc66878934b67c24e137cba8c9db7c79ac