### PR TITLE
Make MediaControllerImplBase local binder aware

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/MediaItem.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MediaItem.java
@@ -23,9 +23,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import android.net.Uri;
+import android.os.Binder;
 import android.os.Bundle;
+import android.os.IBinder;
 import androidx.annotation.IntRange;
 import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
 import androidx.media3.common.util.BundleCollectionUtil;
 import androidx.media3.common.util.UnstableApi;
@@ -2394,6 +2397,7 @@ public final class MediaItem {
   private static final String FIELD_CLIPPING_PROPERTIES = Util.intToStringMaxRadix(3);
   private static final String FIELD_REQUEST_METADATA = Util.intToStringMaxRadix(4);
   private static final String FIELD_LOCAL_CONFIGURATION = Util.intToStringMaxRadix(5);
+  private static final String FIELD_IN_PROCESS_BINDER = Util.intToStringMaxRadix(6);
 
   @UnstableApi
   private Bundle toBundle(boolean includeLocalConfiguration, int interfaceVersion) {
@@ -2473,6 +2477,17 @@ public final class MediaItem {
   }
 
   /**
+   * Returns a {@link Bundle} containing the entirety of this {@link #MediaItem} object without
+   * bundling it, for use in local process communication only.
+   */
+  @UnstableApi
+  public Bundle toBundleIncludeLocalConfigurationForLocalProcess() {
+    Bundle bundle = new Bundle();
+    bundle.putBinder(FIELD_IN_PROCESS_BINDER, new InProcessBinder());
+    return bundle;
+  }
+
+  /**
    * Restores a {@code MediaItem} from a {@link Bundle}.
    *
    * @param bundle The {@link Bundle}.
@@ -2481,6 +2496,10 @@ public final class MediaItem {
   @UnstableApi
   @SuppressWarnings("deprecation") // Unbundling to ClippingProperties while it still exists.
   public static MediaItem fromBundle(Bundle bundle, int interfaceVersion) {
+    IBinder inProcessBinder = bundle.getBinder(FIELD_IN_PROCESS_BINDER);
+    if (inProcessBinder instanceof InProcessBinder) {
+      return ((InProcessBinder) inProcessBinder).getMediaItem();
+    }
     String mediaId = checkNotNull(bundle.getString(FIELD_MEDIA_ID, DEFAULT_MEDIA_ID));
     @Nullable Bundle liveConfigurationBundle = bundle.getBundle(FIELD_LIVE_CONFIGURATION);
     LiveConfiguration liveConfiguration;
@@ -2524,5 +2543,25 @@ public final class MediaItem {
         liveConfiguration,
         mediaMetadata,
         requestMetadata);
+  }
+
+  private final class InProcessBinder extends Binder {
+    public MediaItem getMediaItem() {
+      return MediaItem.this;
+    }
+  }
+
+  @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+  @UnstableApi
+  public static final class ListInProcessBinder extends Binder {
+    private final ImmutableList<MediaItem> theList;
+
+    public ListInProcessBinder(List<MediaItem> theList) {
+      this.theList = ImmutableList.copyOf(theList);
+    }
+
+    public ImmutableList<MediaItem> getMediaItemList() {
+      return theList;
+    }
   }
 }

--- a/libraries/common/src/main/java/androidx/media3/common/MediaMetadata.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MediaMetadata.java
@@ -24,7 +24,9 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 
 import android.net.Uri;
+import android.os.Binder;
 import android.os.Bundle;
+import android.os.IBinder;
 import android.text.TextUtils;
 import androidx.annotation.IntDef;
 import androidx.annotation.IntRange;
@@ -1379,6 +1381,7 @@ public final class MediaMetadata {
   private static final String FIELD_DURATION_MS = Util.intToStringMaxRadix(33);
   private static final String FIELD_SUPPORTED_COMMANDS = Util.intToStringMaxRadix(34);
   private static final String FIELD_DISC_SUBTITLE = Util.intToStringMaxRadix(35);
+  private static final String FIELD_IN_PROCESS_BINDER = Util.intToStringMaxRadix(36);
   private static final String FIELD_EXTRAS = Util.intToStringMaxRadix(1000);
 
   // Use a fairly lenient threshold for sending byte array to legacy processes that don't support
@@ -1526,6 +1529,17 @@ public final class MediaMetadata {
   }
 
   /**
+   * Returns a {@link Bundle} containing the entirety of this {@link #MediaMetadata} object without
+   * bundling it, for use in local process communication only.
+   */
+  @UnstableApi
+  public Bundle toBundleForLocalProcess() {
+    Bundle bundle = new Bundle();
+    bundle.putBinder(FIELD_IN_PROCESS_BINDER, new InProcessBinder());
+    return bundle;
+  }
+
+  /**
    * @deprecated Use {@link #fromBundle(Bundle, int)}.
    */
   @UnstableApi
@@ -1544,6 +1558,10 @@ public final class MediaMetadata {
   @UnstableApi
   @SuppressWarnings("deprecation") // Unbundling deprecated fields.
   public static MediaMetadata fromBundle(Bundle bundle, int interfaceVersion) {
+    IBinder inProcessBinder = bundle.getBinder(FIELD_IN_PROCESS_BINDER);
+    if (inProcessBinder instanceof InProcessBinder) {
+      return ((InProcessBinder) inProcessBinder).getMediaMetadata();
+    }
     Builder builder = new Builder();
     builder
         .setTitle(bundle.getCharSequence(FIELD_TITLE))
@@ -1715,6 +1733,12 @@ public final class MediaMetadata {
       case FOLDER_TYPE_NONE:
       default:
         return MEDIA_TYPE_FOLDER_MIXED;
+    }
+  }
+
+  private final class InProcessBinder extends Binder {
+    public MediaMetadata getMediaMetadata() {
+      return MediaMetadata.this;
     }
   }
 }

--- a/libraries/common/src/main/java/androidx/media3/common/TrackSelectionParameters.java
+++ b/libraries/common/src/main/java/androidx/media3/common/TrackSelectionParameters.java
@@ -22,7 +22,9 @@ import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 import android.content.Context;
+import android.os.Binder;
 import android.os.Bundle;
+import android.os.IBinder;
 import android.view.accessibility.CaptioningManager;
 import androidx.annotation.CallSuper;
 import androidx.annotation.IntDef;
@@ -1591,6 +1593,7 @@ public class TrackSelectionParameters {
   private static final String FIELD_PREFERRED_VIDEO_LABELS = Util.intToStringMaxRadix(36);
   private static final String FIELD_PREFERRED_AUDIO_LABELS = Util.intToStringMaxRadix(37);
   private static final String FIELD_PREFERRED_TEXT_LABELS = Util.intToStringMaxRadix(38);
+  private static final String FIELD_IN_PROCESS_BINDER = Util.intToStringMaxRadix(39);
 
   /**
    * Defines a minimum field ID value for subclasses to use when implementing {@link #toBundle()}
@@ -1669,8 +1672,29 @@ public class TrackSelectionParameters {
     return bundle;
   }
 
+  /**
+   * Returns a {@link Bundle} containing the entirety of this {@link #TrackSelectionParameters}
+   * object without bundling it, for use in local process communication only.
+   */
+  @UnstableApi
+  public Bundle toBundleForLocalProcess() {
+    Bundle bundle = new Bundle();
+    bundle.putBinder(FIELD_IN_PROCESS_BINDER, new InProcessBinder());
+    return bundle;
+  }
+
   /** Construct an instance from a {@link Bundle} produced by {@link #toBundle()}. */
   public static TrackSelectionParameters fromBundle(Bundle bundle) {
+    IBinder inProcessBinder = bundle.getBinder(FIELD_IN_PROCESS_BINDER);
+    if (inProcessBinder instanceof InProcessBinder) {
+      return ((InProcessBinder) inProcessBinder).getTrackSelectionParameters();
+    }
     return new Builder(bundle).build();
+  }
+
+  private final class InProcessBinder extends Binder {
+    public TrackSelectionParameters getTrackSelectionParameters() {
+      return TrackSelectionParameters.this;
+    }
   }
 }

--- a/libraries/common/src/test/java/androidx/media3/common/MediaItemTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/MediaItemTest.java
@@ -1025,6 +1025,17 @@ public class MediaItemTest {
   }
 
   @Test
+  public void roundTripViaBundleForLocalProcess_yieldsSameInstance() {
+    MediaItem mediaItem = new MediaItem.Builder().setUri(URI_STRING).build();
+    MediaItem unbundledItem =
+        MediaItem.fromBundle(
+            mediaItem.toBundleIncludeLocalConfigurationForLocalProcess(),
+            MediaLibraryInfo.INTERFACE_VERSION);
+
+    assertThat(mediaItem == unbundledItem).isTrue();
+  }
+
+  @Test
   public void roundTripViaBundle_withoutLocalConfiguration_yieldsEqualInstance() {
     MediaItem mediaItem =
         new MediaItem.Builder()

--- a/libraries/common/src/test/java/androidx/media3/common/MediaMetadataTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/MediaMetadataTest.java
@@ -233,6 +233,15 @@ public class MediaMetadataTest {
     assertThat(restoredMetadata.artworkData).isNull();
   }
 
+  public void roundTripViaBundleForLocalProcess_yieldsSameInstance() {
+    MediaMetadata mediaMetadata = new MediaMetadata.Builder().setGenre("hi").build();
+    MediaMetadata unbundledMetadata =
+        MediaMetadata.fromBundle(
+            mediaMetadata.toBundleForLocalProcess(), MediaLibraryInfo.INTERFACE_VERSION);
+
+    assertThat(mediaMetadata == unbundledMetadata).isTrue();
+  }
+
   @SuppressWarnings("deprecation") // Testing deprecated setter.
   @Test
   public void builderSetFolderType_toNone_setsIsBrowsableToFalse() {

--- a/libraries/common/src/test/java/androidx/media3/common/MediaMetadataTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/MediaMetadataTest.java
@@ -234,6 +234,15 @@ public class MediaMetadataTest {
     assertThat(restoredMetadata.artworkData).isNull();
   }
 
+  public void roundTripViaBundleForLocalProcess_yieldsSameInstance() {
+    MediaMetadata mediaMetadata = new MediaMetadata.Builder().setGenre("hi").build();
+    MediaMetadata unbundledMetadata =
+        MediaMetadata.fromBundle(
+            mediaMetadata.toBundleForLocalProcess(), MediaLibraryInfo.INTERFACE_VERSION);
+
+    assertThat(mediaMetadata == unbundledMetadata).isTrue();
+  }
+
   @SuppressWarnings("deprecation") // Testing deprecated setter.
   @Test
   public void builderSetFolderType_toNone_setsIsBrowsableToFalse() {

--- a/libraries/common/src/test/java/androidx/media3/common/TrackSelectionParametersTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/TrackSelectionParametersTest.java
@@ -240,6 +240,16 @@ public final class TrackSelectionParametersTest {
   }
 
   @Test
+  public void roundTripViaBundleForLocalProcess_yieldsSameInstance() {
+    TrackSelectionParameters parameters =
+        new TrackSelectionParameters.Builder().setMaxVideoSizeSd().build();
+    TrackSelectionParameters unbundledParameters =
+        TrackSelectionParameters.fromBundle(parameters.toBundleForLocalProcess());
+
+    assertThat(parameters == unbundledParameters).isTrue();
+  }
+
+  @Test
   public void roundTripViaBundle_withLegacyPreferenceFields_yieldsEqualInstance() {
     TrackSelectionParameters trackSelectionParameters =
         new TrackSelectionParameters.Builder()

--- a/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplBase.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplBase.java
@@ -841,7 +841,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.setMediaItem(
                 controllerStub,
                 seq,
-                mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
+                iSession instanceof MediaSessionStub
+                    ? mediaItem.toBundleIncludeLocalConfigurationForLocalProcess()
+                    : mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
 
     setMediaItemsInternal(
         Collections.singletonList(mediaItem),
@@ -861,7 +863,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.setMediaItemWithStartPosition(
                 controllerStub,
                 seq,
-                mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()),
+                iSession instanceof MediaSessionStub
+                    ? mediaItem.toBundleIncludeLocalConfigurationForLocalProcess()
+                    : mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()),
                 startPositionMs));
 
     setMediaItemsInternal(
@@ -882,7 +886,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.setMediaItemWithResetPosition(
                 controllerStub,
                 seq,
-                mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()),
+                iSession instanceof MediaSessionStub
+                    ? mediaItem.toBundleIncludeLocalConfigurationForLocalProcess()
+                    : mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()),
                 resetPosition));
 
     setMediaItemsInternal(
@@ -903,12 +909,14 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.setMediaItems(
                 controllerStub,
                 seq,
-                new BundleListRetriever(
-                    BundleCollectionUtil.toBundleList(
-                        mediaItems,
-                        item ->
-                            item.toBundleIncludeLocalConfiguration(
-                                getSessionInterfaceVersion())))));
+                iSession instanceof MediaSessionStub
+                    ? new MediaItem.ListInProcessBinder(mediaItems)
+                    : new BundleListRetriever(
+                        BundleCollectionUtil.toBundleList(
+                            mediaItems,
+                            item ->
+                                item.toBundleIncludeLocalConfiguration(
+                                    getSessionInterfaceVersion())))));
 
     setMediaItemsInternal(
         mediaItems,
@@ -928,11 +936,14 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.setMediaItemsWithResetPosition(
                 controllerStub,
                 seq,
-                new BundleListRetriever(
-                    BundleCollectionUtil.toBundleList(
-                        mediaItems,
-                        item ->
-                            item.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()))),
+                iSession instanceof MediaSessionStub
+                    ? new MediaItem.ListInProcessBinder(mediaItems)
+                    : new BundleListRetriever(
+                        BundleCollectionUtil.toBundleList(
+                            mediaItems,
+                            item ->
+                                item.toBundleIncludeLocalConfiguration(
+                                    getSessionInterfaceVersion()))),
                 resetPosition));
 
     setMediaItemsInternal(
@@ -953,11 +964,14 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.setMediaItemsWithStartIndex(
                 controllerStub,
                 seq,
-                new BundleListRetriever(
-                    BundleCollectionUtil.toBundleList(
-                        mediaItems,
-                        item ->
-                            item.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()))),
+                iSession instanceof MediaSessionStub
+                    ? new MediaItem.ListInProcessBinder(mediaItems)
+                    : new BundleListRetriever(
+                        BundleCollectionUtil.toBundleList(
+                            mediaItems,
+                            item ->
+                                item.toBundleIncludeLocalConfiguration(
+                                    getSessionInterfaceVersion()))),
                 startIndex,
                 startPositionMs));
 
