### PR TITLE
Add AC-4 decoder capability assessment during track selection

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
@@ -357,13 +357,22 @@ public final class MediaCodecInfo {
       }
     }
 
-    if (!isVideo && profile != CodecProfileLevel.AACObjectXHE) {
+    if (!isVideo &&
+        !mimeType.equals(MimeTypes.AUDIO_AC4) &&
+        profile != CodecProfileLevel.AACObjectXHE) {
+      // AC-4 decoder reports profile levels or audio capabilities that determine whether input
+      // format is supported or not.
       // Some devices/builds underreport audio capabilities, so assume support except for xHE-AAC
       // which may not be widely supported. See https://github.com/google/ExoPlayer/issues/5145.
       return true;
     }
 
     CodecProfileLevel[] profileLevels = getProfileLevels();
+    if (MimeTypes.AUDIO_AC4.equals(mimeType) && profileLevels.length == 0) {
+      // Some older devices don't report profile levels for AC-4. Estimate them using other data
+      // in the codec capabilities.
+      profileLevels = estimateLegacyAc4ProfileLevels(capabilities);
+    }
     if (SDK_INT <= 23 && MimeTypes.VIDEO_VP9.equals(mimeType) && profileLevels.length == 0) {
       // Some older devices don't report profile levels for VP9. Estimate them using other data in
       // the codec capabilities.
@@ -817,6 +826,39 @@ public final class MediaCodecInfo {
   @RequiresApi(23)
   private static int getMaxSupportedInstancesV23(CodecCapabilities capabilities) {
     return capabilities.getMaxSupportedInstances();
+  }
+
+  /**
+   * Called on devices with AC-4 decoders whose {@link CodecCapabilities} do not report profile
+   * levels. The returned {@link CodecProfileLevel CodecProfileLevels} are estimated based on other
+   * data in the {@link CodecCapabilities}.
+   *
+   * @param capabilities The {@link CodecCapabilities} for an AC-4 decoder, or {@code null} if not
+   *     known.
+   * @return The estimated {@link CodecProfileLevel CodecProfileLevels} for the decoder.
+   */
+  private static CodecProfileLevel[] estimateLegacyAc4ProfileLevels(
+      @Nullable CodecCapabilities capabilities) {
+    int maxInChCount = 2;
+    if (capabilities != null) {
+      @Nullable AudioCapabilities audioCapabilities = capabilities.getAudioCapabilities();
+      if (audioCapabilities != null) {
+        maxInChCount = audioCapabilities.getMaxInputChannelCount();
+      }
+    }
+
+    int level = CodecProfileLevel.AC4Level3;
+    if (maxInChCount > 18) { // AC-4 Level 3 stream is up to 17.1 channel
+      level = CodecProfileLevel.AC4Level4;
+    }
+
+    return new CodecProfileLevel[] {
+        createCodecProfileLevel(CodecProfileLevel.AC4Profile00, level),
+        createCodecProfileLevel(CodecProfileLevel.AC4Profile10, level),
+        createCodecProfileLevel(CodecProfileLevel.AC4Profile11, level),
+        createCodecProfileLevel(CodecProfileLevel.AC4Profile21, level),
+        createCodecProfileLevel(CodecProfileLevel.AC4Profile22, level)
+    };
   }
 
   /**


### PR DESCRIPTION
Beginning with Android 16, some devices will expose AC-4 profile/level information. This update adds AC-4 decoder capability assessment during track selection.