### PR TITLE
Asynchronously connect to media3 controllers

### DIFF
--- a/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplBase.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplBase.java
@@ -76,8 +76,10 @@ import androidx.media3.common.TrackSelectionParameters;
 import androidx.media3.common.Tracks;
 import androidx.media3.common.VideoSize;
 import androidx.media3.common.text.CueGroup;
+import androidx.media3.common.util.BackgroundExecutor;
 import androidx.media3.common.util.BundleCollectionUtil;
 import androidx.media3.common.util.Clock;
+import androidx.media3.common.util.Consumer;
 import androidx.media3.common.util.ListenerSet;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.Size;
@@ -209,17 +211,19 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
   @Override
   public void connect(@UnderInitialization MediaControllerImplBase this) {
-    boolean connectionRequested;
+    Consumer<Boolean> onConnectionRequested =
+        connectionRequested -> {
+          if (!connectionRequested) {
+            getInstance().runOnApplicationLooper(getInstance()::release);
+          }
+        };
     if (this.token.getType() == SessionToken.TYPE_SESSION) {
       // Session
       serviceConnection = null;
-      connectionRequested = requestConnectToSession(connectionHints);
+      requestConnectToSession(connectionHints, onConnectionRequested);
     } else {
       serviceConnection = new SessionServiceConnection(connectionHints);
-      connectionRequested = requestConnectToService();
-    }
-    if (!connectionRequested) {
-      getInstance().runOnApplicationLooper(getInstance()::release);
+      requestConnectToService(onConnectionRequested);
     }
   }
 
@@ -2617,7 +2621,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
     listeners.flushEvents();
   }
 
-  private boolean requestConnectToService() {
+  private void requestConnectToService(Consumer<Boolean> onConnectionRequested) {
     int flags =
         SDK_INT >= 29
             ? Context.BIND_AUTO_CREATE | Context.BIND_INCLUDE_CAPABILITIES
@@ -2641,34 +2645,49 @@ import org.checkerframework.checker.nullness.qual.NonNull;
     //    If a service wants to keep running, it should be either foreground service or
     //    bound service. But there had been request for the feature for system apps
     //    and using bindService() will be better fit with it.
-    try {
-      if (context.bindService(intent, serviceConnection, flags)) {
-        return true;
-      }
-      Log.w(TAG, "bind to " + token + " failed");
-    } catch (SecurityException e) {
-      Log.w(TAG, "bind to " + token + " not allowed", e);
-    }
-    return false;
+    BackgroundExecutor.get()
+        .execute(
+            () -> {
+              try {
+                if (context.bindService(intent, serviceConnection, flags)) {
+                  onConnectionRequested.accept(true);
+                  return;
+                }
+                Log.w(TAG, "bind to " + token + " failed");
+              } catch (SecurityException e) {
+                Log.w(TAG, "bind to " + token + " not allowed", e);
+              }
+              onConnectionRequested.accept(false);
+            });
   }
 
-  private boolean requestConnectToSession(Bundle connectionHints) {
-    IMediaSession iSession =
-        IMediaSession.Stub.asInterface((IBinder) checkNotNull(token.getBinder()));
-    int seq = sequencedFutureManager.obtainNextSequenceNumber();
-    ConnectionRequest request =
-        new ConnectionRequest(
-            context.getPackageName(),
-            Process.myPid(),
-            connectionHints,
-            instance.getMaxCommandsForMediaItems());
-    try {
-      iSession.connect(controllerStub, seq, request.toBundle());
-    } catch (RemoteException e) {
-      Log.w(TAG, "Failed to call connection request.", e);
-      return false;
-    }
-    return true;
+  private void requestConnectToSession(
+      Bundle connectionHints, Consumer<Boolean> onConnectionRequested) {
+    // If the session is not remote, it will answer swiftly. In order to support creating a media
+    // controller in the media session service onCreate, connect in-place if not remote.
+    (token.getBinder() instanceof MediaSessionStub
+            ? MoreExecutors.directExecutor()
+            : BackgroundExecutor.get())
+        .execute(
+            () -> {
+              IMediaSession iSession =
+                  IMediaSession.Stub.asInterface((IBinder) checkNotNull(token.getBinder()));
+              int seq = sequencedFutureManager.obtainNextSequenceNumber();
+              ConnectionRequest request =
+                  new ConnectionRequest(
+                      context.getPackageName(),
+                      Process.myPid(),
+                      connectionHints,
+                      instance.getMaxCommandsForMediaItems());
+              try {
+                iSession.connect(controllerStub, seq, request.toBundle());
+              } catch (RemoteException e) {
+                Log.w(TAG, "Failed to call connection request.", e);
+                onConnectionRequested.accept(false);
+                return;
+              }
+              onConnectionRequested.accept(true);
+            });
   }
 
   private void clearSurfacesAndCallbacks() {


### PR DESCRIPTION
In order to migitate an ANR on a slow device:
```
      at android.os.BinderProxy.transactNative (Native method)
This binder call may be taking too long, causing the main thread to wait and triggering the ANR. [Learn more](https://developer.android.com/topic/performance/anrs/find-unresponsive-thread#slow-binder)
      at android.os.BinderProxy.transact (BinderProxy.java:590)
      at android.app.IActivityManager$Stub$Proxy.bindIsolatedService (IActivityManager.java:6868)
      at android.app.ContextImpl.bindServiceCommon (ContextImpl.java:2140)
      at android.app.ContextImpl.bindService (ContextImpl.java:2037)
      at android.content.ContextWrapper.bindService (ContextWrapper.java:827)
      at androidx.media3.session.MediaControllerImplBase.requestConnectToService (MediaControllerImplBase.java:2559)
      at androidx.media3.session.MediaControllerImplBase.connect (MediaControllerImplBase.java:216)
      at androidx.media3.session.MediaController.<init> (MediaController.java:612)
      at androidx.media3.session.MediaController$Builder.buildAsync (MediaController.java:378)
      at org.akanework.gramophone.ui.MediaControllerViewModel.onStart (MediaControllerViewModel.kt:50)
      at androidx.lifecycle.DefaultLifecycleObserverAdapter.onStateChanged (DefaultLifecycleObserverAdapter.kt:25)
```