@@ -974,7 +988,11 @@ import org.checkerframework.checker.nullness.qual.NonNull;
     dispatchRemoteSessionTaskWithPlayerCommand(
         (iSession, seq) ->
             iSession.setPlaylistMetadata(
-                controllerStub, seq, playlistMetadata.toBundle(getSessionInterfaceVersion())));
+                controllerStub,
+                seq,
+                iSession instanceof MediaSessionStub
+                    ? playlistMetadata.toBundleForLocalProcess()
+                    : playlistMetadata.toBundle(getSessionInterfaceVersion())));
 
     if (!playerInfo.playlistMetadata.equals(playlistMetadata)) {
       playerInfo = playerInfo.copyWithPlaylistMetadata(playlistMetadata);
@@ -1001,7 +1019,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.addMediaItem(
                 controllerStub,
                 seq,
-                mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
+                iSession instanceof MediaSessionStub
+                    ? mediaItem.toBundleIncludeLocalConfigurationForLocalProcess()
+                    : mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
 
     addMediaItemsInternal(
         getCurrentTimeline().getWindowCount(), Collections.singletonList(mediaItem));
@@ -1020,7 +1040,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
                 controllerStub,
                 seq,
                 index,
-                mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
+                iSession instanceof MediaSessionStub
+                    ? mediaItem.toBundleIncludeLocalConfigurationForLocalProcess()
+                    : mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
 
     addMediaItemsInternal(index, Collections.singletonList(mediaItem));
   }
@@ -1036,12 +1058,14 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.addMediaItems(
                 controllerStub,
                 seq,
-                new BundleListRetriever(
-                    BundleCollectionUtil.toBundleList(
-                        mediaItems,
-                        item ->
-                            item.toBundleIncludeLocalConfiguration(
-                                getSessionInterfaceVersion())))));
+                iSession instanceof MediaSessionStub
+                    ? new MediaItem.ListInProcessBinder(mediaItems)
+                    : new BundleListRetriever(
+                        BundleCollectionUtil.toBundleList(
+                            mediaItems,
+                            item ->
+                                item.toBundleIncludeLocalConfiguration(
+                                    getSessionInterfaceVersion())))));
 
     addMediaItemsInternal(getCurrentTimeline().getWindowCount(), mediaItems);
   }
