### PR TITLE
Add `SphericalGLSurfaceView` support to `PlayerSurface`

### DIFF
--- a/demos/compose/src/main/java/androidx/media3/demo/compose/data/videos.kt
+++ b/demos/compose/src/main/java/androidx/media3/demo/compose/data/videos.kt
@@ -15,10 +15,15 @@
  */
 package androidx.media3.demo.compose.data
 
+import androidx.media3.ui.compose.SURFACE_TYPE_SPHERICAL_GL_SURFACE_VIEW
+import androidx.media3.ui.compose.SURFACE_TYPE_SURFACE_VIEW
+
 val videos =
-  listOf(
-    "https://html5demos.com/assets/dizzy.mp4",
-    "https://storage.googleapis.com/exoplayer-test-media-0/shortform_2.mp4",
-    "https://storage.googleapis.com/exoplayer-test-media-1/gen-3/screens/dash-vod-single-segment/video-vp9-360.webm",
-    "https://storage.googleapis.com/exoplayer-test-media-0/shortform_3.mp4",
+  mapOf(
+    "https://html5demos.com/assets/dizzy.mp4" to SURFACE_TYPE_SURFACE_VIEW,
+    "https://storage.googleapis.com/exoplayer-test-media-0/shortform_2.mp4" to SURFACE_TYPE_SURFACE_VIEW,
+    "https://storage.googleapis.com/exoplayer-test-media-1/gen-3/screens/dash-vod-single-segment/video-vp9-360.webm" to SURFACE_TYPE_SURFACE_VIEW,
+    "https://storage.googleapis.com/exoplayer-test-media-0/shortform_3.mp4" to SURFACE_TYPE_SURFACE_VIEW,
+    // https://bitmovin.com/demos/vr-360/
+    "https://cdn.bitmovin.com/content/assets/playhouse-vr/progressive.mp4" to SURFACE_TYPE_SPHERICAL_GL_SURFACE_VIEW,
   )

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/spherical/SphericalGLSurfaceView.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/spherical/SphericalGLSurfaceView.java
@@ -47,8 +47,9 @@ import javax.microedition.khronos.opengles.GL10;
 /**
  * Renders a GL scene in a non-VR Activity that is affected by phone orientation and touch input.
  *
- * <p>The two input components are the TYPE_GAME_ROTATION_VECTOR Sensor and a TouchListener. The GL
- * renderer combines these two inputs to render a scene with the appropriate camera orientation.
+ * <p>The two input components are the {@link Sensor#TYPE_GAME_ROTATION_VECTOR
+ * TYPE_GAME_ROTATION_VECTOR} Sensor and a TouchListener. The GL renderer combines these two inputs
+ * to render a scene with the appropriate camera orientation.
  *
  * <p>The primary complexity in this class is related to the various rotations. It is important to
  * apply the touch and sensor rotations in the correct order or the user's touch manipulations won't

--- a/libraries/ui_compose/build.gradle
+++ b/libraries/ui_compose/build.gradle
@@ -49,7 +49,6 @@ android {
 dependencies {
     api project(modulePrefix + 'lib-common')
     api project(modulePrefix + 'lib-common-ktx')
-    api project(modulePrefix + 'lib-exoplayer')
 
     def composeBom = platform('androidx.compose:compose-bom:2024.12.01')
     api composeBom
@@ -60,6 +59,7 @@ dependencies {
     testImplementation 'androidx.compose.ui:ui-test-android:1.8.2'
     testImplementation 'androidx.compose.ui:ui-test'
     testImplementation 'androidx.compose.ui:ui-test-junit4'
+    testImplementation project(modulePrefix + 'lib-exoplayer')
     testImplementation project(modulePrefix + 'test-utils')
     testImplementation 'org.robolectric:robolectric:' + robolectricVersion
 }

--- a/libraries/ui_compose/build.gradle
+++ b/libraries/ui_compose/build.gradle
@@ -49,6 +49,7 @@ android {
 dependencies {
     api project(modulePrefix + 'lib-common')
     api project(modulePrefix + 'lib-common-ktx')
+    api project(modulePrefix + 'lib-exoplayer')
 
     def composeBom = platform('androidx.compose:compose-bom:2024.12.01')
     api composeBom

--- a/libraries/ui_compose/proguard-rules.txt
+++ b/libraries/ui_compose/proguard-rules.txt
@@ -1,0 +1,7 @@
+# Proguard rules specific to the UI Compose module.
+
+# Constructor method and classes accessed via reflection in PlayerSurface
+-dontnote androidx.media3.exoplayer.video.spherical.SphericalGLSurfaceView
+-keepclassmembers class androidx.media3.exoplayer.video.spherical.SphericalGLSurfaceView {
+  <init>(android.content.Context);
+}

--- a/libraries/ui_compose/src/test/java/androidx/media3/ui/compose/PlayerSurfaceTest.kt
+++ b/libraries/ui_compose/src/test/java/androidx/media3/ui/compose/PlayerSurfaceTest.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.Player
 import androidx.media3.common.SimpleBasePlayer
+import androidx.media3.exoplayer.video.spherical.SphericalGLSurfaceView
 import androidx.media3.ui.compose.utils.TestPlayer
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
@@ -76,6 +77,18 @@ class PlayerSurfaceTest {
     composeTestRule.waitForIdle()
 
     assertThat(player.videoOutput).isInstanceOf(TextureView::class.java)
+  }
+
+  @Test
+  fun playerSurface_withSphericalGlSurfaceViewType_setsSphericalGlSurfaceViewOnPlayer() {
+    val player = TestPlayer()
+
+    composeTestRule.setContent {
+      PlayerSurface(player = player, surfaceType = SURFACE_TYPE_SPHERICAL_GL_SURFACE_VIEW)
+    }
+    composeTestRule.waitForIdle()
+
+    assertThat(player.videoOutput).isInstanceOf(SphericalGLSurfaceView::class.java)
   }
 
   @Test


### PR DESCRIPTION
This change allows `PlayerSurface` to render video using `SphericalGLSurfaceView` when specifying the `SURFACE_TYPE_SPHERICAL_GL_SURFACE_VIEW` type.

The Compose demo has also been updated to include a 360 video example that utilizes this new surface type.

> [!NOTE]
> The 360° video used in the video comes from [Bitmovin](https://bitmovin.com/demos/vr-360/). I've added a link to the page in the demo source code. Let me know if you'd rather use a different video or handle attribution differently.