### PR TITLE
Bump Robolectric to 4.15.1

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -33,7 +33,7 @@ project.ext {
     kotlinxCoroutinesVersion = '1.9.0'
     leakCanaryVersion = '2.10'
     mockitoVersion = '3.12.4'
-    robolectricVersion = '4.14.1'
+    robolectricVersion = '4.15.1'
     // Keep this in sync with Google's internal Checker Framework version.
     checkerframeworkVersion = '3.13.0'
     errorProneVersion = '2.18.0'

--- a/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/e2etest/DashPlaybackTest.java
+++ b/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/e2etest/DashPlaybackTest.java
@@ -88,6 +88,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 
 /** End-to-end tests using DASH samples. */
 @RunWith(AndroidJUnit4.class)
@@ -357,6 +358,9 @@ public final class DashPlaybackTest {
         .ignoringNonFatalErrors()
         .untilBackgroundThreadCondition(() -> secondSubtitleFailureCount.get() == 4);
     secondSubtitleResolves.set(true);
+
+    ShadowLooper.runUiThreadTasks();
+
     advance(player)
         .ignoringNonFatalErrors()
         .untilBackgroundThreadCondition(secondSubtitleChunkLoaded::get);


### PR DESCRIPTION
Bump Robolectric to 4.15.1 and adapt test code to flush runnables before internal checking.