@@ -1059,12 +1083,14 @@ import org.checkerframework.checker.nullness.qual.NonNull;
                 controllerStub,
                 seq,
                 index,
-                new BundleListRetriever(
-                    BundleCollectionUtil.toBundleList(
-                        mediaItems,
-                        item ->
-                            item.toBundleIncludeLocalConfiguration(
-                                getSessionInterfaceVersion())))));
+                iSession instanceof MediaSessionStub
+                    ? new MediaItem.ListInProcessBinder(mediaItems)
+                    : new BundleListRetriever(
+                        BundleCollectionUtil.toBundleList(
+                            mediaItems,
+                            item ->
+                                item.toBundleIncludeLocalConfiguration(
+                                    getSessionInterfaceVersion())))));
 
     addMediaItemsInternal(index, mediaItems);
   }
@@ -1417,7 +1443,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
                 controllerStub,
                 seq,
                 index,
-                mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()));
+                iSession instanceof MediaSessionStub
+                    ? mediaItem.toBundleIncludeLocalConfigurationForLocalProcess()
+                    : mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()));
           } else {
             iSession.addMediaItemWithIndex(
                 controllerStub,
@@ -1441,11 +1469,14 @@ import org.checkerframework.checker.nullness.qual.NonNull;
     dispatchRemoteSessionTaskWithPlayerCommand(
         (iSession, seq) -> {
           IBinder mediaItemsBundleBinder =
-              new BundleListRetriever(
-                  BundleCollectionUtil.toBundleList(
-                      mediaItems,
-                      item ->
-                          item.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
+              iSession instanceof MediaSessionStub
+                  ? new MediaItem.ListInProcessBinder(mediaItems)
+                  : new BundleListRetriever(
+                      BundleCollectionUtil.toBundleList(
+                          mediaItems,
+                          item ->
+                              item.toBundleIncludeLocalConfiguration(
+                                  getSessionInterfaceVersion())));
           if (getSessionInterfaceVersion() >= 2) {
             iSession.replaceMediaItems(
                 controllerStub, seq, fromIndex, toIndex, mediaItemsBundleBinder);
@@ -2155,7 +2186,12 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
     dispatchRemoteSessionTaskWithPlayerCommand(
         (iSession, seq) ->
-            iSession.setTrackSelectionParameters(controllerStub, seq, parameters.toBundle()));
+            iSession.setTrackSelectionParameters(
+                controllerStub,
+                seq,
+                iSession instanceof MediaSessionStub
+                    ? parameters.toBundleForLocalProcess()
+                    : parameters.toBundle()));
 
     if (parameters != playerInfo.trackSelectionParameters) {
       playerInfo = playerInfo.copyWithTrackSelectionParameters(parameters);

--- a/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplBase.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplBase.java
@@ -843,7 +843,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.setMediaItem(
                 controllerStub,
                 seq,
-                mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
+                iSession instanceof MediaSessionStub
+                    ? mediaItem.toBundleIncludeLocalConfigurationForLocalProcess()
+                    : mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
 
     setMediaItemsInternal(
         Collections.singletonList(mediaItem),
@@ -863,7 +865,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.setMediaItemWithStartPosition(
                 controllerStub,
                 seq,
-                mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()),
+                iSession instanceof MediaSessionStub
+                    ? mediaItem.toBundleIncludeLocalConfigurationForLocalProcess()
+                    : mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()),
                 startPositionMs));
 
     setMediaItemsInternal(
@@ -884,7 +888,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.setMediaItemWithResetPosition(
                 controllerStub,
                 seq,
-                mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()),
+                iSession instanceof MediaSessionStub
+                    ? mediaItem.toBundleIncludeLocalConfigurationForLocalProcess()
+                    : mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()),
                 resetPosition));
 
     setMediaItemsInternal(
@@ -905,12 +911,14 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.setMediaItems(
                 controllerStub,
                 seq,
-                new BundleListRetriever(
-                    BundleCollectionUtil.toBundleList(
-                        mediaItems,
-                        item ->
-                            item.toBundleIncludeLocalConfiguration(
-                                getSessionInterfaceVersion())))));
+                iSession instanceof MediaSessionStub
+                    ? new MediaItem.ListInProcessBinder(mediaItems)
+                    : new BundleListRetriever(
+                        BundleCollectionUtil.toBundleList(
+                            mediaItems,
+                            item ->
+                                item.toBundleIncludeLocalConfiguration(
+                                    getSessionInterfaceVersion())))));
 
     setMediaItemsInternal(
         mediaItems,
@@ -930,11 +938,14 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.setMediaItemsWithResetPosition(
                 controllerStub,
                 seq,
-                new BundleListRetriever(
-                    BundleCollectionUtil.toBundleList(
-                        mediaItems,
-                        item ->
-                            item.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()))),
+                iSession instanceof MediaSessionStub
+                    ? new MediaItem.ListInProcessBinder(mediaItems)
+                    : new BundleListRetriever(
+                        BundleCollectionUtil.toBundleList(
+                            mediaItems,
+                            item ->
+                                item.toBundleIncludeLocalConfiguration(
+                                    getSessionInterfaceVersion()))),
                 resetPosition));
 
     setMediaItemsInternal(
@@ -955,11 +966,14 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.setMediaItemsWithStartIndex(
                 controllerStub,
                 seq,
-                new BundleListRetriever(
-                    BundleCollectionUtil.toBundleList(
-                        mediaItems,
-                        item ->
-                            item.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()))),
+                iSession instanceof MediaSessionStub
+                    ? new MediaItem.ListInProcessBinder(mediaItems)
+                    : new BundleListRetriever(
+                        BundleCollectionUtil.toBundleList(
+                            mediaItems,
+                            item ->
+                                item.toBundleIncludeLocalConfiguration(
+                                    getSessionInterfaceVersion()))),
                 startIndex,
                 startPositionMs));
 
