### PR TITLE
test: Flush ui thread runnables before testing its result

### DIFF
--- a/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/e2etest/DashPlaybackTest.java
+++ b/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/e2etest/DashPlaybackTest.java
@@ -88,6 +88,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 
 /** End-to-end tests using DASH samples. */
 @RunWith(AndroidJUnit4.class)
@@ -357,6 +358,9 @@ public final class DashPlaybackTest {
         .ignoringNonFatalErrors()
         .untilBackgroundThreadCondition(() -> secondSubtitleFailureCount.get() == 4);
     secondSubtitleResolves.set(true);
+
+    ShadowLooper.runUiThreadTasks();
+
     advance(player)
         .ignoringNonFatalErrors()
         .untilBackgroundThreadCondition(secondSubtitleChunkLoaded::get);


### PR DESCRIPTION
It prepares for next Robolectric release.