### PR TITLE
Make frequently called controller callbacks local binder aware

### DIFF
--- a/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplBase.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplBase.java
@@ -2875,7 +2875,12 @@ import org.checkerframework.checker.nullness.qual.NonNull;
       return;
     }
     try {
-      iSession.onControllerResult(controllerStub, seq, result.toBundle());
+      iSession.onControllerResult(
+          controllerStub,
+          seq,
+          iSession instanceof MediaSessionStub
+              ? result.toBundleForLocalProcess()
+              : result.toBundle());
     } catch (RemoteException e) {
       Log.w(TAG, "Error in sending");
     }

--- a/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplBase.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaControllerImplBase.java
@@ -2885,7 +2885,12 @@ import org.checkerframework.checker.nullness.qual.NonNull;
       return;
     }
     try {
-      iSession.onControllerResult(controllerStub, seq, result.toBundle());
+      iSession.onControllerResult(
+          controllerStub,
+          seq,
+          iSession instanceof MediaSessionStub
+              ? result.toBundleForLocalProcess()
+              : result.toBundle());
     } catch (RemoteException e) {
       Log.w(TAG, "Error in sending");
     }

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
@@ -2297,13 +2297,21 @@ import java.util.concurrent.ExecutionException;
 
     @Override
     public void onSessionResult(int sequenceNumber, SessionResult result) throws RemoteException {
-      iController.onSessionResult(sequenceNumber, result.toBundle());
+      iController.onSessionResult(
+          sequenceNumber,
+          iController instanceof MediaControllerStub
+              ? result.toBundleForLocalProcess()
+              : result.toBundle());
     }
 
     @Override
     public void onLibraryResult(int sequenceNumber, LibraryResult<?> result)
         throws RemoteException {
-      iController.onLibraryResult(sequenceNumber, result.toBundle(controllerInterfaceVersion));
+      iController.onLibraryResult(
+          sequenceNumber,
+          iController instanceof MediaControllerStub
+              ? result.toBundleForLocalProcess()
+              : result.toBundle(controllerInterfaceVersion));
     }
 
     @Override
@@ -2443,11 +2451,14 @@ import java.util.concurrent.ExecutionException;
         boolean canAccessTimeline,
         int controllerInterfaceVersion)
         throws RemoteException {
+      SessionPositionInfo filteredPositionInfo =
+          sessionPositionInfo.filterByAvailableCommands(
+              canAccessCurrentMediaItem, canAccessTimeline);
       iController.onPeriodicSessionPositionInfoChanged(
           sequenceNumber,
-          sessionPositionInfo
-              .filterByAvailableCommands(canAccessCurrentMediaItem, canAccessTimeline)
-              .toBundle(controllerInterfaceVersion));
+          iController instanceof MediaControllerStub
+              ? filteredPositionInfo.toBundleForLocalProcess()
+              : filteredPositionInfo.toBundle(controllerInterfaceVersion));
     }
 
     @Override

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
@@ -2659,13 +2659,21 @@ import java.util.concurrent.ExecutionException;
 
     @Override
     public void onSessionResult(int sequenceNumber, SessionResult result) throws RemoteException {
-      iController.onSessionResult(sequenceNumber, result.toBundle());
+      iController.onSessionResult(
+          sequenceNumber,
+          iController instanceof MediaControllerStub
+              ? result.toBundleForLocalProcess()
+              : result.toBundle());
     }
 
     @Override
     public void onLibraryResult(int sequenceNumber, LibraryResult<?> result)
         throws RemoteException {
-      iController.onLibraryResult(sequenceNumber, result.toBundle(controllerInterfaceVersion));
+      iController.onLibraryResult(
+          sequenceNumber,
+          iController instanceof MediaControllerStub
+              ? result.toBundleForLocalProcess()
+              : result.toBundle(controllerInterfaceVersion));
     }
 
     @Override
@@ -2805,11 +2813,14 @@ import java.util.concurrent.ExecutionException;
         boolean canAccessTimeline,
         int controllerInterfaceVersion)
         throws RemoteException {
+      SessionPositionInfo filteredPositionInfo =
+          sessionPositionInfo.filterByAvailableCommands(
+              canAccessCurrentMediaItem, canAccessTimeline);
       iController.onPeriodicSessionPositionInfoChanged(
           sequenceNumber,
-          sessionPositionInfo
-              .filterByAvailableCommands(canAccessCurrentMediaItem, canAccessTimeline)
-              .toBundle(controllerInterfaceVersion));
+          iController instanceof MediaControllerStub
+              ? filteredPositionInfo.toBundleForLocalProcess()
+              : filteredPositionInfo.toBundle(controllerInterfaceVersion));
     }
 
     @Override