@@ -976,7 +990,11 @@ import org.checkerframework.checker.nullness.qual.NonNull;
     dispatchRemoteSessionTaskWithPlayerCommand(
         (iSession, seq) ->
             iSession.setPlaylistMetadata(
-                controllerStub, seq, playlistMetadata.toBundle(getSessionInterfaceVersion())));
+                controllerStub,
+                seq,
+                iSession instanceof MediaSessionStub
+                    ? playlistMetadata.toBundleForLocalProcess()
+                    : playlistMetadata.toBundle(getSessionInterfaceVersion())));
 
     if (!playerInfo.playlistMetadata.equals(playlistMetadata)) {
       playerInfo = playerInfo.copyWithPlaylistMetadata(playlistMetadata);
@@ -1003,7 +1021,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.addMediaItem(
                 controllerStub,
                 seq,
-                mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
+                iSession instanceof MediaSessionStub
+                    ? mediaItem.toBundleIncludeLocalConfigurationForLocalProcess()
+                    : mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
 
     addMediaItemsInternal(
         getCurrentTimeline().getWindowCount(), Collections.singletonList(mediaItem));
@@ -1022,7 +1042,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
                 controllerStub,
                 seq,
                 index,
-                mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
+                iSession instanceof MediaSessionStub
+                    ? mediaItem.toBundleIncludeLocalConfigurationForLocalProcess()
+                    : mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
 
     addMediaItemsInternal(index, Collections.singletonList(mediaItem));
   }
@@ -1038,12 +1060,14 @@ import org.checkerframework.checker.nullness.qual.NonNull;
             iSession.addMediaItems(
                 controllerStub,
                 seq,
-                new BundleListRetriever(
-                    BundleCollectionUtil.toBundleList(
-                        mediaItems,
-                        item ->
-                            item.toBundleIncludeLocalConfiguration(
-                                getSessionInterfaceVersion())))));
+                iSession instanceof MediaSessionStub
+                    ? new MediaItem.ListInProcessBinder(mediaItems)
+                    : new BundleListRetriever(
+                        BundleCollectionUtil.toBundleList(
+                            mediaItems,
+                            item ->
+                                item.toBundleIncludeLocalConfiguration(
+                                    getSessionInterfaceVersion())))));
 
     addMediaItemsInternal(getCurrentTimeline().getWindowCount(), mediaItems);
   }
