### PR TITLE
c2.sec.flac.decoder does not support 32-bit audio on Android 14

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
@@ -382,7 +382,7 @@ public final class MediaCodecInfo {
   }
 
   private boolean isCompressedAudioBitDepthSupported(Format format) {
-    // MediaCodec doesn't have a way to query decoder bit-depth support.
+    // MediaCodec does not have a way to query decoder bit-depth support.
     if (!Objects.equals(format.sampleMimeType, MimeTypes.AUDIO_FLAC)
         || format.pcmEncoding != C.ENCODING_PCM_32BIT) {
       // Only 32-bit FLAC is a concern at the moment, everything else can be marked supported.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
@@ -392,9 +392,9 @@ public final class MediaCodecInfo {
     if (name.equals("c2.android.flac.decoder")) {
       return SDK_INT >= 34;
     }
-    // c2.sec.flac.decoder is known not to support 32-bit until API 35.
+    // c2.sec.flac.decoder is known not to support 32-bit on any API level currently.
     if (name.equals("c2.sec.flac.decoder")) {
-      return SDK_INT >= 35;
+      return false;
     }
     // We optimistically assume that another (unrecognized) FLAC decoder does support 32-bit on all
     // API levels where it exists.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
@@ -382,14 +382,23 @@ public final class MediaCodecInfo {
   }
 
   private boolean isCompressedAudioBitDepthSupported(Format format) {
-    // MediaCodec doesn't have a way to query FLAC decoder bit-depth support.
-    // c2.android.flac.decoder is known not to support 32-bit until API 34. We optimistically assume
-    // that another (unrecognized) FLAC decoder does support 32-bit on all API levels where it
-    // exists.
-    return !Objects.equals(format.sampleMimeType, MimeTypes.AUDIO_FLAC)
-        || format.pcmEncoding != C.ENCODING_PCM_32BIT
-        || SDK_INT >= 34
-        || !name.equals("c2.android.flac.decoder");
+    // MediaCodec doesn't have a way to query decoder bit-depth support.
+    if (!Objects.equals(format.sampleMimeType, MimeTypes.AUDIO_FLAC)
+        || format.pcmEncoding != C.ENCODING_PCM_32BIT) {
+      // Only 32-bit FLAC is a concern at the moment, everything else can be marked supported.
+      return true;
+    }
+    // c2.android.flac.decoder is known not to support 32-bit until API 34.
+    if (name.equals("c2.android.flac.decoder")) {
+      return SDK_INT >= 34;
+    }
+    // c2.sec.flac.decoder is known not to support 32-bit until API 35.
+    if (name.equals("c2.sec.flac.decoder")) {
+      return SDK_INT >= 35;
+    }
+    // We optimistically assume that another (unrecognized) FLAC decoder does support 32-bit on all
+    // API levels where it exists.
+    return true;
   }
 
   /** Whether the codec handles HDR10+ out-of-band metadata. */


### PR DESCRIPTION
fixes 32-bit FLAC playback on Galaxy S23 FE (Snapdragon 8 Gen 1 version)