--- a/libraries/session/src/main/java/androidx/media3/session/SessionResult.java
+++ b/libraries/session/src/main/java/androidx/media3/session/SessionResult.java
@@ -19,7 +19,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.annotation.ElementType.TYPE_USE;
 
 import android.annotation.SuppressLint;
+import android.os.Binder;
 import android.os.Bundle;
+import android.os.IBinder;
 import android.os.SystemClock;
 import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
@@ -241,6 +243,7 @@ public final class SessionResult {
   private static final String FIELD_EXTRAS = Util.intToStringMaxRadix(1);
   private static final String FIELD_COMPLETION_TIME_MS = Util.intToStringMaxRadix(2);
   private static final String FIELD_SESSION_ERROR = Util.intToStringMaxRadix(3);
+  private static final String FIELD_IN_PROCESS_BINDER = Util.intToStringMaxRadix(4);
 
   @UnstableApi
   public Bundle toBundle() {
@@ -254,9 +257,24 @@ public final class SessionResult {
     return bundle;
   }
 
+  /**
+   * Returns a {@link Bundle} containing the entirety of this {@link #SessionResult} object without
+   * bundling it, for use in local process communication only.
+   */
+  @UnstableApi
+  public Bundle toBundleForLocalProcess() {
+    Bundle bundle = new Bundle();
+    bundle.putBinder(FIELD_IN_PROCESS_BINDER, new InProcessBinder());
+    return bundle;
+  }
+
   /** Restores a {@code SessionResult} from a {@link Bundle}. */
   @UnstableApi
   public static SessionResult fromBundle(Bundle bundle) {
+    IBinder inProcessBinder = bundle.getBinder(FIELD_IN_PROCESS_BINDER);
+    if (inProcessBinder instanceof InProcessBinder) {
+      return ((InProcessBinder) inProcessBinder).getSessionResult();
+    }
     int resultCode =
         bundle.getInt(FIELD_RESULT_CODE, /* defaultValue= */ SessionError.ERROR_UNKNOWN);
     @Nullable Bundle extras = bundle.getBundle(FIELD_EXTRAS);
@@ -273,5 +291,11 @@ public final class SessionResult {
     }
     return new SessionResult(
         resultCode, extras == null ? Bundle.EMPTY : extras, completionTimeMs, sessionError);
+  }
+
+  private final class InProcessBinder extends Binder {
+    public SessionResult getSessionResult() {
+      return SessionResult.this;
+    }
   }
 }

--- a/libraries/session/src/main/java/androidx/media3/session/SessionResult.java
+++ b/libraries/session/src/main/java/androidx/media3/session/SessionResult.java
@@ -20,7 +20,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.annotation.ElementType.TYPE_USE;
 
 import android.annotation.SuppressLint;
+import android.os.Binder;
 import android.os.Bundle;
+import android.os.IBinder;
 import android.os.SystemClock;
 import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
@@ -243,6 +245,7 @@ public final class SessionResult {
   private static final String FIELD_EXTRAS = Util.intToStringMaxRadix(1);
   private static final String FIELD_COMPLETION_TIME_MS = Util.intToStringMaxRadix(2);
   private static final String FIELD_SESSION_ERROR = Util.intToStringMaxRadix(3);
+  private static final String FIELD_IN_PROCESS_BINDER = Util.intToStringMaxRadix(4);
 
   @UnstableApi
   public Bundle toBundle() {
@@ -256,9 +259,24 @@ public final class SessionResult {
     return bundle;
   }
 
+  /**
+   * Returns a {@link Bundle} containing the entirety of this {@link #SessionResult} object without
+   * bundling it, for use in local process communication only.
+   */
+  @UnstableApi
+  public Bundle toBundleForLocalProcess() {
+    Bundle bundle = new Bundle();
+    bundle.putBinder(FIELD_IN_PROCESS_BINDER, new InProcessBinder());
+    return bundle;
+  }
+
   /** Restores a {@code SessionResult} from a {@link Bundle}. */
   @UnstableApi
   public static SessionResult fromBundle(Bundle bundle) {
+    IBinder inProcessBinder = bundle.getBinder(FIELD_IN_PROCESS_BINDER);
+    if (inProcessBinder instanceof InProcessBinder) {
+      return ((InProcessBinder) inProcessBinder).getSessionResult();
+    }
     int resultCode =
         bundle.getInt(FIELD_RESULT_CODE, /* defaultValue= */ SessionError.ERROR_UNKNOWN);
     @Nullable Bundle extras = convertToNullIfInvalid(bundle.getBundle(FIELD_EXTRAS));
@@ -275,5 +293,11 @@ public final class SessionResult {
     }
     return new SessionResult(
         resultCode, extras == null ? Bundle.EMPTY : extras, completionTimeMs, sessionError);
+  }
+
+  private final class InProcessBinder extends Binder {
+    public SessionResult getSessionResult() {
+      return SessionResult.this;
+    }
   }
 }

--- a/libraries/session/src/test/java/androidx/media3/session/LibraryResultTest.java
+++ b/libraries/session/src/test/java/androidx/media3/session/LibraryResultTest.java
@@ -166,4 +166,14 @@ public class LibraryResultTest {
     assertThat(errorLibraryResultFromBundle.completionTimeMs)
         .isEqualTo(errorLibraryResult.completionTimeMs);
   }
+
+  @Test
+  public void roundTripViaBundleForLocalProcess_yieldsSameInstance() {
+    LibraryResult<SessionError> errorLibraryResult =
+        LibraryResult.ofError(new SessionError(ERROR_NOT_SUPPORTED, "error message", new Bundle()));
+    LibraryResult<?> unbundledLibraryResult =
+        LibraryResult.fromUnknownBundle(errorLibraryResult.toBundleForLocalProcess());
+
+    assertThat(errorLibraryResult == unbundledLibraryResult).isTrue();
+  }
 }

--- a/libraries/session/src/test/java/androidx/media3/session/SessionPositionInfoTest.java
+++ b/libraries/session/src/test/java/androidx/media3/session/SessionPositionInfoTest.java
@@ -63,6 +63,14 @@ public class SessionPositionInfoTest {
   }
 
   @Test
+  public void roundTripViaBundleForLocalProcess_yieldsSameInstance() {
+    SessionPositionInfo roundTripValue =
+        SessionPositionInfo.fromBundle(SessionPositionInfo.DEFAULT.toBundleForLocalProcess());
+
+    assertThat(SessionPositionInfo.DEFAULT == roundTripValue).isTrue();
+  }
+
+  @Test
   public void constructor_invalidIsPlayingAd_throwsIllegalArgumentException() {
     Assert.assertThrows(
         IllegalArgumentException.class,

--- a/libraries/session/src/test/java/androidx/media3/session/SessionResultTest.java
+++ b/libraries/session/src/test/java/androidx/media3/session/SessionResultTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static androidx.media3.session.SessionError.ERROR_NOT_SUPPORTED;
 import static androidx.media3.session.SessionError.ERROR_SESSION_AUTHENTICATION_EXPIRED;
 import static androidx.media3.session.SessionError.ERROR_SESSION_CONCURRENT_STREAM_LIMIT;
 import static com.google.common.truth.Truth.assertThat;
@@ -71,5 +72,15 @@ public class SessionResultTest {
     assertThat(resultFromBundle.sessionError.extras.size()).isEqualTo(1);
     assertThat(resultFromBundle.sessionError.extras.getString("errorKey")).isEqualTo("errorValue");
     assertThat(resultFromBundle.extras.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void roundTripViaBundleForLocalProcess_yieldsSameInstance() {
+    SessionResult errorSessionResult =
+        new SessionResult(new SessionError(ERROR_NOT_SUPPORTED, "error message", new Bundle()));
+    SessionResult unbundledSessionResult =
+        SessionResult.fromBundle(errorSessionResult.toBundleForLocalProcess());
+
+    assertThat(errorSessionResult == unbundledSessionResult).isTrue();
   }
 }

--- a/libraries/session/src/test/java/androidx/media3/session/SessionResultTest.java
+++ b/libraries/session/src/test/java/androidx/media3/session/SessionResultTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.session;
 
+import static androidx.media3.session.SessionError.ERROR_NOT_SUPPORTED;
 import static androidx.media3.session.SessionError.ERROR_SESSION_AUTHENTICATION_EXPIRED;
 import static androidx.media3.session.SessionError.ERROR_SESSION_CONCURRENT_STREAM_LIMIT;
 import static com.google.common.truth.Truth.assertThat;
@@ -80,5 +81,15 @@ public class SessionResultTest {
 
     assertThat(sessionResult.resultCode).isEqualTo(SessionError.INFO_CANCELLED);
     assertThat(sessionResult.sessionError).isEqualTo(sessionError);
+  }
+
+  @Test
+  public void roundTripViaBundleForLocalProcess_yieldsSameInstance() {
+    SessionResult errorSessionResult =
+        new SessionResult(new SessionError(ERROR_NOT_SUPPORTED, "error message", new Bundle()));
+    SessionResult unbundledSessionResult =
+        SessionResult.fromBundle(errorSessionResult.toBundleForLocalProcess());
+
+    assertThat(errorSessionResult == unbundledSessionResult).isTrue();
   }
 }


### PR DESCRIPTION
Especially MediaBrowser will profit from this, as List\<MediaItem> no longer has to be bundled if the caller is in the same process.