@@ -1061,12 +1085,14 @@ import org.checkerframework.checker.nullness.qual.NonNull;
                 controllerStub,
                 seq,
                 index,
-                new BundleListRetriever(
-                    BundleCollectionUtil.toBundleList(
-                        mediaItems,
-                        item ->
-                            item.toBundleIncludeLocalConfiguration(
-                                getSessionInterfaceVersion())))));
+                iSession instanceof MediaSessionStub
+                    ? new MediaItem.ListInProcessBinder(mediaItems)
+                    : new BundleListRetriever(
+                        BundleCollectionUtil.toBundleList(
+                            mediaItems,
+                            item ->
+                                item.toBundleIncludeLocalConfiguration(
+                                    getSessionInterfaceVersion())))));
 
     addMediaItemsInternal(index, mediaItems);
   }
@@ -1419,7 +1445,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
                 controllerStub,
                 seq,
                 index,
-                mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()));
+                iSession instanceof MediaSessionStub
+                    ? mediaItem.toBundleIncludeLocalConfigurationForLocalProcess()
+                    : mediaItem.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion()));
           } else {
             iSession.addMediaItemWithIndex(
                 controllerStub,
@@ -1443,11 +1471,14 @@ import org.checkerframework.checker.nullness.qual.NonNull;
     dispatchRemoteSessionTaskWithPlayerCommand(
         (iSession, seq) -> {
           IBinder mediaItemsBundleBinder =
-              new BundleListRetriever(
-                  BundleCollectionUtil.toBundleList(
-                      mediaItems,
-                      item ->
-                          item.toBundleIncludeLocalConfiguration(getSessionInterfaceVersion())));
+              iSession instanceof MediaSessionStub
+                  ? new MediaItem.ListInProcessBinder(mediaItems)
+                  : new BundleListRetriever(
+                      BundleCollectionUtil.toBundleList(
+                          mediaItems,
+                          item ->
+                              item.toBundleIncludeLocalConfiguration(
+                                  getSessionInterfaceVersion())));
           if (getSessionInterfaceVersion() >= 2) {
             iSession.replaceMediaItems(
                 controllerStub, seq, fromIndex, toIndex, mediaItemsBundleBinder);
@@ -2157,7 +2188,12 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
     dispatchRemoteSessionTaskWithPlayerCommand(
         (iSession, seq) ->
-            iSession.setTrackSelectionParameters(controllerStub, seq, parameters.toBundle()));
+            iSession.setTrackSelectionParameters(
+                controllerStub,
+                seq,
+                iSession instanceof MediaSessionStub
+                    ? parameters.toBundleForLocalProcess()
+                    : parameters.toBundle()));
 
     if (parameters != playerInfo.trackSelectionParameters) {
       playerInfo = playerInfo.copyWithTrackSelectionParameters(parameters);

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
@@ -1226,14 +1226,18 @@ import java.util.concurrent.ExecutionException;
       return;
     }
     List<MediaItem> mediaItemList;
-    try {
-      mediaItemList =
-          BundleCollectionUtil.fromBundleList(
-              bundle -> MediaItem.fromBundle(bundle, controllerInfo.getInterfaceVersion()),
-              BundleListRetriever.getList(mediaItemsRetriever));
-    } catch (RuntimeException e) {
-      Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
-      return;
+    if (mediaItemsRetriever instanceof MediaItem.ListInProcessBinder) {
+      mediaItemList = ((MediaItem.ListInProcessBinder) mediaItemsRetriever).getMediaItemList();
+    } else {
+      try {
+        mediaItemList =
+            BundleCollectionUtil.fromBundleList(
+                bundle -> MediaItem.fromBundle(bundle, controllerInfo.getInterfaceVersion()),
+                BundleListRetriever.getList(mediaItemsRetriever));
+      } catch (RuntimeException e) {
+        Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
+        return;
+      }
     }
     queueSessionTaskWithPlayerCommandForControllerInfo(
         controllerInfo,
@@ -1271,14 +1275,18 @@ import java.util.concurrent.ExecutionException;
       return;
     }
     List<MediaItem> mediaItemList;
-    try {
-      mediaItemList =
-          BundleCollectionUtil.fromBundleList(
-              bundle -> MediaItem.fromBundle(bundle, controllerInfo.getInterfaceVersion()),
-              BundleListRetriever.getList(mediaItemsRetriever));
-    } catch (RuntimeException e) {
-      Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
-      return;
+    if (mediaItemsRetriever instanceof MediaItem.ListInProcessBinder) {
+      mediaItemList = ((MediaItem.ListInProcessBinder) mediaItemsRetriever).getMediaItemList();
+    } else {
+      try {
+        mediaItemList =
+            BundleCollectionUtil.fromBundleList(
+                bundle -> MediaItem.fromBundle(bundle, controllerInfo.getInterfaceVersion()),
+                BundleListRetriever.getList(mediaItemsRetriever));
+      } catch (RuntimeException e) {
+        Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
+        return;
+      }
     }
     queueSessionTaskWithPlayerCommandForControllerInfo(
         controllerInfo,
@@ -1402,14 +1410,18 @@ import java.util.concurrent.ExecutionException;
       return;
     }
     List<MediaItem> mediaItems;
-    try {
-      mediaItems =
-          BundleCollectionUtil.fromBundleList(
-              bundle -> MediaItem.fromBundle(bundle, controllerInfo.getInterfaceVersion()),
-              BundleListRetriever.getList(mediaItemsRetriever));
-    } catch (RuntimeException e) {
-      Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
-      return;
+    if (mediaItemsRetriever instanceof MediaItem.ListInProcessBinder) {
+      mediaItems = ((MediaItem.ListInProcessBinder) mediaItemsRetriever).getMediaItemList();
+    } else {
+      try {
+        mediaItems =
+            BundleCollectionUtil.fromBundleList(
+                bundle -> MediaItem.fromBundle(bundle, controllerInfo.getInterfaceVersion()),
+                BundleListRetriever.getList(mediaItemsRetriever));
+      } catch (RuntimeException e) {
+        Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
+        return;
+      }
     }
     queueSessionTaskWithPlayerCommandForControllerInfo(
         controllerInfo,
@@ -1436,14 +1448,18 @@ import java.util.concurrent.ExecutionException;
       return;
     }
     List<MediaItem> mediaItems;
-    try {
-      mediaItems =
-          BundleCollectionUtil.fromBundleList(
-              bundle -> MediaItem.fromBundle(bundle, controllerInfo.getInterfaceVersion()),
-              BundleListRetriever.getList(mediaItemsRetriever));
-    } catch (RuntimeException e) {
-      Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
-      return;
+    if (mediaItemsRetriever instanceof MediaItem.ListInProcessBinder) {
+      mediaItems = ((MediaItem.ListInProcessBinder) mediaItemsRetriever).getMediaItemList();
+    } else {
+      try {
+        mediaItems =
+            BundleCollectionUtil.fromBundleList(
+                bundle -> MediaItem.fromBundle(bundle, controllerInfo.getInterfaceVersion()),
+                BundleListRetriever.getList(mediaItemsRetriever));
+      } catch (RuntimeException e) {
+        Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
+        return;
+      }
     }
     queueSessionTaskWithPlayerCommandForControllerInfo(
         controllerInfo,
@@ -1587,14 +1603,18 @@ import java.util.concurrent.ExecutionException;
       return;
     }
     ImmutableList<MediaItem> mediaItems;
-    try {
-      mediaItems =
-          BundleCollectionUtil.fromBundleList(
-              bundle -> MediaItem.fromBundle(bundle, controllerInfo.getInterfaceVersion()),
-              BundleListRetriever.getList(mediaItemsRetriever));
-    } catch (RuntimeException e) {
-      Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
-      return;
+    if (mediaItemsRetriever instanceof MediaItem.ListInProcessBinder) {
+      mediaItems = ((MediaItem.ListInProcessBinder) mediaItemsRetriever).getMediaItemList();
+    } else {
+      try {
+        mediaItems =
+            BundleCollectionUtil.fromBundleList(
+                bundle -> MediaItem.fromBundle(bundle, controllerInfo.getInterfaceVersion()),
+                BundleListRetriever.getList(mediaItemsRetriever));
+      } catch (RuntimeException e) {
+        Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
+        return;
+      }
     }
     queueSessionTaskWithPlayerCommandForControllerInfo(
         controllerInfo,

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
@@ -1301,15 +1301,19 @@ import java.util.concurrent.ExecutionException;
             handleMediaItemsWithStartPositionWhenReady(
                 (sessionImpl, controller, sequenceNum) -> {
                   ImmutableList<MediaItem> mediaItemList;
-                  try {
-                    mediaItemList =
-                        BundleCollectionUtil.fromBundleList(
-                            bundle ->
-                                MediaItem.fromBundle(bundle, controller.getInterfaceVersion()),
-                            BundleListRetriever.getList(mediaItemsRetriever));
-                  } catch (RuntimeException e) {
-                    Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
-                    return Futures.immediateFailedFuture(e);
+                  if (mediaItemsRetriever instanceof MediaItem.ListInProcessBinder) {
+                    mediaItemList = ((MediaItem.ListInProcessBinder) mediaItemsRetriever).getMediaItemList();
+                  } else {
+                    try {
+                      mediaItemList =
+                          BundleCollectionUtil.fromBundleList(
+                              bundle ->
+                                  MediaItem.fromBundle(bundle, controller.getInterfaceVersion()),
+                              BundleListRetriever.getList(mediaItemsRetriever));
+                    } catch (RuntimeException e) {
+                      Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
+                      return Futures.immediateFailedFuture(e);
+                    }
                   }
                   return sessionImpl.onSetMediaItemsOnHandler(
                       controller,
@@ -1344,15 +1348,19 @@ import java.util.concurrent.ExecutionException;
             handleMediaItemsWithStartPositionWhenReady(
                 (sessionImpl, controller, sequenceNum) -> {
                   ImmutableList<MediaItem> mediaItemList;
-                  try {
-                    mediaItemList =
-                        BundleCollectionUtil.fromBundleList(
-                            bundle ->
-                                MediaItem.fromBundle(bundle, controller.getInterfaceVersion()),
-                            BundleListRetriever.getList(mediaItemsRetriever));
-                  } catch (RuntimeException e) {
-                    Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
-                    return Futures.immediateFailedFuture(e);
+                  if (mediaItemsRetriever instanceof MediaItem.ListInProcessBinder) {
+                    mediaItemList = ((MediaItem.ListInProcessBinder) mediaItemsRetriever).getMediaItemList();
+                  } else {
+                    try {
+                      mediaItemList =
+                          BundleCollectionUtil.fromBundleList(
+                              bundle ->
+                                  MediaItem.fromBundle(bundle, controller.getInterfaceVersion()),
+                              BundleListRetriever.getList(mediaItemsRetriever));
+                    } catch (RuntimeException e) {
+                      Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
+                      return Futures.immediateFailedFuture(e);
+                    }
                   }
                   return sessionImpl.onSetMediaItemsOnHandler(
                       controller,
@@ -1471,15 +1479,19 @@ import java.util.concurrent.ExecutionException;
             handleMediaItemsWhenReady(
                 (sessionImpl, controller, sequenceNum) -> {
                   ImmutableList<MediaItem> mediaItems;
-                  try {
-                    mediaItems =
-                        BundleCollectionUtil.fromBundleList(
-                            bundle ->
-                                MediaItem.fromBundle(bundle, controller.getInterfaceVersion()),
-                            BundleListRetriever.getList(mediaItemsRetriever));
-                  } catch (RuntimeException e) {
-                    Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
-                    return Futures.immediateFailedFuture(e);
+                  if (mediaItemsRetriever instanceof MediaItem.ListInProcessBinder) {
+                    mediaItems = ((MediaItem.ListInProcessBinder) mediaItemsRetriever).getMediaItemList();
+                  } else {
+                    try {
+                      mediaItems =
+                          BundleCollectionUtil.fromBundleList(
+                              bundle ->
+                                  MediaItem.fromBundle(bundle, controller.getInterfaceVersion()),
+                              BundleListRetriever.getList(mediaItemsRetriever));
+                    } catch (RuntimeException e) {
+                      Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
+                      return Futures.immediateFailedFuture(e);
+                    }
                   }
                   return sessionImpl.onAddMediaItemsOnHandler(controller, mediaItems);
                 },
@@ -1503,15 +1515,19 @@ import java.util.concurrent.ExecutionException;
             handleMediaItemsWhenReady(
                 (sessionImpl, controller, sequenceNum) -> {
                   ImmutableList<MediaItem> mediaItems;
-                  try {
-                    mediaItems =
-                        BundleCollectionUtil.fromBundleList(
-                            bundle ->
-                                MediaItem.fromBundle(bundle, controller.getInterfaceVersion()),
-                            BundleListRetriever.getList(mediaItemsRetriever));
-                  } catch (RuntimeException e) {
-                    Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
-                    return Futures.immediateFailedFuture(e);
+                  if (mediaItemsRetriever instanceof MediaItem.ListInProcessBinder) {
+                    mediaItems = ((MediaItem.ListInProcessBinder) mediaItemsRetriever).getMediaItemList();
+                  } else {
+                    try {
+                      mediaItems =
+                          BundleCollectionUtil.fromBundleList(
+                              bundle ->
+                                  MediaItem.fromBundle(bundle, controller.getInterfaceVersion()),
+                              BundleListRetriever.getList(mediaItemsRetriever));
+                    } catch (RuntimeException e) {
+                      Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
+                      return Futures.immediateFailedFuture(e);
+                    }
                   }
                   return sessionImpl.onAddMediaItemsOnHandler(controller, mediaItems);
                 },
@@ -1651,15 +1667,19 @@ import java.util.concurrent.ExecutionException;
             handleMediaItemsWhenReady(
                 (sessionImpl, controller, sequenceNum) -> {
                   ImmutableList<MediaItem> mediaItems;
-                  try {
-                    mediaItems =
-                        BundleCollectionUtil.fromBundleList(
-                            bundle ->
-                                MediaItem.fromBundle(bundle, controller.getInterfaceVersion()),
-                            BundleListRetriever.getList(mediaItemsRetriever));
-                  } catch (RuntimeException e) {
-                    Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
-                    return Futures.immediateFailedFuture(e);
+                  if (mediaItemsRetriever instanceof MediaItem.ListInProcessBinder) {
+                    mediaItems = ((MediaItem.ListInProcessBinder) mediaItemsRetriever).getMediaItemList();
+                  } else {
+                    try {
+                      mediaItems =
+                          BundleCollectionUtil.fromBundleList(
+                              bundle ->
+                                  MediaItem.fromBundle(bundle, controller.getInterfaceVersion()),
+                              BundleListRetriever.getList(mediaItemsRetriever));
+                    } catch (RuntimeException e) {
+                      Log.w(TAG, "Ignoring malformed Bundle for MediaItem", e);
+                      return Futures.immediateFailedFuture(e);
+                    }
                   }
                   return sessionImpl.onAddMediaItemsOnHandler(controller, mediaItems);
                 },


### PR DESCRIPTION
The session->controller data flow already nicely avoids bundling if we don't have to bundle by skipping the entire PlayerInfo object which contains almost everything. But in the controller->session data flow, some complex objects (MediaMetadata, MediaItem and TrackSelectionParameters) were always bundled even if we don't have to. This change skips bundling for these object and should improve performance significantly when sending large lists of MediaItems to a session in the same process.