### PR TITLE
Move legacy session calls to a new thread

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -906,7 +906,7 @@ public final class Util {
    */
   @UnstableApi
   public static <T> ListenableFuture<T> postOrRunWithCompletion(
-      Handler handler, Runnable runnable, T successValue) {
+      Handler handler, Runnable runnable, @Nullable T successValue) {
     SettableFuture<T> outputFuture = SettableFuture.create();
     postOrRun(
         handler,

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -907,7 +907,7 @@ public final class Util {
    */
   @UnstableApi
   public static <T> ListenableFuture<T> postOrRunWithCompletion(
-      Handler handler, Runnable runnable, T successValue) {
+      Handler handler, Runnable runnable, @Nullable T successValue) {
     SettableFuture<T> outputFuture = SettableFuture.create();
     postOrRun(
         handler,

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -471,20 +471,6 @@ import java.util.concurrent.TimeoutException;
     }
 
     @Override
-    public void onMediaButtonPreferencesChanged(
-        MediaController controller, List<CommandButton> mediaButtonPreferences) {
-      mediaSessionService.onUpdateNotificationInternal(
-          session, /* startInForegroundWhenPaused= */ false);
-    }
-
-    @Override
-    public void onAvailableSessionCommandsChanged(
-        MediaController controller, SessionCommands commands) {
-      mediaSessionService.onUpdateNotificationInternal(
-          session, /* startInForegroundWhenPaused= */ false);
-    }
-
-    @Override
     public ListenableFuture<SessionResult> onCustomCommand(
         MediaController controller, SessionCommand command, Bundle args) {
       @SessionResult.Code int resultCode = SessionError.ERROR_NOT_SUPPORTED;
@@ -503,20 +489,6 @@ import java.util.concurrent.TimeoutException;
       // We may need to hide the notification.
       mediaSessionService.onUpdateNotificationInternal(
           session, /* startInForegroundWhenPaused= */ false);
-    }
-
-    @Override
-    public void onEvents(Player player, Player.Events events) {
-      // We must limit the frequency of notification updates, otherwise the system may suppress
-      // them.
-      if (events.containsAny(
-          Player.EVENT_PLAYBACK_STATE_CHANGED,
-          Player.EVENT_PLAY_WHEN_READY_CHANGED,
-          Player.EVENT_MEDIA_METADATA_CHANGED,
-          Player.EVENT_TIMELINE_CHANGED)) {
-        mediaSessionService.onUpdateNotificationInternal(
-            session, /* startInForegroundWhenPaused= */ false);
-      }
     }
   }
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -760,6 +760,7 @@ import java.util.concurrent.atomic.AtomicInteger;
         Log.e(TAG, "Failed to start foreground", e);
         return false;
       }
+      throw e;
     }
     if (hasOtherForegroundSession) {
       // startForeground() normally does this, but as we passed another notification to it, we have

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -840,7 +840,7 @@ import java.util.concurrent.atomic.AtomicInteger;
   }
 
   @RequiresApi(31)
-  /* package */ static final class Api31 {
+  private static final class Api31 {
     public static boolean instanceOfForegroundServiceStartNotAllowedException(
         IllegalStateException e) {
       return e instanceof ForegroundServiceStartNotAllowedException;

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -79,11 +79,17 @@ import java.util.concurrent.TimeoutException;
   private final Intent startSelfIntent;
   private final String startSelfIntentUid;
   private final Map<MediaSession, ControllerInfo> controllerMap;
+  private final Map<MediaSession, MediaNotification> mediaNotifications;
 
   private MediaNotification.Provider mediaNotificationProvider;
-  private int totalNotificationCount;
-  @Nullable private MediaNotification mediaNotification;
-  private boolean startedInForeground;
+
+  /**
+   * The session that provides the notification the foreground service is started with, or null if
+   * the service is not in foreground at the moment. Each service can only have one foreground
+   * notification, so we have to switch this around as needed if we have multiple sessions.
+   */
+  private @Nullable MediaSession foregroundSession;
+
   private boolean isUserEngaged;
   private boolean isUserEngagedTimeoutEnabled;
   private long userEngagedTimeoutMs;
@@ -106,7 +112,7 @@ import java.util.concurrent.TimeoutException;
     startSelfIntentUid = UUID.randomUUID().toString();
     startSelfIntent.putExtra(SELF_INTENT_UID_KEY, startSelfIntentUid);
     controllerMap = new HashMap<>();
-    startedInForeground = false;
+    mediaNotifications = new HashMap<>();
     isUserEngagedTimeoutEnabled = true;
     userEngagedTimeoutMs = MediaSessionService.DEFAULT_FOREGROUND_SERVICE_TIMEOUT_MS;
     showNotificationForIdlePlayerMode =
@@ -155,6 +161,9 @@ import java.util.concurrent.TimeoutException;
   public void removeSession(MediaSession session) {
     @Nullable ControllerInfo controllerInfo = controllerMap.remove(session);
     if (controllerInfo != null) {
+      // Update the notification count so that if a pending notification callback arrives (e.g., a
+      // bitmap is loaded), we don't show a stale notification.
+      controllerInfo.notificationSequence++;
       MediaController.releaseFuture(controllerInfo.controllerFuture);
     }
   }
@@ -195,18 +204,21 @@ import java.util.concurrent.TimeoutException;
     return CallbackToFutureAdapter.getFuture(
         completer -> {
           if (!mediaSessionService.isSessionAdded(session) || !shouldShowNotification(session)) {
-            removeNotification();
+            removeNotification(session);
             completer.set(null);
             return "notificationRemoved";
           }
-          int notificationSequence = ++totalNotificationCount;
+
+          ControllerInfo controllerInfo = checkNotNull(controllerMap.get(session));
+          int notificationSequence = ++controllerInfo.notificationSequence;
           ImmutableList<CommandButton> mediaButtonPreferences =
               checkNotNull(getConnectedControllerForSession(session)).getMediaButtonPreferences();
           MediaNotification.Provider.Callback callback =
               notification ->
                   mainExecutor.execute(
-                      () -> onNotificationUpdated(notificationSequence, session, notification));
-
+                      () ->
+                          onNotificationUpdated(
+                              controllerInfo, notificationSequence, session, notification));
           Util.postOrRun(
               session.getImpl().getApplicationHandler(),
               () -> {
@@ -242,7 +254,7 @@ import java.util.concurrent.TimeoutException;
   }
 
   public boolean isStartedInForeground() {
-    return startedInForeground;
+    return foregroundSession != null;
   }
 
   public void setUserEngagedTimeoutMs(long userEngagedTimeoutMs) {
@@ -316,8 +328,11 @@ import java.util.concurrent.TimeoutException;
   }
 
   private void onNotificationUpdated(
-      int notificationSequence, MediaSession session, MediaNotification mediaNotification) {
-    if (notificationSequence == totalNotificationCount) {
+      ControllerInfo controllerInfo,
+      int notificationSequence,
+      MediaSession session,
+      MediaNotification mediaNotification) {
+    if (controllerInfo.notificationSequence == notificationSequence) {
       boolean startInForegroundRequired =
           shouldRunInForeground(/* startInForegroundWhenPaused= */ false);
       try {
@@ -339,9 +354,6 @@ import java.util.concurrent.TimeoutException;
     }
   }
 
-  // POST_NOTIFICATIONS permission is not required for media session related notifications.
-  // https://developer.android.com/develop/ui/views/notifications/notification-permission#exemptions-media-sessions
-  @SuppressLint("MissingPermission")
   private void updateNotificationInternal(
       MediaSession session,
       MediaNotification mediaNotification,
@@ -349,28 +361,33 @@ import java.util.concurrent.TimeoutException;
     // Call Notification.MediaStyle#setMediaSession() indirectly.
     Token fwkToken = session.getPlatformToken();
     mediaNotification.notification.extras.putParcelable(Notification.EXTRA_MEDIA_SESSION, fwkToken);
-    this.mediaNotification = mediaNotification;
+    this.mediaNotifications.put(session, mediaNotification);
     if (startInForegroundRequired) {
-      startForeground(mediaNotification);
+      startForeground(session, mediaNotification);
     } else {
       // Notification manager has to be updated first to avoid missing updates
       // (https://github.com/androidx/media/issues/192).
-      notificationManager.notify(mediaNotification.notificationId, mediaNotification.notification);
-      Util.stopForeground(mediaSessionService, /* removeNotification= */ false);
+      notify(mediaNotification);
+      stopForeground(session, /* removeNotifications= */ false);
     }
   }
 
   /** Removes the notification and stops the foreground service if running. */
-  private void removeNotification() {
+  private void removeNotification(MediaSession session) {
     // To hide the notification on all API levels, we need to call both Service.stopForeground(true)
     // and notificationManagerCompat.cancel(notificationId).
-    Util.stopForeground(mediaSessionService, /* removeNotification= */ true);
+    stopForeground(session, /* removeNotifications= */ true);
+    @Nullable MediaNotification mediaNotification = mediaNotifications.remove(session);
     if (mediaNotification != null) {
       notificationManager.cancel(mediaNotification.notificationId);
       // Update the notification count so that if a pending notification callback arrives (e.g., a
       // bitmap is loaded), we don't show the notification.
-      totalNotificationCount++;
-      mediaNotification = null;
+      @Nullable ControllerInfo controllerInfo = controllerMap.get(session);
+      // If the controllerInfo is already removed from the map, removeSession() has increased the
+      // sequence, so it's fine.
+      if (controllerInfo != null) {
+        controllerInfo.notificationSequence++;
+      }
     }
   }
 
@@ -502,7 +519,23 @@ import java.util.concurrent.TimeoutException;
   }
 
   @SuppressLint("InlinedApi") // Using compile time constant FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
-  private void startForeground(MediaNotification mediaNotification) {
+  private void startForeground(MediaSession session, MediaNotification newMediaNotification) {
+    MediaNotification mediaNotification;
+    boolean hasOtherForegroundSession;
+    if (foregroundSession != null && foregroundSession != session) {
+      // If we would use the newly updated notification, the old foreground session's notification
+      // would be canceled by the system because the service switched to another foreground service
+      // notification. However, we don't want to cancel it, so we just keep using the old session's
+      // notification as long as we can, and post our new notification as normal notification.
+      // We still need to call startForeground() in any case to avoid
+      // ForegroundServiceDidNotStartInTimeException.
+      mediaNotification = checkNotNull(mediaNotifications.get(foregroundSession));
+      hasOtherForegroundSession = true;
+    } else {
+      mediaNotification = newMediaNotification;
+      foregroundSession = session;
+      hasOtherForegroundSession = false;
+    }
     ContextCompat.startForegroundService(mediaSessionService, startSelfIntent);
     Util.setForegroundServiceNotification(
         mediaSessionService,
@@ -510,7 +543,52 @@ import java.util.concurrent.TimeoutException;
         mediaNotification.notification,
         ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
         "mediaPlayback");
-    startedInForeground = true;
+    if (hasOtherForegroundSession) {
+      // startForeground() normally does this, but as we passed another notification to it, we have
+      // to do it manually here.
+      notify(newMediaNotification);
+    }
+  }
+
+  private void stopForeground(MediaSession session, boolean removeNotifications) {
+    if (foregroundSession != session) {
+      // This happens if there is another session in foreground since before this session wanted to
+      // go in the foreground. As this other session still wants to be in the foreground, we don't
+      // need to stop the foreground service. cancel() will be called by the caller if
+      // removeNotifications is true, so we don't need to do anything here.
+      return;
+    }
+    foregroundSession = null;
+    if (shouldRunInForeground(false)) {
+      // If we shouldn't show a notification for this session anymore, but there's another session
+      // and it wants to stay in foreground, we have to change the foreground service notification
+      // to the other session.
+      List<MediaSession> sessions = mediaSessionService.getSessions();
+      for (MediaSession candidateSession : sessions) {
+        // Just take the first one willing to show a notification, it doesn't matter which one.
+        if (shouldShowNotification(candidateSession)) {
+          startForeground(candidateSession, checkNotNull(mediaNotifications.get(candidateSession)));
+          // When calling startForeground() with a different notification ID, the old notification
+          // will be canceled by the system. It's an unfortunate limitation of the API we can't do
+          // anything about. Hence, if removeNotifications is false, we have to send the
+          // notification out again using notify() as we didn't want it to be canceled.
+          if (!removeNotifications) {
+            notify(checkNotNull(mediaNotifications.get(session)));
+          }
+          return;
+        }
+      }
+    }
+    // Either we don't have any notification left, or we don't want to stay in foreground. It's
+    // time to stop the foreground service.
+    Util.stopForeground(mediaSessionService, removeNotifications);
+  }
+
+  // POST_NOTIFICATIONS permission is not required for media session related notifications.
+  // https://developer.android.com/develop/ui/views/notifications/notification-permission#exemptions-media-sessions
+  @SuppressLint("MissingPermission")
+  private void notify(MediaNotification notification) {
+    notificationManager.notify(notification.notificationId, notification.notification);
   }
 
   private static final class ControllerInfo {
@@ -522,6 +600,9 @@ import java.util.concurrent.TimeoutException;
 
     /** Indicated whether the player has ever been prepared. */
     public boolean hasBeenPrepared;
+
+    /** The notification sequence number. */
+    public int notificationSequence;
 
     public ControllerInfo(ListenableFuture<MediaController> controllerFuture) {
       this.controllerFuture = controllerFuture;

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -697,6 +697,11 @@ import java.util.concurrent.atomic.AtomicInteger;
           session, /* startInForegroundWhenPaused= */ false);
     }
 
+    // Note: Because setAvailableCommands can be called from any thread and processing the updated
+    // state requires executing code on both player and background thread, MediaSessionLegacyStub is
+    // responsible for manually triggering a refresh of the notification instead of this being
+    // handled here.
+
     @Override
     public ListenableFuture<SessionResult> onCustomCommand(
         MediaController controller, SessionCommand command, Bundle args) {
@@ -721,11 +726,12 @@ import java.util.concurrent.atomic.AtomicInteger;
     @Override
     public void onEvents(Player player, Player.Events events) {
       // We must limit the frequency of notification updates, otherwise the system may suppress
-      // them. (Note: EVENT_TIMELINE_CHANGED is handled in MediaSessionLegacyStub)
+      // them.
       if (events.containsAny(
           Player.EVENT_PLAYBACK_STATE_CHANGED,
           Player.EVENT_PLAY_WHEN_READY_CHANGED,
-          Player.EVENT_MEDIA_METADATA_CHANGED)) {
+          Player.EVENT_MEDIA_METADATA_CHANGED,
+          Player.EVENT_TIMELINE_CHANGED)) {
         mediaSessionService.onUpdateNotificationInternal(
             session, /* startInForegroundWhenPaused= */ false);
       }

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -752,6 +752,7 @@ import java.util.concurrent.atomic.AtomicInteger;
         Log.e(TAG, "Failed to start foreground", e);
         return false;
       }
+      throw e;
     }
     if (hasOtherForegroundSession) {
       // startForeground() normally does this, but as we passed another notification to it, we have

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -480,20 +480,6 @@ import java.util.concurrent.TimeoutException;
     }
 
     @Override
-    public void onMediaButtonPreferencesChanged(
-        MediaController controller, List<CommandButton> mediaButtonPreferences) {
-      mediaSessionService.onUpdateNotificationInternal(
-          session, /* startInForegroundWhenPaused= */ false);
-    }
-
-    @Override
-    public void onAvailableSessionCommandsChanged(
-        MediaController controller, SessionCommands commands) {
-      mediaSessionService.onUpdateNotificationInternal(
-          session, /* startInForegroundWhenPaused= */ false);
-    }
-
-    @Override
     public ListenableFuture<SessionResult> onCustomCommand(
         MediaController controller, SessionCommand command, Bundle args) {
       @SessionResult.Code int resultCode = SessionError.ERROR_NOT_SUPPORTED;
@@ -512,20 +498,6 @@ import java.util.concurrent.TimeoutException;
       // We may need to hide the notification.
       mediaSessionService.onUpdateNotificationInternal(
           session, /* startInForegroundWhenPaused= */ false);
-    }
-
-    @Override
-    public void onEvents(Player player, Player.Events events) {
-      // We must limit the frequency of notification updates, otherwise the system may suppress
-      // them.
-      if (events.containsAny(
-          Player.EVENT_PLAYBACK_STATE_CHANGED,
-          Player.EVENT_PLAY_WHEN_READY_CHANGED,
-          Player.EVENT_MEDIA_METADATA_CHANGED,
-          Player.EVENT_TIMELINE_CHANGED)) {
-        mediaSessionService.onUpdateNotificationInternal(
-            session, /* startInForegroundWhenPaused= */ false);
-      }
     }
   }
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -90,11 +90,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 
   /**
    * The session that provides the notification the foreground service is started with, or null if
-   * the service is not in foreground at the moment. Each service can only have one foreground
-   * notification, so we have to switch this around as needed if we have multiple sessions.
+   * the service is not in foreground at the moment. Each service must have exactly one foreground
+   * service notification as long as it is in foreground, so we have to switch this around as needed
+   * if we have multiple sessions.
    */
   @GuardedBy("#lock")
-  private @Nullable MediaSession foregroundSession;
+  private @Nullable MediaSession foregroundNotificationSession;
 
   @GuardedBy("#lock")
   private boolean isUserEngaged;
@@ -321,7 +322,7 @@ import java.util.concurrent.atomic.AtomicInteger;
   // This method can be called on any thread.
   public boolean isStartedInForeground() {
     synchronized (lock) {
-      return foregroundSession != null;
+      return foregroundNotificationSession != null;
     }
   }
 
@@ -735,14 +736,14 @@ import java.util.concurrent.atomic.AtomicInteger;
   private boolean startForeground(MediaSession session, MediaNotification newMediaNotification) {
     MediaNotification mediaNotification;
     boolean hasOtherForegroundSession;
-    if (foregroundSession != null && foregroundSession != session) {
-      // If we would use the newly updated notification, the old foreground session's notification
+    if (foregroundNotificationSession != null && foregroundNotificationSession != session) {
+      // If we used the newly updated notification, the old foreground session's notification
       // would be canceled by the system because the service switched to another foreground service
       // notification. However, we don't want to cancel it, so we just keep using the old session's
       // notification as long as we can, and post our new notification as normal notification.
       // We still need to call startForeground() in any case to avoid
       // ForegroundServiceDidNotStartInTimeException.
-      mediaNotification = checkNotNull(mediaNotifications.get(foregroundSession));
+      mediaNotification = checkNotNull(mediaNotifications.get(foregroundNotificationSession));
       hasOtherForegroundSession = true;
     } else {
       mediaNotification = newMediaNotification;
@@ -764,11 +765,11 @@ import java.util.concurrent.atomic.AtomicInteger;
       throw e;
     }
     if (hasOtherForegroundSession) {
-      // startForeground() normally does this, but as we passed another notification to it, we have
-      // to do it manually here.
+      // startForeground() does this, but because we passed another notification to it, we have to
+      // do it manually here.
       notify(newMediaNotification);
     } else {
-      foregroundSession = session;
+      foregroundNotificationSession = session;
     }
     return true;
   }
@@ -776,18 +777,33 @@ import java.util.concurrent.atomic.AtomicInteger;
   @GuardedBy("#lock")
   private void stopForeground(
       MediaSession session, boolean removeNotifications, boolean startInForegroundRequired) {
-    if (foregroundSession != session) {
-      // This happens if there is another session in foreground since before this session wanted to
-      // go in the foreground. As this other session still wants to be in the foreground, we don't
-      // need to stop the foreground service. cancel() will be called by the caller if
-      // removeNotifications is true, so we don't need to do anything here.
-      return;
-    }
-    foregroundSession = null;
     if (startInForegroundRequired) {
-      // If we shouldn't show a notification for this session anymore, but there's another session
-      // and it wants to stay in foreground, we have to change the foreground service notification
-      // to the other session.
+      // There is another session that wants to stay in the foreground, so we won't need to stop the
+      // foreground service. The only question is whether we change the notification used by the
+      // foreground service or not.
+      if (foregroundNotificationSession != session) {
+        // The foreground service notification is provided by another session, so we don't need to
+        // do anything here.
+        return;
+      }
+      if (!removeNotifications) {
+        // We want to keep this session's notification, but the session doesn't need foreground
+        // service anymore. We have two options:
+        // 1. Call startForeground() on another session to cancel this session's notification (not
+        //    desired) and change the service notification (desired), or
+        // 2. Do nothing.
+        // Because the user will notice if the notification dis- and reappears, we will do nothing
+        // here. It's okay to provide the foreground service notification from a session which
+        // doesn't want to be in foreground because which notification allows this service to stay
+        // in foreground is not displayed to the user. Hence, we don't need to do anything.
+        return;
+      }
+    }
+    foregroundNotificationSession = null;
+    if (startInForegroundRequired) {
+      // We shouldn't show a notification for this session anymore and hence must remove the current
+      // foreground service notification, but there's another session which wants to stay in
+      // foreground. We'll have to change the foreground service notification to the other session.
       List<MediaSession> sessions = mediaSessionService.getSessions();
       for (MediaSession candidateSession : sessions) {
         // Just take the first one willing to show a notification, it doesn't matter which one.
@@ -795,12 +811,8 @@ import java.util.concurrent.atomic.AtomicInteger;
           // Because we are already a foreground service, this should not fail.
           startForeground(candidateSession, checkNotNull(mediaNotifications.get(candidateSession)));
           // When calling startForeground() with a different notification ID, the old notification
-          // will be canceled by the system. It's an unfortunate limitation of the API we can't do
-          // anything about. Hence, if removeNotifications is false, we have to send the
-          // notification out again using notify() as we didn't want it to be canceled.
-          if (!removeNotifications) {
-            notify(checkNotNull(mediaNotifications.get(session)));
-          }
+          // will be canceled by the system, so we are done. (Even if that doesn't work, the caller
+          // will call cancel() to make sure the notification is removed.)
           return;
         }
       }

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -689,6 +689,11 @@ import java.util.concurrent.atomic.AtomicInteger;
           session, /* startInForegroundWhenPaused= */ false);
     }
 
+    // Note: Because setAvailableCommands can be called from any thread and processing the updated
+    // state requires executing code on both player and background thread, MediaSessionLegacyStub is
+    // responsible for manually triggering a refresh of the notification instead of this being
+    // handled here.
+
     @Override
     public ListenableFuture<SessionResult> onCustomCommand(
         MediaController controller, SessionCommand command, Bundle args) {
@@ -713,11 +718,12 @@ import java.util.concurrent.atomic.AtomicInteger;
     @Override
     public void onEvents(Player player, Player.Events events) {
       // We must limit the frequency of notification updates, otherwise the system may suppress
-      // them. (Note: EVENT_TIMELINE_CHANGED is handled in MediaSessionLegacyStub)
+      // them.
       if (events.containsAny(
           Player.EVENT_PLAYBACK_STATE_CHANGED,
           Player.EVENT_PLAY_WHEN_READY_CHANGED,
-          Player.EVENT_MEDIA_METADATA_CHANGED)) {
+          Player.EVENT_MEDIA_METADATA_CHANGED,
+          Player.EVENT_TIMELINE_CHANGED)) {
         mediaSessionService.onUpdateNotificationInternal(
             session, /* startInForegroundWhenPaused= */ false);
       }

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -33,11 +33,14 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import android.util.Pair;
+import androidx.annotation.GuardedBy;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.concurrent.futures.CallbackToFutureAdapter;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
 import androidx.media3.common.Player;
+import androidx.media3.common.util.BackgroundExecutor;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.NullableType;
 import androidx.media3.common.util.Util;
@@ -48,20 +51,20 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Manages media notifications for a {@link MediaSessionService} and sets the service as
  * foreground/background according to the player state.
- *
- * <p>All methods must be called on the main thread.
  */
 /* package */ final class MediaNotificationManager implements Handler.Callback {
 
@@ -72,28 +75,40 @@ import java.util.concurrent.TimeoutException;
 
   private final MediaSessionService mediaSessionService;
 
+  private final Object lock;
   private final MediaNotification.ActionFactory actionFactory;
   private final NotificationManager notificationManager;
   private final Handler mainHandler;
-  private final Executor mainExecutor;
   private final Intent startSelfIntent;
   private final String startSelfIntentUid;
-  private final Map<MediaSession, ControllerInfo> controllerMap;
+  private final Map<MediaSession, ControllerInfo> controllerMap; // write only on main
+
+  @GuardedBy("#lock")
   private final Map<MediaSession, MediaNotification> mediaNotifications;
 
-  private MediaNotification.Provider mediaNotificationProvider;
+  private volatile MediaNotification.Provider mediaNotificationProvider;
 
   /**
    * The session that provides the notification the foreground service is started with, or null if
    * the service is not in foreground at the moment. Each service can only have one foreground
    * notification, so we have to switch this around as needed if we have multiple sessions.
    */
+  @GuardedBy("#lock")
   private @Nullable MediaSession foregroundSession;
 
+  @GuardedBy("#lock")
   private boolean isUserEngaged;
+
+  @GuardedBy("#lock")
   private boolean isUserEngagedTimeoutEnabled;
+
+  @GuardedBy("#lock")
   private long userEngagedTimeoutMs;
-  @ShowNotificationForIdlePlayerMode int showNotificationForIdlePlayerMode;
+
+  @GuardedBy("#lock")
+  private boolean notificationsEnabled;
+
+  @ShowNotificationForIdlePlayerMode volatile int showNotificationForIdlePlayerMode;
 
   public MediaNotificationManager(
       MediaSessionService mediaSessionService,
@@ -102,18 +117,19 @@ import java.util.concurrent.TimeoutException;
     this.mediaSessionService = mediaSessionService;
     this.mediaNotificationProvider = mediaNotificationProvider;
     this.actionFactory = actionFactory;
+    lock = new Object();
     notificationManager =
         checkNotNull(
             (NotificationManager)
                 mediaSessionService.getSystemService(Context.NOTIFICATION_SERVICE));
     mainHandler = Util.createHandler(Looper.getMainLooper(), /* callback= */ this);
-    mainExecutor = (runnable) -> Util.postOrRun(mainHandler, runnable);
     startSelfIntent = new Intent(mediaSessionService, mediaSessionService.getClass());
     startSelfIntentUid = UUID.randomUUID().toString();
     startSelfIntent.putExtra(SELF_INTENT_UID_KEY, startSelfIntentUid);
     controllerMap = new HashMap<>();
     mediaNotifications = new HashMap<>();
     isUserEngagedTimeoutEnabled = true;
+    notificationsEnabled = true;
     userEngagedTimeoutMs = MediaSessionService.DEFAULT_FOREGROUND_SERVICE_TIMEOUT_MS;
     showNotificationForIdlePlayerMode =
         MediaSessionService.SHOW_NOTIFICATION_FOR_IDLE_PLAYER_AFTER_STOP_OR_ERROR;
@@ -127,6 +143,7 @@ import java.util.concurrent.TimeoutException;
     return startSelfIntentUid;
   }
 
+  // This method will be called on the main thread.
   public void addSession(MediaSession session) {
     if (controllerMap.containsKey(session)) {
       return;
@@ -138,9 +155,11 @@ import java.util.concurrent.TimeoutException;
         new MediaController.Builder(mediaSessionService, session.getToken())
             .setConnectionHints(connectionHints)
             .setListener(listener)
-            .setApplicationLooper(Looper.getMainLooper())
+            .setApplicationLooper(session.getBackgroundLooper())
             .buildAsync();
-    controllerMap.put(session, new ControllerInfo(controllerFuture));
+    Handler backgroundHandler = new Handler(session.getBackgroundLooper());
+    controllerMap.put(
+        session, new ControllerInfo(controllerFuture, backgroundHandler));
     controllerFuture.addListener(
         () -> {
           try {
@@ -155,30 +174,35 @@ import java.util.concurrent.TimeoutException;
             mediaSessionService.removeSession(session);
           }
         },
-        mainExecutor);
+        r -> Util.postOrRun(backgroundHandler, r));
   }
 
+  // This method will be called on the main thread.
   public void removeSession(MediaSession session) {
     @Nullable ControllerInfo controllerInfo = controllerMap.remove(session);
     if (controllerInfo != null) {
       // Update the notification count so that if a pending notification callback arrives (e.g., a
       // bitmap is loaded), we don't show a stale notification.
       controllerInfo.notificationSequence++;
-      MediaController.releaseFuture(controllerInfo.controllerFuture);
+      controllerInfo.backgroundHandler.post(
+          () -> MediaController.releaseFuture(controllerInfo.controllerFuture));
     }
   }
 
+  // This method will be called on the main thread.
   public void onCustomAction(MediaSession session, String action, Bundle extras) {
-    @Nullable MediaController mediaController = getConnectedControllerForSession(session);
-    if (mediaController == null) {
+    @Nullable ControllerInfo controllerInfo = getConnectedControllerInfoForSession(session);
+    if (controllerInfo == null) {
       return;
     }
+    MediaController mediaController = getControllerForControllerInfo(controllerInfo);
     // Let the notification provider handle the command first before forwarding it directly.
     Util.postOrRun(
         session.getImpl().getApplicationHandler(),
         () -> {
           if (!mediaNotificationProvider.handleCustomCommand(session, action, extras)) {
-            mainExecutor.execute(
+            Util.postOrRun(
+                controllerInfo.backgroundHandler,
                 () -> sendCustomCommandIfCommandIsAvailable(mediaController, action, extras));
           }
         });
@@ -186,6 +210,8 @@ import java.util.concurrent.TimeoutException;
 
   /**
    * Updates the media notification provider.
+   *
+   * <p>This method will be called on the main thread.
    *
    * @param mediaNotificationProvider The {@link MediaNotification.Provider}.
    */
@@ -196,69 +222,111 @@ import java.util.concurrent.TimeoutException;
   /**
    * Updates the notification.
    *
+   * <p>This method can be called on any thread.
+   *
    * @param session A session that needs notification update.
    * @param startInForegroundRequired Whether the service is required to start in the foreground.
+   * @return Future is set to false if a {@link ForegroundServiceStartNotAllowedException} prevented
+   *     starting the foreground service, otherwise (even if no start attempted) true.
    */
   public ListenableFuture<@NullableType Void> updateNotification(
       MediaSession session, boolean startInForegroundRequired) {
     return CallbackToFutureAdapter.getFuture(
         completer -> {
-          if (!mediaSessionService.isSessionAdded(session) || !shouldShowNotification(session)) {
-            removeNotification(session);
-            completer.set(null);
-            return "notificationRemoved";
-          }
+          @Nullable ControllerInfo controllerInfo = getConnectedControllerInfoForSession(session);
+          boolean updateStarted = false;
+          if (controllerInfo != null) {
+            updateStarted =
+                Util.postOrRun(
+                    controllerInfo.backgroundHandler,
+                    () -> {
+                      if (!mediaSessionService.isSessionAdded(session) || !shouldShowNotification(
+                          session)) {
+                        removeNotification(session, startInForegroundRequired);
+                        completer.set(null);
+                        return;
+                      }
 
-          ControllerInfo controllerInfo = checkNotNull(controllerMap.get(session));
-          int notificationSequence = ++controllerInfo.notificationSequence;
-          ImmutableList<CommandButton> mediaButtonPreferences =
-              checkNotNull(getConnectedControllerForSession(session)).getMediaButtonPreferences();
-          MediaNotification.Provider.Callback callback =
-              notification ->
-                  mainExecutor.execute(
-                      () ->
-                          onNotificationUpdated(
-                              controllerInfo, notificationSequence, session, notification));
-          Util.postOrRun(
-              session.getImpl().getApplicationHandler(),
-              () -> {
-                try {
-                  MediaNotification mediaNotification =
-                      this.mediaNotificationProvider.createNotification(
-                          session, mediaButtonPreferences, actionFactory, callback);
-                  checkState(
-                      /* expression= */ mediaNotification.notificationId
-                          != SHUTDOWN_NOTIFICATION_ID,
-                      /* errorMessage= */ "notification ID "
-                          + SHUTDOWN_NOTIFICATION_ID
-                          + " is already used internally.");
-                  mainExecutor.execute(
-                      () -> {
-                        try {
-                          updateNotificationInternal(
-                              session, mediaNotification, startInForegroundRequired);
-                          completer.set(null);
-                        } catch (IllegalStateException e) {
-                          // Re-throw exception thrown in the main thread caused by not being
-                          // allowed to start a service into the foreground from the background.
-                          completer.setException(e);
-                        }
-                      });
-                } catch (RuntimeException e) {
-                  // Re-throw exception thrown in the app thread caused by programming errors.
-                  completer.setException(e);
-                }
-              });
+                      int notificationSequence = ++controllerInfo.notificationSequence;
+                      ImmutableList<CommandButton> mediaButtonPreferences =
+                          getControllerForControllerInfo(controllerInfo).getMediaButtonPreferences();
+                      MediaNotification.Provider.Callback callback =
+                          notification ->
+                              Util.postOrRun(
+                                  controllerInfo.backgroundHandler,
+                                  () ->
+                                      onNotificationUpdated(
+                                          controllerInfo, notificationSequence, session, notification));
+                      Util.postOrRun(
+                          session.getImpl().getApplicationHandler(),
+                          () -> {
+                            try {
+                              MediaNotification mediaNotification =
+                                  this.mediaNotificationProvider.createNotification(
+                                      session, mediaButtonPreferences, actionFactory, callback);
+                              checkState(
+                                  /* expression= */ mediaNotification.notificationId
+                                      != SHUTDOWN_NOTIFICATION_ID,
+                                  /* errorMessage= */ "notification ID "
+                                      + SHUTDOWN_NOTIFICATION_ID
+                                      + " is already used internally.");
+                              Util.postOrRun(
+                                  controllerInfo.backgroundHandler,
+                                  () -> {
+                                    try {
+                                      updateNotificationInternal(
+                                          session, mediaNotification, startInForegroundRequired);
+                                      completer.set(null);
+                                    } catch (IllegalStateException e) {
+                                      // Re-throw exception thrown in the main thread caused by not being
+                                      // allowed to start a service into the foreground from the background.
+                                      completer.setException(e);
+                                    }
+                                  });
+                            } catch (RuntimeException e) {
+                              // Re-throw exception thrown in the app thread caused by programming errors.
+                              completer.setException(e);
+                            }
+                          });
+                    });
+          }
+          if (!updateStarted) {
+            postToControllerBackground(
+                controllerInfo,
+                session,
+                () -> {
+                  removeNotification(session, startInForegroundRequired);
+                  completer.set(null);
+                });
+          }
           return "notificationUpdated";
         });
   }
 
-  public boolean isStartedInForeground() {
-    return foregroundSession != null;
+  private void postToControllerBackground(
+      @Nullable ControllerInfo controllerInfo, MediaSession session, Runnable r) {
+    @Nullable Handler bgHandler = controllerInfo != null ? controllerInfo.backgroundHandler : null;
+    if (bgHandler == null) {
+      bgHandler = new Handler(session.getBackgroundLooper());
+    }
+    if (!bgHandler.post(r)) {
+      // If we end up here, the thread already quit. We should use another thread as stand-in.
+      BackgroundExecutor.get().execute(r);
+    }
   }
 
+  // This method can be called on any thread.
+  public boolean isStartedInForeground() {
+    synchronized (lock) {
+      return foregroundSession != null;
+    }
+  }
+
+  // This method will be called on the main thread.
   public void setUserEngagedTimeoutMs(long userEngagedTimeoutMs) {
-    this.userEngagedTimeoutMs = userEngagedTimeoutMs;
+    synchronized (lock) {
+      this.userEngagedTimeoutMs = userEngagedTimeoutMs;
+    }
   }
 
   public void setShowNotificationForIdlePlayer(
@@ -284,39 +352,101 @@ import java.util.concurrent.TimeoutException;
     return false;
   }
 
-  /* package */ boolean shouldRunInForeground(boolean startInForegroundWhenPaused) {
-    boolean isUserEngaged = isAnySessionUserEngaged(startInForegroundWhenPaused);
-    boolean useTimeout = isUserEngagedTimeoutEnabled && userEngagedTimeoutMs > 0;
-    if (this.isUserEngaged && !isUserEngaged && useTimeout) {
-      mainHandler.sendEmptyMessageDelayed(MSG_USER_ENGAGED_TIMEOUT, userEngagedTimeoutMs);
-    } else if (isUserEngaged) {
-      mainHandler.removeMessages(MSG_USER_ENGAGED_TIMEOUT);
-    }
-    this.isUserEngaged = isUserEngaged;
-    boolean hasPendingTimeout = mainHandler.hasMessages(MSG_USER_ENGAGED_TIMEOUT);
-    return isUserEngaged || hasPendingTimeout;
+  // This method can be called on any thread.
+  /* package */ ListenableFuture<Boolean> shouldRunInForeground(
+      boolean startInForegroundWhenPaused) {
+    SettableFuture<Boolean> completion = SettableFuture.create();
+    ListenableFuture<Boolean> isUserEngagedFuture =
+        isAnySessionUserEngaged(startInForegroundWhenPaused);
+    isUserEngagedFuture.addListener(
+        () -> {
+          boolean isUserEngaged;
+          try {
+            isUserEngaged = isUserEngagedFuture.get();
+          } catch (ExecutionException | InterruptedException e) {
+            throw new IllegalStateException(e);
+          }
+          synchronized (lock) {
+            boolean useTimeout = isUserEngagedTimeoutEnabled && userEngagedTimeoutMs > 0;
+            if (this.isUserEngaged && !isUserEngaged && useTimeout) {
+              mainHandler.sendEmptyMessageDelayed(MSG_USER_ENGAGED_TIMEOUT, userEngagedTimeoutMs);
+            } else if (isUserEngaged) {
+              mainHandler.removeMessages(MSG_USER_ENGAGED_TIMEOUT);
+            }
+            this.isUserEngaged = isUserEngaged;
+          }
+          boolean hasPendingTimeout = mainHandler.hasMessages(MSG_USER_ENGAGED_TIMEOUT);
+          completion.set(isUserEngaged || hasPendingTimeout);
+        },
+        MoreExecutors.directExecutor());
+    return completion;
   }
 
-  private boolean isAnySessionUserEngaged(boolean startInForegroundWhenPaused) {
+  // This method can be called on any thread.
+  private ListenableFuture<Boolean> isAnySessionUserEngaged(boolean startInForegroundWhenPaused) {
     List<MediaSession> sessions = mediaSessionService.getSessions();
-    for (int i = 0; i < sessions.size(); i++) {
-      @Nullable MediaController controller = getConnectedControllerForSession(sessions.get(i));
-      if (controller != null
-          && (controller.getPlayWhenReady() || startInForegroundWhenPaused)
-          && (controller.getPlaybackState() == Player.STATE_READY
-              || controller.getPlaybackState() == Player.STATE_BUFFERING)) {
-        return true;
+    synchronized (lock) {
+      if (!notificationsEnabled || sessions.isEmpty()) {
+        return Futures.immediateFuture(false);
       }
     }
-    return false;
+    SettableFuture<Boolean> outputFuture = SettableFuture.create();
+    List<@NullableType ListenableFuture<Boolean>> sessionFutures = new ArrayList<>();
+    final AtomicInteger resultCount = new AtomicInteger(0);
+    Runnable handleSessionFuturesTask =
+        () -> {
+          int completedSessionFutureCount = resultCount.incrementAndGet();
+          if (completedSessionFutureCount == sessions.size()) {
+            boolean value = false;
+            for (@NullableType ListenableFuture<Boolean> future : sessionFutures) {
+              if (future != null) {
+                try {
+                  value = future.get();
+                } catch (ExecutionException | InterruptedException e) {
+                  throw new RuntimeException(e);
+                }
+                if (value) {
+                  break;
+                }
+              }
+            }
+            outputFuture.set(value);
+          }
+        };
+
+    for (int i = 0; i < sessions.size(); i++) {
+      MediaSession session = sessions.get(i);
+      @Nullable ControllerInfo controllerInfo = getConnectedControllerInfoForSession(session);
+      if (controllerInfo != null) {
+        MediaController controller = getControllerForControllerInfo(controllerInfo);
+        SettableFuture<Boolean> completion = SettableFuture.create();
+        Util.postOrRun(
+            controllerInfo.backgroundHandler,
+            () ->
+                completion.set(
+                    (controller.getPlayWhenReady() || startInForegroundWhenPaused)
+                        && (controller.getPlaybackState() == Player.STATE_READY
+                            || controller.getPlaybackState() == Player.STATE_BUFFERING)));
+        sessionFutures.add(completion);
+        completion.addListener(handleSessionFuturesTask, MoreExecutors.directExecutor());
+      } else {
+        sessionFutures.add(null);
+        handleSessionFuturesTask.run();
+      }
+    }
+    return outputFuture;
   }
 
   /**
    * Permanently disable the user engaged timeout, which is needed to immediately stop the
    * foreground service.
+   *
+   * <p>This method will be called on the main thread.
    */
   /* package */ void disableUserEngagedTimeout() {
-    isUserEngagedTimeoutEnabled = false;
+    synchronized (lock) {
+      isUserEngagedTimeoutEnabled = false;
+    }
     if (mainHandler.hasMessages(MSG_USER_ENGAGED_TIMEOUT)) {
       mainHandler.removeMessages(MSG_USER_ENGAGED_TIMEOUT);
       List<MediaSession> sessions = mediaSessionService.getSessions();
@@ -327,26 +457,58 @@ import java.util.concurrent.TimeoutException;
     }
   }
 
+  /**
+   * Permanently disable both the user engaged timeout and posting new notifications, immediately
+   * stop the foreground service and cancel all media notifications.
+   *
+   * <p>This method will be called on the main thread.
+   */
+  /* package */ void stopForegroundServiceAndDisableNotifications() {
+    synchronized (lock) {
+      isUserEngagedTimeoutEnabled = false;
+      notificationsEnabled = false;
+      if (mainHandler.hasMessages(MSG_USER_ENGAGED_TIMEOUT)) {
+        mainHandler.removeMessages(MSG_USER_ENGAGED_TIMEOUT);
+      }
+      List<MediaSession> sessions = mediaSessionService.getSessions();
+      for (int i = 0; i < sessions.size(); i++) {
+        removeNotification(sessions.get(i), false);
+      }
+    }
+  }
+
+  // Will be called on controller's application thread.
   private void onNotificationUpdated(
       ControllerInfo controllerInfo,
       int notificationSequence,
       MediaSession session,
       MediaNotification mediaNotification) {
     if (controllerInfo.notificationSequence == notificationSequence) {
-      boolean startInForegroundRequired =
+      ListenableFuture<Boolean> startInForegroundRequiredFuture =
           shouldRunInForeground(/* startInForegroundWhenPaused= */ false);
-      try {
-        updateNotificationInternal(session, mediaNotification, startInForegroundRequired);
-      } catch (IllegalStateException e) {
-        if (SDK_INT >= 31 && e instanceof ForegroundServiceStartNotAllowedException) {
-          mediaSessionService.onForegroundServiceStartNotAllowedException();
-        } else {
-          throw e;
-        }
-      }
+      startInForegroundRequiredFuture.addListener(
+          () -> {
+            boolean startInForegroundRequired;
+            try {
+              startInForegroundRequired = startInForegroundRequiredFuture.get();
+            } catch (ExecutionException | InterruptedException e) {
+              throw new RuntimeException(e);
+            }
+            try {
+              updateNotificationInternal(session, mediaNotification, startInForegroundRequired);
+            } catch (IllegalStateException e) {
+              if (SDK_INT >= 31 && e instanceof ForegroundServiceStartNotAllowedException) {
+                mediaSessionService.onForegroundServiceStartNotAllowedException();
+              } else {
+                throw e;
+              }
+            }
+          },
+          r -> Util.postOrRun(controllerInfo.backgroundHandler, r));
     }
   }
 
+  // Will be called on controller's application thread.
   private void onNotificationDismissed(MediaSession session) {
     @Nullable ControllerInfo controllerInfo = controllerMap.get(session);
     if (controllerInfo != null) {
@@ -354,49 +516,69 @@ import java.util.concurrent.TimeoutException;
     }
   }
 
-  private void updateNotificationInternal(
+  // Will be called on controller's application thread.
+  private boolean updateNotificationInternal(
       MediaSession session,
       MediaNotification mediaNotification,
       boolean startInForegroundRequired) {
     // Call Notification.MediaStyle#setMediaSession() indirectly.
     Token fwkToken = session.getPlatformToken();
     mediaNotification.notification.extras.putParcelable(Notification.EXTRA_MEDIA_SESSION, fwkToken);
-    this.mediaNotifications.put(session, mediaNotification);
-    if (startInForegroundRequired) {
-      startForeground(session, mediaNotification);
-    } else {
-      // Notification manager has to be updated first to avoid missing updates
-      // (https://github.com/androidx/media/issues/192).
-      notify(mediaNotification);
-      stopForeground(session, /* removeNotifications= */ false);
-    }
-  }
-
-  /** Removes the notification and stops the foreground service if running. */
-  private void removeNotification(MediaSession session) {
-    // To hide the notification on all API levels, we need to call both Service.stopForeground(true)
-    // and notificationManagerCompat.cancel(notificationId).
-    stopForeground(session, /* removeNotifications= */ true);
-    @Nullable MediaNotification mediaNotification = mediaNotifications.remove(session);
-    if (mediaNotification != null) {
-      notificationManager.cancel(mediaNotification.notificationId);
-      // Update the notification count so that if a pending notification callback arrives (e.g., a
-      // bitmap is loaded), we don't show the notification.
-      @Nullable ControllerInfo controllerInfo = controllerMap.get(session);
-      // If the controllerInfo is already removed from the map, removeSession() has increased the
-      // sequence, so it's fine.
-      if (controllerInfo != null) {
-        controllerInfo.notificationSequence++;
+    synchronized (lock) {
+      if (!notificationsEnabled) {
+        return true;
+      }
+      this.mediaNotifications.put(session, mediaNotification);
+      if (startInForegroundRequired) {
+        return startForeground(session, mediaNotification);
+      } else {
+        // Notification manager has to be updated first to avoid missing updates
+        // (https://github.com/androidx/media/issues/192).
+        notify(mediaNotification);
+        stopForeground(session, /* removeNotifications= */ false, false);
+        return true;
       }
     }
   }
 
+  /** Removes the notification and stops the foreground service if running. */
+  // Can be called on any thread.
+  private void removeNotification(MediaSession session, boolean startInForegroundRequired) {
+    synchronized (lock) {
+      // To hide the notification on all API levels, we need to call both
+      // Service.stopForeground(true)
+      // and notificationManagerCompat.cancel(notificationId).
+      stopForeground(session, /* removeNotifications= */ true, startInForegroundRequired);
+      @Nullable MediaNotification mediaNotification = mediaNotifications.remove(session);
+      if (mediaNotification != null) {
+        notificationManager.cancel(mediaNotification.notificationId);
+        @Nullable ControllerInfo controllerInfo = controllerMap.get(session);
+        // If the controllerInfo is already removed from the map, removeSession() has increased the
+        // sequence, so it's fine.
+        if (controllerInfo != null) {
+          // Update the notification count so that if a pending notification callback arrives (e.g.,
+          // a bitmap is loaded), we don't show the notification.
+          controllerInfo.notificationSequence++;
+        }
+      }
+    }
+  }
+
+  // Will be called on controller's application thread.
   private boolean shouldShowNotification(MediaSession session) {
-    MediaController controller = getConnectedControllerForSession(session);
-    if (controller == null || controller.getCurrentTimeline().isEmpty()) {
+    synchronized (lock) {
+      if (!notificationsEnabled) {
+        return false;
+      }
+    }
+    ControllerInfo controllerInfo = getConnectedControllerInfoForSession(session);
+    if (controllerInfo == null) {
       return false;
     }
-    ControllerInfo controllerInfo = checkNotNull(controllerMap.get(session));
+    MediaController controller = getControllerForControllerInfo(controllerInfo);
+    if (controller.getCurrentTimeline().isEmpty()) {
+      return false;
+    }
     if (controller.getPlaybackState() != Player.STATE_IDLE) {
       // Playback first prepared or restarted, reset previous notification dismissed flag.
       controllerInfo.wasNotificationDismissed = false;
@@ -416,10 +598,18 @@ import java.util.concurrent.TimeoutException;
   }
 
   @Nullable
-  private MediaController getConnectedControllerForSession(MediaSession session) {
+  private ControllerInfo getConnectedControllerInfoForSession(MediaSession session) {
     @Nullable ControllerInfo controllerInfo = controllerMap.get(session);
     if (controllerInfo == null || !controllerInfo.controllerFuture.isDone()) {
       return null;
+    }
+    return controllerInfo;
+  }
+
+  private static MediaController getControllerForControllerInfo(ControllerInfo controllerInfo) {
+    if (!controllerInfo.controllerFuture.isDone()) {
+      // This is checked in getConnectedControllerInfoForSession() already, so can't happen.
+      throw new IllegalArgumentException("controllerInfo is not done");
     }
     try {
       return Futures.getDone(controllerInfo.controllerFuture);
@@ -429,6 +619,7 @@ import java.util.concurrent.TimeoutException;
     }
   }
 
+  // Will be called on controller's application thread.
   private void sendCustomCommandIfCommandIsAvailable(
       MediaController mediaController, String action, Bundle extras) {
     @Nullable SessionCommand customCommand = null;
@@ -497,6 +688,13 @@ import java.util.concurrent.TimeoutException;
     }
 
     @Override
+    public void onMediaButtonPreferencesChanged(
+        MediaController controller, List<CommandButton> mediaButtonPreferences) {
+      mediaSessionService.onUpdateNotificationInternal(
+          session, /* startInForegroundWhenPaused= */ false);
+    }
+
+    @Override
     public ListenableFuture<SessionResult> onCustomCommand(
         MediaController controller, SessionCommand command, Bundle args) {
       @SessionResult.Code int resultCode = SessionError.ERROR_NOT_SUPPORTED;
@@ -516,10 +714,24 @@ import java.util.concurrent.TimeoutException;
       mediaSessionService.onUpdateNotificationInternal(
           session, /* startInForegroundWhenPaused= */ false);
     }
+
+    @Override
+    public void onEvents(Player player, Player.Events events) {
+      // We must limit the frequency of notification updates, otherwise the system may suppress
+      // them. (Note: EVENT_TIMELINE_CHANGED is handled in MediaSessionLegacyStub)
+      if (events.containsAny(
+          Player.EVENT_PLAYBACK_STATE_CHANGED,
+          Player.EVENT_PLAY_WHEN_READY_CHANGED,
+          Player.EVENT_MEDIA_METADATA_CHANGED)) {
+        mediaSessionService.onUpdateNotificationInternal(
+            session, /* startInForegroundWhenPaused= */ false);
+      }
+    }
   }
 
+  @GuardedBy("#lock")
   @SuppressLint("InlinedApi") // Using compile time constant FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
-  private void startForeground(MediaSession session, MediaNotification newMediaNotification) {
+  private boolean startForeground(MediaSession session, MediaNotification newMediaNotification) {
     MediaNotification mediaNotification;
     boolean hasOtherForegroundSession;
     if (foregroundSession != null && foregroundSession != session) {
@@ -533,24 +745,35 @@ import java.util.concurrent.TimeoutException;
       hasOtherForegroundSession = true;
     } else {
       mediaNotification = newMediaNotification;
-      foregroundSession = session;
       hasOtherForegroundSession = false;
     }
-    ContextCompat.startForegroundService(mediaSessionService, startSelfIntent);
-    Util.setForegroundServiceNotification(
-        mediaSessionService,
-        mediaNotification.notificationId,
-        mediaNotification.notification,
-        ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
-        "mediaPlayback");
+    try {
+      ContextCompat.startForegroundService(mediaSessionService, startSelfIntent);
+      Util.setForegroundServiceNotification(
+          mediaSessionService,
+          mediaNotification.notificationId,
+          mediaNotification.notification,
+          ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
+          "mediaPlayback");
+    } catch (IllegalStateException e) {
+      if (SDK_INT >= 31 && Api31.instanceOfForegroundServiceStartNotAllowedException(e)) {
+        Log.e(TAG, "Failed to start foreground", e);
+        return false;
+      }
+    }
     if (hasOtherForegroundSession) {
       // startForeground() normally does this, but as we passed another notification to it, we have
       // to do it manually here.
       notify(newMediaNotification);
+    } else {
+      foregroundSession = session;
     }
+    return true;
   }
 
-  private void stopForeground(MediaSession session, boolean removeNotifications) {
+  @GuardedBy("#lock")
+  private void stopForeground(
+      MediaSession session, boolean removeNotifications, boolean startInForegroundRequired) {
     if (foregroundSession != session) {
       // This happens if there is another session in foreground since before this session wanted to
       // go in the foreground. As this other session still wants to be in the foreground, we don't
@@ -559,7 +782,7 @@ import java.util.concurrent.TimeoutException;
       return;
     }
     foregroundSession = null;
-    if (shouldRunInForeground(false)) {
+    if (startInForegroundRequired) {
       // If we shouldn't show a notification for this session anymore, but there's another session
       // and it wants to stay in foreground, we have to change the foreground service notification
       // to the other session.
@@ -567,6 +790,7 @@ import java.util.concurrent.TimeoutException;
       for (MediaSession candidateSession : sessions) {
         // Just take the first one willing to show a notification, it doesn't matter which one.
         if (shouldShowNotification(candidateSession)) {
+          // Because we are already a foreground service, this should not fail.
           startForeground(candidateSession, checkNotNull(mediaNotifications.get(candidateSession)));
           // When calling startForeground() with a different notification ID, the old notification
           // will be canceled by the system. It's an unfortunate limitation of the API we can't do
@@ -594,6 +818,7 @@ import java.util.concurrent.TimeoutException;
   private static final class ControllerInfo {
 
     public final ListenableFuture<MediaController> controllerFuture;
+    public final Handler backgroundHandler;
 
     /** Indicates whether the user actively dismissed the notification. */
     public boolean wasNotificationDismissed;
@@ -604,8 +829,19 @@ import java.util.concurrent.TimeoutException;
     /** The notification sequence number. */
     public int notificationSequence;
 
-    public ControllerInfo(ListenableFuture<MediaController> controllerFuture) {
+    public ControllerInfo(
+        ListenableFuture<MediaController> controllerFuture,
+        Handler backgroundHandler) {
       this.controllerFuture = controllerFuture;
+      this.backgroundHandler = backgroundHandler;
+    }
+  }
+
+  @RequiresApi(31)
+  /* package */ static final class Api31 {
+    public static boolean instanceOfForegroundServiceStartNotAllowedException(
+        IllegalStateException e) {
+      return e instanceof ForegroundServiceStartNotAllowedException;
     }
   }
 }

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import android.annotation.SuppressLint;
+import android.app.ForegroundServiceStartNotAllowedException;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -32,11 +33,14 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import android.util.Pair;
+import androidx.annotation.GuardedBy;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.concurrent.futures.CallbackToFutureAdapter;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
 import androidx.media3.common.Player;
+import androidx.media3.common.util.BackgroundExecutor;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.NullableType;
 import androidx.media3.common.util.Util;
@@ -47,20 +51,20 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Manages media notifications for a {@link MediaSessionService} and sets the service as
  * foreground/background according to the player state.
- *
- * <p>All methods must be called on the main thread.
  */
 /* package */ final class MediaNotificationManager implements Handler.Callback {
 
@@ -71,28 +75,40 @@ import java.util.concurrent.TimeoutException;
 
   private final MediaSessionService mediaSessionService;
 
+  private final Object lock;
   private final MediaNotification.ActionFactory actionFactory;
   private final NotificationManager notificationManager;
   private final Handler mainHandler;
-  private final Executor mainExecutor;
   private final Intent startSelfIntent;
   private final String startSelfIntentUid;
-  private final Map<MediaSession, ControllerInfo> controllerMap;
+  private final Map<MediaSession, ControllerInfo> controllerMap; // write only on main
+
+  @GuardedBy("#lock")
   private final Map<MediaSession, MediaNotification> mediaNotifications;
 
-  private MediaNotification.Provider mediaNotificationProvider;
+  private volatile MediaNotification.Provider mediaNotificationProvider;
 
   /**
    * The session that provides the notification the foreground service is started with, or null if
    * the service is not in foreground at the moment. Each service can only have one foreground
    * notification, so we have to switch this around as needed if we have multiple sessions.
    */
+  @GuardedBy("#lock")
   private @Nullable MediaSession foregroundSession;
 
+  @GuardedBy("#lock")
   private boolean isUserEngaged;
+
+  @GuardedBy("#lock")
   private boolean isUserEngagedTimeoutEnabled;
+
+  @GuardedBy("#lock")
   private long userEngagedTimeoutMs;
-  @ShowNotificationForIdlePlayerMode int showNotificationForIdlePlayerMode;
+
+  @GuardedBy("#lock")
+  private boolean notificationsEnabled;
+
+  @ShowNotificationForIdlePlayerMode volatile int showNotificationForIdlePlayerMode;
 
   public MediaNotificationManager(
       MediaSessionService mediaSessionService,
@@ -101,18 +117,19 @@ import java.util.concurrent.TimeoutException;
     this.mediaSessionService = mediaSessionService;
     this.mediaNotificationProvider = mediaNotificationProvider;
     this.actionFactory = actionFactory;
+    lock = new Object();
     notificationManager =
         checkNotNull(
             (NotificationManager)
                 mediaSessionService.getSystemService(Context.NOTIFICATION_SERVICE));
     mainHandler = Util.createHandler(Looper.getMainLooper(), /* callback= */ this);
-    mainExecutor = (runnable) -> Util.postOrRun(mainHandler, runnable);
     startSelfIntent = new Intent(mediaSessionService, mediaSessionService.getClass());
     startSelfIntentUid = UUID.randomUUID().toString();
     startSelfIntent.putExtra(SELF_INTENT_UID_KEY, startSelfIntentUid);
     controllerMap = new HashMap<>();
     mediaNotifications = new HashMap<>();
     isUserEngagedTimeoutEnabled = true;
+    notificationsEnabled = true;
     userEngagedTimeoutMs = MediaSessionService.DEFAULT_FOREGROUND_SERVICE_TIMEOUT_MS;
     showNotificationForIdlePlayerMode =
         MediaSessionService.SHOW_NOTIFICATION_FOR_IDLE_PLAYER_AFTER_STOP_OR_ERROR;
@@ -126,6 +143,7 @@ import java.util.concurrent.TimeoutException;
     return startSelfIntentUid;
   }
 
+  // This method will be called on the main thread.
   public void addSession(MediaSession session) {
     if (controllerMap.containsKey(session)) {
       return;
@@ -137,9 +155,11 @@ import java.util.concurrent.TimeoutException;
         new MediaController.Builder(mediaSessionService, session.getToken())
             .setConnectionHints(connectionHints)
             .setListener(listener)
-            .setApplicationLooper(Looper.getMainLooper())
+            .setApplicationLooper(session.getBackgroundLooper())
             .buildAsync();
-    controllerMap.put(session, new ControllerInfo(controllerFuture));
+    Handler backgroundHandler = new Handler(session.getBackgroundLooper());
+    controllerMap.put(
+        session, new ControllerInfo(controllerFuture, backgroundHandler));
     controllerFuture.addListener(
         () -> {
           try {
@@ -154,30 +174,35 @@ import java.util.concurrent.TimeoutException;
             mediaSessionService.removeSession(session);
           }
         },
-        mainExecutor);
+        r -> Util.postOrRun(backgroundHandler, r));
   }
 
+  // This method will be called on the main thread.
   public void removeSession(MediaSession session) {
     @Nullable ControllerInfo controllerInfo = controllerMap.remove(session);
     if (controllerInfo != null) {
       // Update the notification count so that if a pending notification callback arrives (e.g., a
       // bitmap is loaded), we don't show a stale notification.
       controllerInfo.notificationSequence++;
-      MediaController.releaseFuture(controllerInfo.controllerFuture);
+      controllerInfo.backgroundHandler.post(
+          () -> MediaController.releaseFuture(controllerInfo.controllerFuture));
     }
   }
 
+  // This method will be called on the main thread.
   public void onCustomAction(MediaSession session, String action, Bundle extras) {
-    @Nullable MediaController mediaController = getConnectedControllerForSession(session);
-    if (mediaController == null) {
+    @Nullable ControllerInfo controllerInfo = getConnectedControllerInfoForSession(session);
+    if (controllerInfo == null) {
       return;
     }
+    MediaController mediaController = getControllerForControllerInfo(controllerInfo);
     // Let the notification provider handle the command first before forwarding it directly.
     Util.postOrRun(
         session.getImpl().getApplicationHandler(),
         () -> {
           if (!mediaNotificationProvider.handleCustomCommand(session, action, extras)) {
-            mainExecutor.execute(
+            Util.postOrRun(
+                controllerInfo.backgroundHandler,
                 () -> sendCustomCommandIfCommandIsAvailable(mediaController, action, extras));
           }
         });
@@ -185,6 +210,8 @@ import java.util.concurrent.TimeoutException;
 
   /**
    * Updates the media notification provider.
+   *
+   * <p>This method will be called on the main thread.
    *
    * @param mediaNotificationProvider The {@link MediaNotification.Provider}.
    */
@@ -195,69 +222,111 @@ import java.util.concurrent.TimeoutException;
   /**
    * Updates the notification.
    *
+   * <p>This method can be called on any thread.
+   *
    * @param session A session that needs notification update.
    * @param startInForegroundRequired Whether the service is required to start in the foreground.
+   * @return Future is set to false if a {@link ForegroundServiceStartNotAllowedException} prevented
+   *     starting the foreground service, otherwise (even if no start attempted) true.
    */
   public ListenableFuture<@NullableType Void> updateNotification(
       MediaSession session, boolean startInForegroundRequired) {
     return CallbackToFutureAdapter.getFuture(
         completer -> {
-          if (!mediaSessionService.isSessionAdded(session) || !shouldShowNotification(session)) {
-            removeNotification(session);
-            completer.set(null);
-            return "notificationRemoved";
-          }
+          @Nullable ControllerInfo controllerInfo = getConnectedControllerInfoForSession(session);
+          boolean updateStarted = false;
+          if (controllerInfo != null) {
+            updateStarted =
+                Util.postOrRun(
+                    controllerInfo.backgroundHandler,
+                    () -> {
+                      if (!mediaSessionService.isSessionAdded(session) || !shouldShowNotification(
+                          session)) {
+                        removeNotification(session, startInForegroundRequired);
+                        completer.set(null);
+                        return;
+                      }
 
-          ControllerInfo controllerInfo = checkNotNull(controllerMap.get(session));
-          int notificationSequence = ++controllerInfo.notificationSequence;
-          ImmutableList<CommandButton> mediaButtonPreferences =
-              checkNotNull(getConnectedControllerForSession(session)).getMediaButtonPreferences();
-          MediaNotification.Provider.Callback callback =
-              notification ->
-                  mainExecutor.execute(
-                      () ->
-                          onNotificationUpdated(
-                              controllerInfo, notificationSequence, session, notification));
-          Util.postOrRun(
-              session.getImpl().getApplicationHandler(),
-              () -> {
-                try {
-                  MediaNotification mediaNotification =
-                      this.mediaNotificationProvider.createNotification(
-                          session, mediaButtonPreferences, actionFactory, callback);
-                  checkState(
-                      /* expression= */ mediaNotification.notificationId
-                          != SHUTDOWN_NOTIFICATION_ID,
-                      /* errorMessage= */ "notification ID "
-                          + SHUTDOWN_NOTIFICATION_ID
-                          + " is already used internally.");
-                  mainExecutor.execute(
-                      () -> {
-                        try {
-                          updateNotificationInternal(
-                              session, mediaNotification, startInForegroundRequired);
-                          completer.set(null);
-                        } catch (IllegalStateException e) {
-                          // Re-throw exception thrown in the main thread caused by not being
-                          // allowed to start a service into the foreground from the background.
-                          completer.setException(e);
-                        }
-                      });
-                } catch (RuntimeException e) {
-                  // Re-throw exception thrown in the app thread caused by programming errors.
-                  completer.setException(e);
-                }
-              });
+                      int notificationSequence = ++controllerInfo.notificationSequence;
+                      ImmutableList<CommandButton> mediaButtonPreferences =
+                          getControllerForControllerInfo(controllerInfo).getMediaButtonPreferences();
+                      MediaNotification.Provider.Callback callback =
+                          notification ->
+                              Util.postOrRun(
+                                  controllerInfo.backgroundHandler,
+                                  () ->
+                                      onNotificationUpdated(
+                                          controllerInfo, notificationSequence, session, notification));
+                      Util.postOrRun(
+                          session.getImpl().getApplicationHandler(),
+                          () -> {
+                            try {
+                              MediaNotification mediaNotification =
+                                  this.mediaNotificationProvider.createNotification(
+                                      session, mediaButtonPreferences, actionFactory, callback);
+                              checkState(
+                                  /* expression= */ mediaNotification.notificationId
+                                      != SHUTDOWN_NOTIFICATION_ID,
+                                  /* errorMessage= */ "notification ID "
+                                      + SHUTDOWN_NOTIFICATION_ID
+                                      + " is already used internally.");
+                              Util.postOrRun(
+                                  controllerInfo.backgroundHandler,
+                                  () -> {
+                                    try {
+                                      updateNotificationInternal(
+                                          session, mediaNotification, startInForegroundRequired);
+                                      completer.set(null);
+                                    } catch (IllegalStateException e) {
+                                      // Re-throw exception thrown in the main thread caused by not being
+                                      // allowed to start a service into the foreground from the background.
+                                      completer.setException(e);
+                                    }
+                                  });
+                            } catch (RuntimeException e) {
+                              // Re-throw exception thrown in the app thread caused by programming errors.
+                              completer.setException(e);
+                            }
+                          });
+                    });
+          }
+          if (!updateStarted) {
+            postToControllerBackground(
+                controllerInfo,
+                session,
+                () -> {
+                  removeNotification(session, startInForegroundRequired);
+                  completer.set(null);
+                });
+          }
           return "notificationUpdated";
         });
   }
 
-  public boolean isStartedInForeground() {
-    return foregroundSession != null;
+  private void postToControllerBackground(
+      @Nullable ControllerInfo controllerInfo, MediaSession session, Runnable r) {
+    @Nullable Handler bgHandler = controllerInfo != null ? controllerInfo.backgroundHandler : null;
+    if (bgHandler == null) {
+      bgHandler = new Handler(session.getBackgroundLooper());
+    }
+    if (!bgHandler.post(r)) {
+      // If we end up here, the thread already quit. We should use another thread as stand-in.
+      BackgroundExecutor.get().execute(r);
+    }
   }
 
+  // This method can be called on any thread.
+  public boolean isStartedInForeground() {
+    synchronized (lock) {
+      return foregroundSession != null;
+    }
+  }
+
+  // This method will be called on the main thread.
   public void setUserEngagedTimeoutMs(long userEngagedTimeoutMs) {
-    this.userEngagedTimeoutMs = userEngagedTimeoutMs;
+    synchronized (lock) {
+      this.userEngagedTimeoutMs = userEngagedTimeoutMs;
+    }
   }
 
   public void setShowNotificationForIdlePlayer(
@@ -283,39 +352,101 @@ import java.util.concurrent.TimeoutException;
     return false;
   }
 
-  /* package */ boolean shouldRunInForeground(boolean startInForegroundWhenPaused) {
-    boolean isUserEngaged = isAnySessionUserEngaged(startInForegroundWhenPaused);
-    boolean useTimeout = isUserEngagedTimeoutEnabled && userEngagedTimeoutMs > 0;
-    if (this.isUserEngaged && !isUserEngaged && useTimeout) {
-      mainHandler.sendEmptyMessageDelayed(MSG_USER_ENGAGED_TIMEOUT, userEngagedTimeoutMs);
-    } else if (isUserEngaged) {
-      mainHandler.removeMessages(MSG_USER_ENGAGED_TIMEOUT);
-    }
-    this.isUserEngaged = isUserEngaged;
-    boolean hasPendingTimeout = mainHandler.hasMessages(MSG_USER_ENGAGED_TIMEOUT);
-    return isUserEngaged || hasPendingTimeout;
+  // This method can be called on any thread.
+  /* package */ ListenableFuture<Boolean> shouldRunInForeground(
+      boolean startInForegroundWhenPaused) {
+    SettableFuture<Boolean> completion = SettableFuture.create();
+    ListenableFuture<Boolean> isUserEngagedFuture =
+        isAnySessionUserEngaged(startInForegroundWhenPaused);
+    isUserEngagedFuture.addListener(
+        () -> {
+          boolean isUserEngaged;
+          try {
+            isUserEngaged = isUserEngagedFuture.get();
+          } catch (ExecutionException | InterruptedException e) {
+            throw new IllegalStateException(e);
+          }
+          synchronized (lock) {
+            boolean useTimeout = isUserEngagedTimeoutEnabled && userEngagedTimeoutMs > 0;
+            if (this.isUserEngaged && !isUserEngaged && useTimeout) {
+              mainHandler.sendEmptyMessageDelayed(MSG_USER_ENGAGED_TIMEOUT, userEngagedTimeoutMs);
+            } else if (isUserEngaged) {
+              mainHandler.removeMessages(MSG_USER_ENGAGED_TIMEOUT);
+            }
+            this.isUserEngaged = isUserEngaged;
+          }
+          boolean hasPendingTimeout = mainHandler.hasMessages(MSG_USER_ENGAGED_TIMEOUT);
+          completion.set(isUserEngaged || hasPendingTimeout);
+        },
+        MoreExecutors.directExecutor());
+    return completion;
   }
 
-  private boolean isAnySessionUserEngaged(boolean startInForegroundWhenPaused) {
+  // This method can be called on any thread.
+  private ListenableFuture<Boolean> isAnySessionUserEngaged(boolean startInForegroundWhenPaused) {
     List<MediaSession> sessions = mediaSessionService.getSessions();
-    for (int i = 0; i < sessions.size(); i++) {
-      @Nullable MediaController controller = getConnectedControllerForSession(sessions.get(i));
-      if (controller != null
-          && (controller.getPlayWhenReady() || startInForegroundWhenPaused)
-          && (controller.getPlaybackState() == Player.STATE_READY
-              || controller.getPlaybackState() == Player.STATE_BUFFERING)) {
-        return true;
+    synchronized (lock) {
+      if (!notificationsEnabled || sessions.isEmpty()) {
+        return Futures.immediateFuture(false);
       }
     }
-    return false;
+    SettableFuture<Boolean> outputFuture = SettableFuture.create();
+    List<@NullableType ListenableFuture<Boolean>> sessionFutures = new ArrayList<>();
+    final AtomicInteger resultCount = new AtomicInteger(0);
+    Runnable handleSessionFuturesTask =
+        () -> {
+          int completedSessionFutureCount = resultCount.incrementAndGet();
+          if (completedSessionFutureCount == sessions.size()) {
+            boolean value = false;
+            for (@NullableType ListenableFuture<Boolean> future : sessionFutures) {
+              if (future != null) {
+                try {
+                  value = future.get();
+                } catch (ExecutionException | InterruptedException e) {
+                  throw new RuntimeException(e);
+                }
+                if (value) {
+                  break;
+                }
+              }
+            }
+            outputFuture.set(value);
+          }
+        };
+
+    for (int i = 0; i < sessions.size(); i++) {
+      MediaSession session = sessions.get(i);
+      @Nullable ControllerInfo controllerInfo = getConnectedControllerInfoForSession(session);
+      if (controllerInfo != null) {
+        MediaController controller = getControllerForControllerInfo(controllerInfo);
+        SettableFuture<Boolean> completion = SettableFuture.create();
+        Util.postOrRun(
+            controllerInfo.backgroundHandler,
+            () ->
+                completion.set(
+                    (controller.getPlayWhenReady() || startInForegroundWhenPaused)
+                        && (controller.getPlaybackState() == Player.STATE_READY
+                            || controller.getPlaybackState() == Player.STATE_BUFFERING)));
+        sessionFutures.add(completion);
+        completion.addListener(handleSessionFuturesTask, MoreExecutors.directExecutor());
+      } else {
+        sessionFutures.add(null);
+        handleSessionFuturesTask.run();
+      }
+    }
+    return outputFuture;
   }
 
   /**
    * Permanently disable the user engaged timeout, which is needed to immediately stop the
    * foreground service.
+   *
+   * <p>This method will be called on the main thread.
    */
   /* package */ void disableUserEngagedTimeout() {
-    isUserEngagedTimeoutEnabled = false;
+    synchronized (lock) {
+      isUserEngagedTimeoutEnabled = false;
+    }
     if (mainHandler.hasMessages(MSG_USER_ENGAGED_TIMEOUT)) {
       mainHandler.removeMessages(MSG_USER_ENGAGED_TIMEOUT);
       List<MediaSession> sessions = mediaSessionService.getSessions();
@@ -326,18 +457,50 @@ import java.util.concurrent.TimeoutException;
     }
   }
 
+  /**
+   * Permanently disable both the user engaged timeout and posting new notifications, immediately
+   * stop the foreground service and cancel all media notifications.
+   *
+   * <p>This method will be called on the main thread.
+   */
+  /* package */ void stopForegroundServiceAndDisableNotifications() {
+    synchronized (lock) {
+      isUserEngagedTimeoutEnabled = false;
+      notificationsEnabled = false;
+      if (mainHandler.hasMessages(MSG_USER_ENGAGED_TIMEOUT)) {
+        mainHandler.removeMessages(MSG_USER_ENGAGED_TIMEOUT);
+      }
+      List<MediaSession> sessions = mediaSessionService.getSessions();
+      for (int i = 0; i < sessions.size(); i++) {
+        removeNotification(sessions.get(i), false);
+      }
+    }
+  }
+
+  // Will be called on controller's application thread.
   private void onNotificationUpdated(
       ControllerInfo controllerInfo,
       int notificationSequence,
       MediaSession session,
       MediaNotification mediaNotification) {
     if (controllerInfo.notificationSequence == notificationSequence) {
-      boolean startInForegroundRequired =
+      ListenableFuture<Boolean> startInForegroundRequiredFuture =
           shouldRunInForeground(/* startInForegroundWhenPaused= */ false);
-      updateNotificationInternal(session, mediaNotification, startInForegroundRequired);
+      startInForegroundRequiredFuture.addListener(
+          () -> {
+            boolean startInForegroundRequired;
+            try {
+              startInForegroundRequired = startInForegroundRequiredFuture.get();
+            } catch (ExecutionException | InterruptedException e) {
+              throw new RuntimeException(e);
+            }
+            updateNotificationInternal(session, mediaNotification, startInForegroundRequired);
+          },
+          r -> Util.postOrRun(controllerInfo.backgroundHandler, r));
     }
   }
 
+  // Will be called on controller's application thread.
   private void onNotificationDismissed(MediaSession session) {
     @Nullable ControllerInfo controllerInfo = controllerMap.get(session);
     if (controllerInfo != null) {
@@ -345,49 +508,69 @@ import java.util.concurrent.TimeoutException;
     }
   }
 
-  private void updateNotificationInternal(
+  // Will be called on controller's application thread.
+  private boolean updateNotificationInternal(
       MediaSession session,
       MediaNotification mediaNotification,
       boolean startInForegroundRequired) {
     // Call Notification.MediaStyle#setMediaSession() indirectly.
     Token fwkToken = session.getPlatformToken();
     mediaNotification.notification.extras.putParcelable(Notification.EXTRA_MEDIA_SESSION, fwkToken);
-    this.mediaNotifications.put(session, mediaNotification);
-    if (startInForegroundRequired) {
-      startForeground(session, mediaNotification);
-    } else {
-      // Notification manager has to be updated first to avoid missing updates
-      // (https://github.com/androidx/media/issues/192).
-      notify(mediaNotification);
-      stopForeground(session, /* removeNotifications= */ false);
-    }
-  }
-
-  /** Removes the notification and stops the foreground service if running. */
-  private void removeNotification(MediaSession session) {
-    // To hide the notification on all API levels, we need to call both Service.stopForeground(true)
-    // and notificationManagerCompat.cancel(notificationId).
-    stopForeground(session, /* removeNotifications= */ true);
-    @Nullable MediaNotification mediaNotification = mediaNotifications.remove(session);
-    if (mediaNotification != null) {
-      notificationManager.cancel(mediaNotification.notificationId);
-      // Update the notification count so that if a pending notification callback arrives (e.g., a
-      // bitmap is loaded), we don't show the notification.
-      @Nullable ControllerInfo controllerInfo = controllerMap.get(session);
-      // If the controllerInfo is already removed from the map, removeSession() has increased the
-      // sequence, so it's fine.
-      if (controllerInfo != null) {
-        controllerInfo.notificationSequence++;
+    synchronized (lock) {
+      if (!notificationsEnabled) {
+        return true;
+      }
+      this.mediaNotifications.put(session, mediaNotification);
+      if (startInForegroundRequired) {
+        return startForeground(session, mediaNotification);
+      } else {
+        // Notification manager has to be updated first to avoid missing updates
+        // (https://github.com/androidx/media/issues/192).
+        notify(mediaNotification);
+        stopForeground(session, /* removeNotifications= */ false, false);
+        return true;
       }
     }
   }
 
+  /** Removes the notification and stops the foreground service if running. */
+  // Can be called on any thread.
+  private void removeNotification(MediaSession session, boolean startInForegroundRequired) {
+    synchronized (lock) {
+      // To hide the notification on all API levels, we need to call both
+      // Service.stopForeground(true)
+      // and notificationManagerCompat.cancel(notificationId).
+      stopForeground(session, /* removeNotifications= */ true, startInForegroundRequired);
+      @Nullable MediaNotification mediaNotification = mediaNotifications.remove(session);
+      if (mediaNotification != null) {
+        notificationManager.cancel(mediaNotification.notificationId);
+        @Nullable ControllerInfo controllerInfo = controllerMap.get(session);
+        // If the controllerInfo is already removed from the map, removeSession() has increased the
+        // sequence, so it's fine.
+        if (controllerInfo != null) {
+          // Update the notification count so that if a pending notification callback arrives (e.g.,
+          // a bitmap is loaded), we don't show the notification.
+          controllerInfo.notificationSequence++;
+        }
+      }
+    }
+  }
+
+  // Will be called on controller's application thread.
   private boolean shouldShowNotification(MediaSession session) {
-    MediaController controller = getConnectedControllerForSession(session);
-    if (controller == null || controller.getCurrentTimeline().isEmpty()) {
+    synchronized (lock) {
+      if (!notificationsEnabled) {
+        return false;
+      }
+    }
+    ControllerInfo controllerInfo = getConnectedControllerInfoForSession(session);
+    if (controllerInfo == null) {
       return false;
     }
-    ControllerInfo controllerInfo = checkNotNull(controllerMap.get(session));
+    MediaController controller = getControllerForControllerInfo(controllerInfo);
+    if (controller.getCurrentTimeline().isEmpty()) {
+      return false;
+    }
     if (controller.getPlaybackState() != Player.STATE_IDLE) {
       // Playback first prepared or restarted, reset previous notification dismissed flag.
       controllerInfo.wasNotificationDismissed = false;
@@ -407,10 +590,18 @@ import java.util.concurrent.TimeoutException;
   }
 
   @Nullable
-  private MediaController getConnectedControllerForSession(MediaSession session) {
+  private ControllerInfo getConnectedControllerInfoForSession(MediaSession session) {
     @Nullable ControllerInfo controllerInfo = controllerMap.get(session);
     if (controllerInfo == null || !controllerInfo.controllerFuture.isDone()) {
       return null;
+    }
+    return controllerInfo;
+  }
+
+  private static MediaController getControllerForControllerInfo(ControllerInfo controllerInfo) {
+    if (!controllerInfo.controllerFuture.isDone()) {
+      // This is checked in getConnectedControllerInfoForSession() already, so can't happen.
+      throw new IllegalArgumentException("controllerInfo is not done");
     }
     try {
       return Futures.getDone(controllerInfo.controllerFuture);
@@ -420,6 +611,7 @@ import java.util.concurrent.TimeoutException;
     }
   }
 
+  // Will be called on controller's application thread.
   private void sendCustomCommandIfCommandIsAvailable(
       MediaController mediaController, String action, Bundle extras) {
     @Nullable SessionCommand customCommand = null;
@@ -488,6 +680,13 @@ import java.util.concurrent.TimeoutException;
     }
 
     @Override
+    public void onMediaButtonPreferencesChanged(
+        MediaController controller, List<CommandButton> mediaButtonPreferences) {
+      mediaSessionService.onUpdateNotificationInternal(
+          session, /* startInForegroundWhenPaused= */ false);
+    }
+
+    @Override
     public ListenableFuture<SessionResult> onCustomCommand(
         MediaController controller, SessionCommand command, Bundle args) {
       @SessionResult.Code int resultCode = SessionError.ERROR_NOT_SUPPORTED;
@@ -507,10 +706,24 @@ import java.util.concurrent.TimeoutException;
       mediaSessionService.onUpdateNotificationInternal(
           session, /* startInForegroundWhenPaused= */ false);
     }
+
+    @Override
+    public void onEvents(Player player, Player.Events events) {
+      // We must limit the frequency of notification updates, otherwise the system may suppress
+      // them. (Note: EVENT_TIMELINE_CHANGED is handled in MediaSessionLegacyStub)
+      if (events.containsAny(
+          Player.EVENT_PLAYBACK_STATE_CHANGED,
+          Player.EVENT_PLAY_WHEN_READY_CHANGED,
+          Player.EVENT_MEDIA_METADATA_CHANGED)) {
+        mediaSessionService.onUpdateNotificationInternal(
+            session, /* startInForegroundWhenPaused= */ false);
+      }
+    }
   }
 
+  @GuardedBy("#lock")
   @SuppressLint("InlinedApi") // Using compile time constant FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
-  private void startForeground(MediaSession session, MediaNotification newMediaNotification) {
+  private boolean startForeground(MediaSession session, MediaNotification newMediaNotification) {
     MediaNotification mediaNotification;
     boolean hasOtherForegroundSession;
     if (foregroundSession != null && foregroundSession != session) {
@@ -524,24 +737,35 @@ import java.util.concurrent.TimeoutException;
       hasOtherForegroundSession = true;
     } else {
       mediaNotification = newMediaNotification;
-      foregroundSession = session;
       hasOtherForegroundSession = false;
     }
-    ContextCompat.startForegroundService(mediaSessionService, startSelfIntent);
-    Util.setForegroundServiceNotification(
-        mediaSessionService,
-        mediaNotification.notificationId,
-        mediaNotification.notification,
-        ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
-        "mediaPlayback");
+    try {
+      ContextCompat.startForegroundService(mediaSessionService, startSelfIntent);
+      Util.setForegroundServiceNotification(
+          mediaSessionService,
+          mediaNotification.notificationId,
+          mediaNotification.notification,
+          ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
+          "mediaPlayback");
+    } catch (IllegalStateException e) {
+      if (SDK_INT >= 31 && Api31.instanceOfForegroundServiceStartNotAllowedException(e)) {
+        Log.e(TAG, "Failed to start foreground", e);
+        return false;
+      }
+    }
     if (hasOtherForegroundSession) {
       // startForeground() normally does this, but as we passed another notification to it, we have
       // to do it manually here.
       notify(newMediaNotification);
+    } else {
+      foregroundSession = session;
     }
+    return true;
   }
 
-  private void stopForeground(MediaSession session, boolean removeNotifications) {
+  @GuardedBy("#lock")
+  private void stopForeground(
+      MediaSession session, boolean removeNotifications, boolean startInForegroundRequired) {
     if (foregroundSession != session) {
       // This happens if there is another session in foreground since before this session wanted to
       // go in the foreground. As this other session still wants to be in the foreground, we don't
@@ -550,7 +774,7 @@ import java.util.concurrent.TimeoutException;
       return;
     }
     foregroundSession = null;
-    if (shouldRunInForeground(false)) {
+    if (startInForegroundRequired) {
       // If we shouldn't show a notification for this session anymore, but there's another session
       // and it wants to stay in foreground, we have to change the foreground service notification
       // to the other session.
@@ -558,6 +782,7 @@ import java.util.concurrent.TimeoutException;
       for (MediaSession candidateSession : sessions) {
         // Just take the first one willing to show a notification, it doesn't matter which one.
         if (shouldShowNotification(candidateSession)) {
+          // Because we are already a foreground service, this should not fail.
           startForeground(candidateSession, checkNotNull(mediaNotifications.get(candidateSession)));
           // When calling startForeground() with a different notification ID, the old notification
           // will be canceled by the system. It's an unfortunate limitation of the API we can't do
@@ -585,6 +810,7 @@ import java.util.concurrent.TimeoutException;
   private static final class ControllerInfo {
 
     public final ListenableFuture<MediaController> controllerFuture;
+    public final Handler backgroundHandler;
 
     /** Indicates whether the user actively dismissed the notification. */
     public boolean wasNotificationDismissed;
@@ -595,8 +821,19 @@ import java.util.concurrent.TimeoutException;
     /** The notification sequence number. */
     public int notificationSequence;
 
-    public ControllerInfo(ListenableFuture<MediaController> controllerFuture) {
+    public ControllerInfo(
+        ListenableFuture<MediaController> controllerFuture,
+        Handler backgroundHandler) {
       this.controllerFuture = controllerFuture;
+      this.backgroundHandler = backgroundHandler;
+    }
+  }
+
+  @RequiresApi(31)
+  /* package */ static final class Api31 {
+    public static boolean instanceOfForegroundServiceStartNotAllowedException(
+        IllegalStateException e) {
+      return e instanceof ForegroundServiceStartNotAllowedException;
     }
   }
 }

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -155,9 +155,9 @@ import java.util.concurrent.atomic.AtomicInteger;
         new MediaController.Builder(mediaSessionService, session.getToken())
             .setConnectionHints(connectionHints)
             .setListener(listener)
-            .setApplicationLooper(session.getBackgroundLooper())
+            .setApplicationLooper(checkNotNull(session.getBackgroundLooper()))
             .buildAsync();
-    Handler backgroundHandler = new Handler(session.getBackgroundLooper());
+    Handler backgroundHandler = new Handler(checkNotNull(session.getBackgroundLooper()));
     controllerMap.put(
         session, new ControllerInfo(controllerFuture, backgroundHandler));
     controllerFuture.addListener(
@@ -307,9 +307,12 @@ import java.util.concurrent.atomic.AtomicInteger;
       @Nullable ControllerInfo controllerInfo, MediaSession session, Runnable r) {
     @Nullable Handler bgHandler = controllerInfo != null ? controllerInfo.backgroundHandler : null;
     if (bgHandler == null) {
-      bgHandler = new Handler(session.getBackgroundLooper());
+      @Nullable Looper bgLooper = session.getBackgroundLooper();
+      if (bgLooper != null) {
+        bgHandler = new Handler(bgLooper);
+      }
     }
-    if (!bgHandler.post(r)) {
+    if (bgHandler == null || !bgHandler.post(r)) {
       // If we end up here, the thread already quit. We should use another thread as stand-in.
       BackgroundExecutor.get().execute(r);
     }

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -848,7 +848,7 @@ import java.util.concurrent.atomic.AtomicInteger;
   }
 
   @RequiresApi(31)
-  /* package */ static final class Api31 {
+  private static final class Api31 {
     public static boolean instanceOfForegroundServiceStartNotAllowedException(
         IllegalStateException e) {
       return e instanceof ForegroundServiceStartNotAllowedException;

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -90,11 +90,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 
   /**
    * The session that provides the notification the foreground service is started with, or null if
-   * the service is not in foreground at the moment. Each service can only have one foreground
-   * notification, so we have to switch this around as needed if we have multiple sessions.
+   * the service is not in foreground at the moment. Each service must have exactly one foreground
+   * service notification as long as it is in foreground, so we have to switch this around as needed
+   * if we have multiple sessions.
    */
   @GuardedBy("#lock")
-  private @Nullable MediaSession foregroundSession;
+  private @Nullable MediaSession foregroundNotificationSession;
 
   @GuardedBy("#lock")
   private boolean isUserEngaged;
@@ -321,7 +322,7 @@ import java.util.concurrent.atomic.AtomicInteger;
   // This method can be called on any thread.
   public boolean isStartedInForeground() {
     synchronized (lock) {
-      return foregroundSession != null;
+      return foregroundNotificationSession != null;
     }
   }
 
@@ -743,14 +744,14 @@ import java.util.concurrent.atomic.AtomicInteger;
   private boolean startForeground(MediaSession session, MediaNotification newMediaNotification) {
     MediaNotification mediaNotification;
     boolean hasOtherForegroundSession;
-    if (foregroundSession != null && foregroundSession != session) {
-      // If we would use the newly updated notification, the old foreground session's notification
+    if (foregroundNotificationSession != null && foregroundNotificationSession != session) {
+      // If we used the newly updated notification, the old foreground session's notification
       // would be canceled by the system because the service switched to another foreground service
       // notification. However, we don't want to cancel it, so we just keep using the old session's
       // notification as long as we can, and post our new notification as normal notification.
       // We still need to call startForeground() in any case to avoid
       // ForegroundServiceDidNotStartInTimeException.
-      mediaNotification = checkNotNull(mediaNotifications.get(foregroundSession));
+      mediaNotification = checkNotNull(mediaNotifications.get(foregroundNotificationSession));
       hasOtherForegroundSession = true;
     } else {
       mediaNotification = newMediaNotification;
@@ -772,11 +773,11 @@ import java.util.concurrent.atomic.AtomicInteger;
       throw e;
     }
     if (hasOtherForegroundSession) {
-      // startForeground() normally does this, but as we passed another notification to it, we have
-      // to do it manually here.
+      // startForeground() does this, but because we passed another notification to it, we have to
+      // do it manually here.
       notify(newMediaNotification);
     } else {
-      foregroundSession = session;
+      foregroundNotificationSession = session;
     }
     return true;
   }
@@ -784,18 +785,33 @@ import java.util.concurrent.atomic.AtomicInteger;
   @GuardedBy("#lock")
   private void stopForeground(
       MediaSession session, boolean removeNotifications, boolean startInForegroundRequired) {
-    if (foregroundSession != session) {
-      // This happens if there is another session in foreground since before this session wanted to
-      // go in the foreground. As this other session still wants to be in the foreground, we don't
-      // need to stop the foreground service. cancel() will be called by the caller if
-      // removeNotifications is true, so we don't need to do anything here.
-      return;
-    }
-    foregroundSession = null;
     if (startInForegroundRequired) {
-      // If we shouldn't show a notification for this session anymore, but there's another session
-      // and it wants to stay in foreground, we have to change the foreground service notification
-      // to the other session.
+      // There is another session that wants to stay in the foreground, so we won't need to stop the
+      // foreground service. The only question is whether we change the notification used by the
+      // foreground service or not.
+      if (foregroundNotificationSession != session) {
+        // The foreground service notification is provided by another session, so we don't need to
+        // do anything here.
+        return;
+      }
+      if (!removeNotifications) {
+        // We want to keep this session's notification, but the session doesn't need foreground
+        // service anymore. We have two options:
+        // 1. Call startForeground() on another session to cancel this session's notification (not
+        //    desired) and change the service notification (desired), or
+        // 2. Do nothing.
+        // Because the user will notice if the notification dis- and reappears, we will do nothing
+        // here. It's okay to provide the foreground service notification from a session which
+        // doesn't want to be in foreground because which notification allows this service to stay
+        // in foreground is not displayed to the user. Hence, we don't need to do anything.
+        return;
+      }
+    }
+    foregroundNotificationSession = null;
+    if (startInForegroundRequired) {
+      // We shouldn't show a notification for this session anymore and hence must remove the current
+      // foreground service notification, but there's another session which wants to stay in
+      // foreground. We'll have to change the foreground service notification to the other session.
       List<MediaSession> sessions = mediaSessionService.getSessions();
       for (MediaSession candidateSession : sessions) {
         // Just take the first one willing to show a notification, it doesn't matter which one.
@@ -803,12 +819,8 @@ import java.util.concurrent.atomic.AtomicInteger;
           // Because we are already a foreground service, this should not fail.
           startForeground(candidateSession, checkNotNull(mediaNotifications.get(candidateSession)));
           // When calling startForeground() with a different notification ID, the old notification
-          // will be canceled by the system. It's an unfortunate limitation of the API we can't do
-          // anything about. Hence, if removeNotifications is false, we have to send the
-          // notification out again using notify() as we didn't want it to be canceled.
-          if (!removeNotifications) {
-            notify(checkNotNull(mediaNotifications.get(session)));
-          }
+          // will be canceled by the system, so we are done. (Even if that doesn't work, the caller
+          // will call cancel() to make sure the notification is removed.)
           return;
         }
       }

--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -78,11 +78,17 @@ import java.util.concurrent.TimeoutException;
   private final Intent startSelfIntent;
   private final String startSelfIntentUid;
   private final Map<MediaSession, ControllerInfo> controllerMap;
+  private final Map<MediaSession, MediaNotification> mediaNotifications;
 
   private MediaNotification.Provider mediaNotificationProvider;
-  private int totalNotificationCount;
-  @Nullable private MediaNotification mediaNotification;
-  private boolean startedInForeground;
+
+  /**
+   * The session that provides the notification the foreground service is started with, or null if
+   * the service is not in foreground at the moment. Each service can only have one foreground
+   * notification, so we have to switch this around as needed if we have multiple sessions.
+   */
+  private @Nullable MediaSession foregroundSession;
+
   private boolean isUserEngaged;
   private boolean isUserEngagedTimeoutEnabled;
   private long userEngagedTimeoutMs;
@@ -105,7 +111,7 @@ import java.util.concurrent.TimeoutException;
     startSelfIntentUid = UUID.randomUUID().toString();
     startSelfIntent.putExtra(SELF_INTENT_UID_KEY, startSelfIntentUid);
     controllerMap = new HashMap<>();
-    startedInForeground = false;
+    mediaNotifications = new HashMap<>();
     isUserEngagedTimeoutEnabled = true;
     userEngagedTimeoutMs = MediaSessionService.DEFAULT_FOREGROUND_SERVICE_TIMEOUT_MS;
     showNotificationForIdlePlayerMode =
@@ -154,6 +160,9 @@ import java.util.concurrent.TimeoutException;
   public void removeSession(MediaSession session) {
     @Nullable ControllerInfo controllerInfo = controllerMap.remove(session);
     if (controllerInfo != null) {
+      // Update the notification count so that if a pending notification callback arrives (e.g., a
+      // bitmap is loaded), we don't show a stale notification.
+      controllerInfo.notificationSequence++;
       MediaController.releaseFuture(controllerInfo.controllerFuture);
     }
   }
@@ -194,18 +203,21 @@ import java.util.concurrent.TimeoutException;
     return CallbackToFutureAdapter.getFuture(
         completer -> {
           if (!mediaSessionService.isSessionAdded(session) || !shouldShowNotification(session)) {
-            removeNotification();
+            removeNotification(session);
             completer.set(null);
             return "notificationRemoved";
           }
-          int notificationSequence = ++totalNotificationCount;
+
+          ControllerInfo controllerInfo = checkNotNull(controllerMap.get(session));
+          int notificationSequence = ++controllerInfo.notificationSequence;
           ImmutableList<CommandButton> mediaButtonPreferences =
               checkNotNull(getConnectedControllerForSession(session)).getMediaButtonPreferences();
           MediaNotification.Provider.Callback callback =
               notification ->
                   mainExecutor.execute(
-                      () -> onNotificationUpdated(notificationSequence, session, notification));
-
+                      () ->
+                          onNotificationUpdated(
+                              controllerInfo, notificationSequence, session, notification));
           Util.postOrRun(
               session.getImpl().getApplicationHandler(),
               () -> {
@@ -241,7 +253,7 @@ import java.util.concurrent.TimeoutException;
   }
 
   public boolean isStartedInForeground() {
-    return startedInForeground;
+    return foregroundSession != null;
   }
 
   public void setUserEngagedTimeoutMs(long userEngagedTimeoutMs) {
@@ -315,8 +327,11 @@ import java.util.concurrent.TimeoutException;
   }
 
   private void onNotificationUpdated(
-      int notificationSequence, MediaSession session, MediaNotification mediaNotification) {
-    if (notificationSequence == totalNotificationCount) {
+      ControllerInfo controllerInfo,
+      int notificationSequence,
+      MediaSession session,
+      MediaNotification mediaNotification) {
+    if (controllerInfo.notificationSequence == notificationSequence) {
       boolean startInForegroundRequired =
           shouldRunInForeground(/* startInForegroundWhenPaused= */ false);
       updateNotificationInternal(session, mediaNotification, startInForegroundRequired);
@@ -330,9 +345,6 @@ import java.util.concurrent.TimeoutException;
     }
   }
 
-  // POST_NOTIFICATIONS permission is not required for media session related notifications.
-  // https://developer.android.com/develop/ui/views/notifications/notification-permission#exemptions-media-sessions
-  @SuppressLint("MissingPermission")
   private void updateNotificationInternal(
       MediaSession session,
       MediaNotification mediaNotification,
@@ -340,28 +352,33 @@ import java.util.concurrent.TimeoutException;
     // Call Notification.MediaStyle#setMediaSession() indirectly.
     Token fwkToken = session.getPlatformToken();
     mediaNotification.notification.extras.putParcelable(Notification.EXTRA_MEDIA_SESSION, fwkToken);
-    this.mediaNotification = mediaNotification;
+    this.mediaNotifications.put(session, mediaNotification);
     if (startInForegroundRequired) {
-      startForeground(mediaNotification);
+      startForeground(session, mediaNotification);
     } else {
       // Notification manager has to be updated first to avoid missing updates
       // (https://github.com/androidx/media/issues/192).
-      notificationManager.notify(mediaNotification.notificationId, mediaNotification.notification);
-      Util.stopForeground(mediaSessionService, /* removeNotification= */ false);
+      notify(mediaNotification);
+      stopForeground(session, /* removeNotifications= */ false);
     }
   }
 
   /** Removes the notification and stops the foreground service if running. */
-  private void removeNotification() {
+  private void removeNotification(MediaSession session) {
     // To hide the notification on all API levels, we need to call both Service.stopForeground(true)
     // and notificationManagerCompat.cancel(notificationId).
-    Util.stopForeground(mediaSessionService, /* removeNotification= */ true);
+    stopForeground(session, /* removeNotifications= */ true);
+    @Nullable MediaNotification mediaNotification = mediaNotifications.remove(session);
     if (mediaNotification != null) {
       notificationManager.cancel(mediaNotification.notificationId);
       // Update the notification count so that if a pending notification callback arrives (e.g., a
       // bitmap is loaded), we don't show the notification.
-      totalNotificationCount++;
-      mediaNotification = null;
+      @Nullable ControllerInfo controllerInfo = controllerMap.get(session);
+      // If the controllerInfo is already removed from the map, removeSession() has increased the
+      // sequence, so it's fine.
+      if (controllerInfo != null) {
+        controllerInfo.notificationSequence++;
+      }
     }
   }
 
@@ -493,7 +510,23 @@ import java.util.concurrent.TimeoutException;
   }
 
   @SuppressLint("InlinedApi") // Using compile time constant FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
-  private void startForeground(MediaNotification mediaNotification) {
+  private void startForeground(MediaSession session, MediaNotification newMediaNotification) {
+    MediaNotification mediaNotification;
+    boolean hasOtherForegroundSession;
+    if (foregroundSession != null && foregroundSession != session) {
+      // If we would use the newly updated notification, the old foreground session's notification
+      // would be canceled by the system because the service switched to another foreground service
+      // notification. However, we don't want to cancel it, so we just keep using the old session's
+      // notification as long as we can, and post our new notification as normal notification.
+      // We still need to call startForeground() in any case to avoid
+      // ForegroundServiceDidNotStartInTimeException.
+      mediaNotification = checkNotNull(mediaNotifications.get(foregroundSession));
+      hasOtherForegroundSession = true;
+    } else {
+      mediaNotification = newMediaNotification;
+      foregroundSession = session;
+      hasOtherForegroundSession = false;
+    }
     ContextCompat.startForegroundService(mediaSessionService, startSelfIntent);
     Util.setForegroundServiceNotification(
         mediaSessionService,
@@ -501,7 +534,52 @@ import java.util.concurrent.TimeoutException;
         mediaNotification.notification,
         ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK,
         "mediaPlayback");
-    startedInForeground = true;
+    if (hasOtherForegroundSession) {
+      // startForeground() normally does this, but as we passed another notification to it, we have
+      // to do it manually here.
+      notify(newMediaNotification);
+    }
+  }
+
+  private void stopForeground(MediaSession session, boolean removeNotifications) {
+    if (foregroundSession != session) {
+      // This happens if there is another session in foreground since before this session wanted to
+      // go in the foreground. As this other session still wants to be in the foreground, we don't
+      // need to stop the foreground service. cancel() will be called by the caller if
+      // removeNotifications is true, so we don't need to do anything here.
+      return;
+    }
+    foregroundSession = null;
+    if (shouldRunInForeground(false)) {
+      // If we shouldn't show a notification for this session anymore, but there's another session
+      // and it wants to stay in foreground, we have to change the foreground service notification
+      // to the other session.
+      List<MediaSession> sessions = mediaSessionService.getSessions();
+      for (MediaSession candidateSession : sessions) {
+        // Just take the first one willing to show a notification, it doesn't matter which one.
+        if (shouldShowNotification(candidateSession)) {
+          startForeground(candidateSession, checkNotNull(mediaNotifications.get(candidateSession)));
+          // When calling startForeground() with a different notification ID, the old notification
+          // will be canceled by the system. It's an unfortunate limitation of the API we can't do
+          // anything about. Hence, if removeNotifications is false, we have to send the
+          // notification out again using notify() as we didn't want it to be canceled.
+          if (!removeNotifications) {
+            notify(checkNotNull(mediaNotifications.get(session)));
+          }
+          return;
+        }
+      }
+    }
+    // Either we don't have any notification left, or we don't want to stay in foreground. It's
+    // time to stop the foreground service.
+    Util.stopForeground(mediaSessionService, removeNotifications);
+  }
+
+  // POST_NOTIFICATIONS permission is not required for media session related notifications.
+  // https://developer.android.com/develop/ui/views/notifications/notification-permission#exemptions-media-sessions
+  @SuppressLint("MissingPermission")
+  private void notify(MediaNotification notification) {
+    notificationManager.notify(notification.notificationId, notification.notification);
   }
 
   private static final class ControllerInfo {
@@ -513,6 +591,9 @@ import java.util.concurrent.TimeoutException;
 
     /** Indicated whether the player has ever been prepared. */
     public boolean hasBeenPrepared;
+
+    /** The notification sequence number. */
+    public int notificationSequence;
 
     public ControllerInfo(ListenableFuture<MediaController> controllerFuture) {
       this.controllerFuture = controllerFuture;

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSession.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSession.java
@@ -1598,7 +1598,7 @@ public class MediaSession {
     return deprecatedDefaultConnectionResult;
   }
 
-  /* package */ final Looper getBackgroundLooper() {
+  /* package */ @Nullable final Looper getBackgroundLooper() {
     return impl.getBackgroundLooper();
   }
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSession.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSession.java
@@ -1598,6 +1598,10 @@ public class MediaSession {
     return deprecatedDefaultConnectionResult;
   }
 
+  /* package */ final Looper getBackgroundLooper() {
+    return impl.getBackgroundLooper();
+  }
+
   /**
    * A progress reporter to report progress for a custom command sent by a controller.
    *
@@ -2684,7 +2688,7 @@ public class MediaSession {
   /**
    * Listener for media session events.
    *
-   * <p>All methods must be called on the main thread.
+   * <p>All methods can be called on any thread.
    */
   /* package */ interface Listener {
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -402,6 +402,10 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     return sessionToken;
   }
 
+  public Looper getBackgroundLooper() {
+    return backgroundThread.getLooper();
+  }
+
   public List<ControllerInfo> getConnectedControllers() {
     verifyApplicationThread();
     ImmutableList<ControllerInfo> media3Controllers =
@@ -555,7 +559,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       postOrRunOnApplicationHandler(
           () -> {
             sessionLegacyStub.setPlatformCustomLayout(customLayout);
-            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper, true);
+            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper);
           });
     }
     return dispatchRemoteControllerTask(
@@ -586,7 +590,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       postOrRunOnApplicationHandler(
           () -> {
             sessionLegacyStub.setPlatformMediaButtonPreferences(mediaButtonPreferences);
-            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper, true);
+            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper);
           });
     }
     return dispatchRemoteControllerTask(
@@ -1272,13 +1276,9 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   }
 
   /* package */ void onNotificationRefreshRequired() {
-    postOrRun(
-        mainHandler,
-        () -> {
-          if (this.mediaSessionListener != null) {
-            this.mediaSessionListener.onNotificationRefreshRequired(instance);
-          }
-        });
+    if (this.mediaSessionListener != null) {
+      this.mediaSessionListener.onNotificationRefreshRequired(instance);
+    }
   }
 
   /* package */ ListenableFuture<Boolean> onPlayRequested() {

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -95,7 +95,6 @@ import androidx.media3.session.legacy.MediaSessionCompat;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.lang.ref.WeakReference;
@@ -1292,101 +1291,90 @@ import org.checkerframework.checker.initialization.qual.Initialized;
    *
    * @param controller The controller requesting to play.
    */
-  /* package */ void handleMediaControllerPlayRequest(
+  /* package */ ListenableFuture<SessionResult> handleMediaControllerPlayRequest(
       ControllerInfo controller, boolean callOnPlayerInteractionFinished) {
-    ListenableFuture<Boolean> playRequestFuture = onPlayRequested();
-    Futures.addCallback(
-        playRequestFuture,
-        new FutureCallback<Boolean>() {
-          @Override
-          public void onSuccess(Boolean result) {
-            if (result) {
-              handleMediaControllerPlayRequestInternal(controller, callOnPlayerInteractionFinished);
-            }
+    return Futures.transformAsync(
+        onPlayRequested(),
+        playRequested -> {
+          if (!playRequested) {
+            // Request denied, e.g. due to missing foreground service abilities.
+            return Futures.immediateFuture(new SessionResult(SessionResult.RESULT_ERROR_UNKNOWN));
           }
-
-          @Override
-          public void onFailure(Throwable t) {
-            Log.e(TAG, "Failed calling onPlayRequested", t);
+          boolean hasCurrentMediaItem =
+              playerWrapper.isCommandAvailable(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)
+                  && playerWrapper.getCurrentMediaItem() != null;
+          boolean canAddMediaItems =
+              playerWrapper.isCommandAvailable(COMMAND_SET_MEDIA_ITEM)
+                  || playerWrapper.isCommandAvailable(COMMAND_CHANGE_MEDIA_ITEMS);
+          ControllerInfo controllerForRequest = resolveControllerInfoForCallback(controller);
+          Player.Commands playCommand =
+              new Player.Commands.Builder().add(Player.COMMAND_PLAY_PAUSE).build();
+          if (hasCurrentMediaItem || !canAddMediaItems) {
+            // No playback resumption needed or possible.
+            if (!hasCurrentMediaItem) {
+              Log.w(
+                  TAG,
+                  "Play requested without current MediaItem, but playback resumption prevented by"
+                      + " missing available commands");
+            }
+            Util.handlePlayButtonAction(playerWrapper);
+            if (callOnPlayerInteractionFinished) {
+              onPlayerInteractionFinishedOnHandler(controllerForRequest, playCommand);
+            }
+            return Futures.immediateFuture(new SessionResult(SessionResult.RESULT_SUCCESS));
+          } else {
+            ListenableFuture<SessionResult> future =
+                Futures.transform(
+                    checkNotNull(
+                        callback.onPlaybackResumption(
+                            instance, controllerForRequest, /* isForPlayback= */ true),
+                        "Callback.onPlaybackResumption must return a non-null future"),
+                    mediaItemsWithStartPosition -> {
+                      callWithControllerForCurrentRequestSet(
+                              controllerForRequest,
+                              () -> {
+                                MediaUtils.setMediaItemsWithStartIndexAndPosition(
+                                    playerWrapper, mediaItemsWithStartPosition);
+                                Util.handlePlayButtonAction(playerWrapper);
+                                if (callOnPlayerInteractionFinished) {
+                                  onPlayerInteractionFinishedOnHandler(
+                                      controllerForRequest, playCommand);
+                                }
+                              })
+                          .run();
+                      return new SessionResult(SessionResult.RESULT_SUCCESS);
+                    },
+                    this::postOrRunOnApplicationHandler);
+            return Futures.catching(
+                future,
+                Throwable.class,
+                t -> {
+                  if (t instanceof UnsupportedOperationException) {
+                    Log.w(
+                        TAG,
+                        "UnsupportedOperationException: Make sure to implement"
+                            + " MediaSession.Callback.onPlaybackResumption() if you add a media"
+                            + " button receiver to your manifest or if you implement the recent"
+                            + " media item contract with your MediaLibraryService.",
+                        t);
+                  } else {
+                    Log.e(
+                        TAG,
+                        "Failure calling MediaSession.Callback.onPlaybackResumption(): "
+                            + t.getMessage(),
+                        t);
+                  }
+                  // Play as requested even if playback resumption fails.
+                  Util.handlePlayButtonAction(playerWrapper);
+                  if (callOnPlayerInteractionFinished) {
+                    onPlayerInteractionFinishedOnHandler(controllerForRequest, playCommand);
+                  }
+                  return new SessionResult(SessionResult.RESULT_SUCCESS);
+                },
+                this::postOrRunOnApplicationHandler);
           }
         },
         this::postOrRunOnApplicationHandler);
-  }
-
-  private void handleMediaControllerPlayRequestInternal(
-      ControllerInfo controller, boolean callOnPlayerInteractionFinished) {
-    boolean hasCurrentMediaItem =
-        playerWrapper.isCommandAvailable(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)
-            && playerWrapper.getCurrentMediaItem() != null;
-    boolean canAddMediaItems =
-        playerWrapper.isCommandAvailable(COMMAND_SET_MEDIA_ITEM)
-            || playerWrapper.isCommandAvailable(COMMAND_CHANGE_MEDIA_ITEMS);
-    ControllerInfo controllerForRequest = resolveControllerInfoForCallback(controller);
-    Player.Commands playCommand =
-        new Player.Commands.Builder().add(Player.COMMAND_PLAY_PAUSE).build();
-    if (hasCurrentMediaItem || !canAddMediaItems) {
-      // No playback resumption needed or possible.
-      if (!hasCurrentMediaItem) {
-        Log.w(
-            TAG,
-            "Play requested without current MediaItem, but playback resumption prevented by"
-                + " missing available commands");
-      }
-      Util.handlePlayButtonAction(playerWrapper);
-      if (callOnPlayerInteractionFinished) {
-        onPlayerInteractionFinishedOnHandler(controllerForRequest, playCommand);
-      }
-    } else {
-      @Nullable
-      ListenableFuture<MediaItemsWithStartPosition> future =
-          checkNotNull(
-              callback.onPlaybackResumption(
-                  instance, controllerForRequest, /* isForPlayback= */ true),
-              "Callback.onPlaybackResumption must return a non-null future");
-      Futures.addCallback(
-          future,
-          new FutureCallback<MediaItemsWithStartPosition>() {
-            @Override
-            public void onSuccess(MediaItemsWithStartPosition mediaItemsWithStartPosition) {
-              callWithControllerForCurrentRequestSet(
-                      controllerForRequest,
-                      () -> {
-                        MediaUtils.setMediaItemsWithStartIndexAndPosition(
-                            playerWrapper, mediaItemsWithStartPosition);
-                        Util.handlePlayButtonAction(playerWrapper);
-                        if (callOnPlayerInteractionFinished) {
-                          onPlayerInteractionFinishedOnHandler(controllerForRequest, playCommand);
-                        }
-                      })
-                  .run();
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-              if (t instanceof UnsupportedOperationException) {
-                Log.w(
-                    TAG,
-                    "UnsupportedOperationException: Make sure to implement"
-                        + " MediaSession.Callback.onPlaybackResumption() if you add a"
-                        + " media button receiver to your manifest or if you implement the recent"
-                        + " media item contract with your MediaLibraryService.",
-                    t);
-              } else {
-                Log.e(
-                    TAG,
-                    "Failure calling MediaSession.Callback.onPlaybackResumption(): "
-                        + t.getMessage(),
-                    t);
-              }
-              // Play as requested even if playback resumption fails.
-              Util.handlePlayButtonAction(playerWrapper);
-              if (callOnPlayerInteractionFinished) {
-                onPlayerInteractionFinishedOnHandler(controllerForRequest, playCommand);
-              }
-            }
-          },
-          this::postOrRunOnApplicationHandler);
-    }
   }
 
   /* package */ void triggerPlayerInfoUpdate() {

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -547,7 +547,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       postOrRunOnApplicationHandler(
           () -> {
             sessionLegacyStub.setPlatformCustomLayout(customLayout);
-            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper);
+            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper, true);
           });
     }
     return dispatchRemoteControllerTask(
@@ -578,7 +578,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       postOrRunOnApplicationHandler(
           () -> {
             sessionLegacyStub.setPlatformMediaButtonPreferences(mediaButtonPreferences);
-            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper);
+            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper, true);
           });
     }
     return dispatchRemoteControllerTask(

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -548,7 +548,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       postOrRunOnApplicationHandler(
           () -> {
             sessionLegacyStub.setPlatformCustomLayout(customLayout);
-            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper);
+            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper, true);
           });
     }
     return dispatchRemoteControllerTask(
@@ -579,7 +579,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       postOrRunOnApplicationHandler(
           () -> {
             sessionLegacyStub.setPlatformMediaButtonPreferences(mediaButtonPreferences);
-            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper);
+            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper, true);
           });
     }
     return dispatchRemoteControllerTask(

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -402,7 +402,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     return sessionToken;
   }
 
-  public Looper getBackgroundLooper() {
+  public @Nullable Looper getBackgroundLooper() {
     return backgroundThread.getLooper();
   }
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -237,7 +237,6 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         new MediaSessionLegacyStub(
             /* session= */ thisRef,
             sessionUri,
-            applicationHandler,
             tokenExtras,
             sessionActivity,
             playIfSuppressed,
@@ -248,7 +247,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
             sessionExtras,
             packageNameOverride);
 
-    Token platformToken = sessionLegacyStub.getSessionCompat().getSessionToken().getToken();
+    Token platformToken = sessionLegacyStub.getSessionToken().getToken();
     sessionToken =
         new SessionToken(
             Process.myUid(),
@@ -1109,7 +1108,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
   @SuppressWarnings("UnnecessarilyFullyQualified") // Avoiding confusion by just using "Token"
   public android.media.session.MediaSession.Token getPlatformToken() {
-    return sessionLegacyStub.getSessionCompat().getSessionToken().getToken();
+    return sessionLegacyStub.getSessionToken().getToken();
   }
 
   public void setLegacyControllerConnectionTimeoutMs(long timeoutMs) {
@@ -1192,8 +1191,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     MediaSessionServiceLegacyStub legacyStub;
     synchronized (lock) {
       if (browserServiceLegacyStub == null) {
-        browserServiceLegacyStub =
-            createLegacyBrowserService(sessionLegacyStub.getSessionCompat().getSessionToken());
+        browserServiceLegacyStub = createLegacyBrowserService(sessionLegacyStub.getSessionToken());
       }
       legacyStub = browserServiceLegacyStub;
     }
@@ -1670,7 +1668,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         sessionLegacyStub.onSkipToNext();
         return true;
       } else if (callerInfo.getControllerVersion() != ControllerInfo.LEGACY_CONTROLLER_VERSION) {
-        sessionLegacyStub.getSessionCompat().getController().dispatchMediaButtonEvent(keyEvent);
+        sessionLegacyStub.getControllerCompat().dispatchMediaButtonEvent(keyEvent);
         return true;
       }
       // This is an unhandled framework event. Return false to let the framework resolve by calling

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -401,7 +401,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     return sessionToken;
   }
 
-  public Looper getBackgroundLooper() {
+  public @Nullable Looper getBackgroundLooper() {
     return backgroundThread.getLooper();
   }
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -50,6 +50,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.DeadObjectException;
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.os.IBinder;
 import android.os.Looper;
 import android.os.Message;
@@ -144,6 +145,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   private final boolean useLegacySurfaceHandling;
   private final ImmutableList<CommandButton> commandButtonsForMediaItems;
   @Nullable private final String packageNameOverride;
+  private final HandlerThread backgroundThread;
 
   private PlayerInfo playerInfo;
   private PlayerWrapper playerWrapper;
@@ -215,6 +217,9 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
     sessionStub = new MediaSessionStub(thisRef);
 
+    backgroundThread = new HandlerThread("MediaSessionImpl:bg");
+    backgroundThread.start();
+
     mainHandler = new Handler(Looper.getMainLooper());
     Looper applicationLooper = player.getApplicationLooper();
     applicationHandler = new Handler(applicationLooper);
@@ -245,7 +250,8 @@ import org.checkerframework.checker.initialization.qual.Initialized;
             defaultSessionCommands,
             defaultPlayerCommands,
             sessionExtras,
-            packageNameOverride);
+            packageNameOverride,
+            backgroundThread.getLooper());
 
     Token platformToken = sessionLegacyStub.getSessionToken().getToken();
     sessionToken =
@@ -365,6 +371,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         }
       }
     }
+    backgroundThread.quitSafely();
   }
 
   public PlayerWrapper getPlayerWrapper() {

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -401,6 +401,10 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     return sessionToken;
   }
 
+  public Looper getBackgroundLooper() {
+    return backgroundThread.getLooper();
+  }
+
   public List<ControllerInfo> getConnectedControllers() {
     verifyApplicationThread();
     ImmutableList<ControllerInfo> media3Controllers =
@@ -554,7 +558,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       postOrRunOnApplicationHandler(
           () -> {
             sessionLegacyStub.setPlatformCustomLayout(customLayout);
-            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper, true);
+            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper);
           });
     }
     return dispatchRemoteControllerTask(
@@ -585,7 +589,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       postOrRunOnApplicationHandler(
           () -> {
             sessionLegacyStub.setPlatformMediaButtonPreferences(mediaButtonPreferences);
-            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper, true);
+            sessionLegacyStub.updateLegacySessionPlaybackState(playerWrapper);
           });
     }
     return dispatchRemoteControllerTask(
@@ -1270,13 +1274,9 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   }
 
   /* package */ void onNotificationRefreshRequired() {
-    postOrRun(
-        mainHandler,
-        () -> {
-          if (this.mediaSessionListener != null) {
-            this.mediaSessionListener.onNotificationRefreshRequired(instance);
-          }
-        });
+    if (this.mediaSessionListener != null) {
+      this.mediaSessionListener.onNotificationRefreshRequired(instance);
+    }
   }
 
   /* package */ ListenableFuture<Boolean> onPlayRequested() {

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -94,7 +94,6 @@ import androidx.media3.session.legacy.MediaSessionCompat;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.lang.ref.WeakReference;
@@ -1290,101 +1289,90 @@ import org.checkerframework.checker.initialization.qual.Initialized;
    *
    * @param controller The controller requesting to play.
    */
-  /* package */ void handleMediaControllerPlayRequest(
+  /* package */ ListenableFuture<SessionResult> handleMediaControllerPlayRequest(
       ControllerInfo controller, boolean callOnPlayerInteractionFinished) {
-    ListenableFuture<Boolean> playRequestFuture = onPlayRequested();
-    Futures.addCallback(
-        playRequestFuture,
-        new FutureCallback<Boolean>() {
-          @Override
-          public void onSuccess(Boolean result) {
-            if (result) {
-              handleMediaControllerPlayRequestInternal(controller, callOnPlayerInteractionFinished);
-            }
+    return Futures.transformAsync(
+        onPlayRequested(),
+        playRequested -> {
+          if (!playRequested) {
+            // Request denied, e.g. due to missing foreground service abilities.
+            return Futures.immediateFuture(new SessionResult(SessionResult.RESULT_ERROR_UNKNOWN));
           }
-
-          @Override
-          public void onFailure(Throwable t) {
-            Log.e(TAG, "Failed calling onPlayRequested", t);
+          boolean hasCurrentMediaItem =
+              playerWrapper.isCommandAvailable(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)
+                  && playerWrapper.getCurrentMediaItem() != null;
+          boolean canAddMediaItems =
+              playerWrapper.isCommandAvailable(COMMAND_SET_MEDIA_ITEM)
+                  || playerWrapper.isCommandAvailable(COMMAND_CHANGE_MEDIA_ITEMS);
+          ControllerInfo controllerForRequest = resolveControllerInfoForCallback(controller);
+          Player.Commands playCommand =
+              new Player.Commands.Builder().add(Player.COMMAND_PLAY_PAUSE).build();
+          if (hasCurrentMediaItem || !canAddMediaItems) {
+            // No playback resumption needed or possible.
+            if (!hasCurrentMediaItem) {
+              Log.w(
+                  TAG,
+                  "Play requested without current MediaItem, but playback resumption prevented by"
+                      + " missing available commands");
+            }
+            Util.handlePlayButtonAction(playerWrapper);
+            if (callOnPlayerInteractionFinished) {
+              onPlayerInteractionFinishedOnHandler(controllerForRequest, playCommand);
+            }
+            return Futures.immediateFuture(new SessionResult(SessionResult.RESULT_SUCCESS));
+          } else {
+            ListenableFuture<SessionResult> future =
+                Futures.transform(
+                    checkNotNull(
+                        callback.onPlaybackResumption(
+                            instance, controllerForRequest, /* isForPlayback= */ true),
+                        "Callback.onPlaybackResumption must return a non-null future"),
+                    mediaItemsWithStartPosition -> {
+                      callWithControllerForCurrentRequestSet(
+                              controllerForRequest,
+                              () -> {
+                                MediaUtils.setMediaItemsWithStartIndexAndPosition(
+                                    playerWrapper, mediaItemsWithStartPosition);
+                                Util.handlePlayButtonAction(playerWrapper);
+                                if (callOnPlayerInteractionFinished) {
+                                  onPlayerInteractionFinishedOnHandler(
+                                      controllerForRequest, playCommand);
+                                }
+                              })
+                          .run();
+                      return new SessionResult(SessionResult.RESULT_SUCCESS);
+                    },
+                    this::postOrRunOnApplicationHandler);
+            return Futures.catching(
+                future,
+                Throwable.class,
+                t -> {
+                  if (t instanceof UnsupportedOperationException) {
+                    Log.w(
+                        TAG,
+                        "UnsupportedOperationException: Make sure to implement"
+                            + " MediaSession.Callback.onPlaybackResumption() if you add a media"
+                            + " button receiver to your manifest or if you implement the recent"
+                            + " media item contract with your MediaLibraryService.",
+                        t);
+                  } else {
+                    Log.e(
+                        TAG,
+                        "Failure calling MediaSession.Callback.onPlaybackResumption(): "
+                            + t.getMessage(),
+                        t);
+                  }
+                  // Play as requested even if playback resumption fails.
+                  Util.handlePlayButtonAction(playerWrapper);
+                  if (callOnPlayerInteractionFinished) {
+                    onPlayerInteractionFinishedOnHandler(controllerForRequest, playCommand);
+                  }
+                  return new SessionResult(SessionResult.RESULT_SUCCESS);
+                },
+                this::postOrRunOnApplicationHandler);
           }
         },
         this::postOrRunOnApplicationHandler);
-  }
-
-  private void handleMediaControllerPlayRequestInternal(
-      ControllerInfo controller, boolean callOnPlayerInteractionFinished) {
-    boolean hasCurrentMediaItem =
-        playerWrapper.isCommandAvailable(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)
-            && playerWrapper.getCurrentMediaItem() != null;
-    boolean canAddMediaItems =
-        playerWrapper.isCommandAvailable(COMMAND_SET_MEDIA_ITEM)
-            || playerWrapper.isCommandAvailable(COMMAND_CHANGE_MEDIA_ITEMS);
-    ControllerInfo controllerForRequest = resolveControllerInfoForCallback(controller);
-    Player.Commands playCommand =
-        new Player.Commands.Builder().add(Player.COMMAND_PLAY_PAUSE).build();
-    if (hasCurrentMediaItem || !canAddMediaItems) {
-      // No playback resumption needed or possible.
-      if (!hasCurrentMediaItem) {
-        Log.w(
-            TAG,
-            "Play requested without current MediaItem, but playback resumption prevented by"
-                + " missing available commands");
-      }
-      Util.handlePlayButtonAction(playerWrapper);
-      if (callOnPlayerInteractionFinished) {
-        onPlayerInteractionFinishedOnHandler(controllerForRequest, playCommand);
-      }
-    } else {
-      @Nullable
-      ListenableFuture<MediaItemsWithStartPosition> future =
-          checkNotNull(
-              callback.onPlaybackResumption(
-                  instance, controllerForRequest, /* isForPlayback= */ true),
-              "Callback.onPlaybackResumption must return a non-null future");
-      Futures.addCallback(
-          future,
-          new FutureCallback<MediaItemsWithStartPosition>() {
-            @Override
-            public void onSuccess(MediaItemsWithStartPosition mediaItemsWithStartPosition) {
-              callWithControllerForCurrentRequestSet(
-                      controllerForRequest,
-                      () -> {
-                        MediaUtils.setMediaItemsWithStartIndexAndPosition(
-                            playerWrapper, mediaItemsWithStartPosition);
-                        Util.handlePlayButtonAction(playerWrapper);
-                        if (callOnPlayerInteractionFinished) {
-                          onPlayerInteractionFinishedOnHandler(controllerForRequest, playCommand);
-                        }
-                      })
-                  .run();
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-              if (t instanceof UnsupportedOperationException) {
-                Log.w(
-                    TAG,
-                    "UnsupportedOperationException: Make sure to implement"
-                        + " MediaSession.Callback.onPlaybackResumption() if you add a"
-                        + " media button receiver to your manifest or if you implement the recent"
-                        + " media item contract with your MediaLibraryService.",
-                    t);
-              } else {
-                Log.e(
-                    TAG,
-                    "Failure calling MediaSession.Callback.onPlaybackResumption(): "
-                        + t.getMessage(),
-                    t);
-              }
-              // Play as requested even if playback resumption fails.
-              Util.handlePlayButtonAction(playerWrapper);
-              if (callOnPlayerInteractionFinished) {
-                onPlayerInteractionFinishedOnHandler(controllerForRequest, playCommand);
-              }
-            }
-          },
-          this::postOrRunOnApplicationHandler);
-    }
   }
 
   /* package */ void triggerPlayerInfoUpdate() {

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -238,7 +238,6 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         new MediaSessionLegacyStub(
             /* session= */ thisRef,
             sessionUri,
-            applicationHandler,
             tokenExtras,
             sessionActivity,
             playIfSuppressed,
@@ -249,7 +248,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
             sessionExtras,
             packageNameOverride);
 
-    Token platformToken = sessionLegacyStub.getSessionCompat().getSessionToken().getToken();
+    Token platformToken = sessionLegacyStub.getSessionToken().getToken();
     sessionToken =
         new SessionToken(
             Process.myUid(),
@@ -1111,7 +1110,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
   @SuppressWarnings("UnnecessarilyFullyQualified") // Avoiding confusion by just using "Token"
   public android.media.session.MediaSession.Token getPlatformToken() {
-    return sessionLegacyStub.getSessionCompat().getSessionToken().getToken();
+    return sessionLegacyStub.getSessionToken().getToken();
   }
 
   public void setLegacyControllerConnectionTimeoutMs(long timeoutMs) {
@@ -1194,8 +1193,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     MediaSessionServiceLegacyStub legacyStub;
     synchronized (lock) {
       if (browserServiceLegacyStub == null) {
-        browserServiceLegacyStub =
-            createLegacyBrowserService(sessionLegacyStub.getSessionCompat().getSessionToken());
+        browserServiceLegacyStub = createLegacyBrowserService(sessionLegacyStub.getSessionToken());
       }
       legacyStub = browserServiceLegacyStub;
     }
@@ -1672,7 +1670,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         sessionLegacyStub.onSkipToNext();
         return true;
       } else if (callerInfo.getControllerVersion() != ControllerInfo.LEGACY_CONTROLLER_VERSION) {
-        sessionLegacyStub.getSessionCompat().getController().dispatchMediaButtonEvent(keyEvent);
+        sessionLegacyStub.getControllerCompat().dispatchMediaButtonEvent(keyEvent);
         return true;
       }
       // This is an unhandled framework event. Return false to let the framework resolve by calling

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -51,6 +51,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.DeadObjectException;
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.os.IBinder;
 import android.os.Looper;
 import android.os.Message;
@@ -145,6 +146,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   private final boolean useLegacySurfaceHandling;
   private final ImmutableList<CommandButton> commandButtonsForMediaItems;
   @Nullable private final String packageNameOverride;
+  private final HandlerThread backgroundThread;
 
   private PlayerInfo playerInfo;
   private PlayerWrapper playerWrapper;
@@ -216,6 +218,9 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
     sessionStub = new MediaSessionStub(thisRef);
 
+    backgroundThread = new HandlerThread("MediaSessionImpl:bg");
+    backgroundThread.start();
+
     mainHandler = new Handler(Looper.getMainLooper());
     Looper applicationLooper = player.getApplicationLooper();
     applicationHandler = new Handler(applicationLooper);
@@ -246,7 +251,8 @@ import org.checkerframework.checker.initialization.qual.Initialized;
             defaultSessionCommands,
             defaultPlayerCommands,
             sessionExtras,
-            packageNameOverride);
+            packageNameOverride,
+            backgroundThread.getLooper());
 
     Token platformToken = sessionLegacyStub.getSessionToken().getToken();
     sessionToken =
@@ -366,6 +372,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         }
       }
     }
+    backgroundThread.quitSafely();
   }
 
   public PlayerWrapper getPlayerWrapper() {

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
@@ -836,9 +836,27 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   private void dispatchSessionTaskWithPlayRequest() {
     dispatchSessionTaskWithPlayerCommand(
         COMMAND_PLAY_PAUSE,
-        controller ->
-            sessionImpl.handleMediaControllerPlayRequest(
-                controller, /* callOnPlayerInteractionFinished= */ true),
+        controller -> {
+          ListenableFuture<SessionResult> resultFuture =
+              sessionImpl.handleMediaControllerPlayRequest(
+                  controller, /* callOnPlayerInteractionFinished= */ true);
+          Futures.addCallback(
+              resultFuture,
+              new FutureCallback<SessionResult>() {
+                @Override
+                public void onSuccess(SessionResult result) {
+                  if (result.resultCode != RESULT_SUCCESS) {
+                    Log.w(TAG, "onPlay() failed: " + result + " (from: " + controller + ")");
+                  }
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
+                  Log.e(TAG, "Unexpected exception in onPlay() of " + controller, t);
+                }
+              },
+              MoreExecutors.directExecutor());
+        },
         sessionCompat.getCurrentControllerInfo(),
         /* callOnPlayerInteractionFinished= */ false);
   }

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
@@ -145,8 +145,6 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   @Nullable private final MediaButtonReceiver runtimeBroadcastReceiver;
   @Nullable private final ComponentName broadcastReceiverComponentName;
   private final boolean playIfSuppressed;
-  private final Runnable callOnNotificationRefreshRequiredRunnable =
-      this::callOnNotificationRefreshRequiredIfNeeded;
 
   private volatile long connectionTimeoutMs;
   @Nullable private FutureCallback<Bitmap> pendingBitmapLoadCallback;
@@ -154,7 +152,6 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   private int sessionFlags;
   @Nullable private LegacyError legacyError;
   private Bundle legacyExtras;
-  private boolean notificationRefreshRequiredPending;
   private ImmutableList<CommandButton> customLayout;
   private ImmutableList<CommandButton> mediaButtonPreferences;
   private SessionCommands availableSessionCommands;
@@ -304,11 +301,26 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       updateCustomLayoutAndLegacyExtrasForMediaButtonPreferencesAndInformExtrasChanged();
     }
 
-    if (commandGetTimelineChanged) {
-      updateLegacySessionPlaybackStateAndQueue(sessionImpl.getPlayerWrapper(), true);
-    } else {
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), true);
-    }
+    PlayerWrapper playerWrapper = sessionImpl.getPlayerWrapper();
+    postOrRun(
+        sessionImpl.getApplicationHandler(),
+        () -> {
+          // Because setAvailableCommands can be called from any thread and processing the updated
+          // state requires going through both player and background thread, we must manually
+          // trigger a refresh of the notification and cannot rely on MediaNotificationManager.
+          ListenableFuture<Void> completion =
+              sessionCompat.setPlaybackState(createPlaybackStateCompat(playerWrapper));
+          if (commandGetTimelineChanged) {
+            // will refresh notification once all bitmaps are loaded
+            controllerLegacyCbForBroadcast.updateQueue(
+                playerWrapper.getAvailableCommands().contains(Player.COMMAND_GET_TIMELINE)
+                    ? playerWrapper.getCurrentTimeline()
+                    : Timeline.EMPTY);
+          } else {
+            completion.addListener(
+                sessionImpl::onNotificationRefreshRequired, MoreExecutors.directExecutor());
+          }
+        });
   }
 
   /**
@@ -366,7 +378,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     this.playerCommandsForErrorState = playerCommandsForErrorState;
     if (playbackException != null) {
       maybeUpdateFlags(sessionImpl.getPlayerWrapper());
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
   }
 
@@ -407,7 +419,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       bundle = result.sessionError.extras;
     }
     legacyError = new LegacyError(isFatal, legacyErrorCode, errorMessage, bundle);
-    updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
+    updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
   }
 
   /**
@@ -417,7 +429,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   public void clearLegacyErrorStatus() {
     if (legacyError != null) {
       legacyError = null;
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
   }
 
@@ -1114,25 +1126,9 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     connectionTimeoutMs = timeoutMs;
   }
 
-  public void updateLegacySessionPlaybackState(PlayerWrapper playerWrapper, boolean notify) {
-    postOrRunOnApplicationHandler(
-        () -> {
-          requestNotificationRefreshWhenDone(
-              sessionCompat.setPlaybackState(createPlaybackStateCompat(playerWrapper)), notify);
-        });
-  }
-
-  public void updateLegacySessionPlaybackStateAndQueue(
-      PlayerWrapper playerWrapper, boolean notify) {
+  public void updateLegacySessionPlaybackState(PlayerWrapper playerWrapper) {
       postOrRunOnApplicationHandler(
-        () -> {
-          sessionCompat.setPlaybackState(createPlaybackStateCompat(playerWrapper));
-          controllerLegacyCbForBroadcast.updateQueue(
-              playerWrapper.getAvailableCommands().contains(Player.COMMAND_GET_TIMELINE)
-                  ? playerWrapper.getCurrentTimeline()
-                  : Timeline.EMPTY,
-              notify);
-        });
+        () -> sessionCompat.setPlaybackState(createPlaybackStateCompat(playerWrapper)));
   }
 
   private void handleMediaRequest(MediaItem mediaItem, boolean play) {
@@ -1258,33 +1254,8 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         MoreExecutors.directExecutor());
   }
 
-  private void callOnNotificationRefreshRequiredIfNeeded() {
-    if (notificationRefreshRequiredPending) {
-      sessionImpl.onNotificationRefreshRequired();
-      notificationRefreshRequiredPending = false;
-    }
-  }
-
-  private void requestNotificationRefresh(boolean postRunnable) {
-    notificationRefreshRequiredPending = true;
-    if (postRunnable) {
-      postOnNotificationRefreshRequiredRunnable();
-    }
-  }
-
-  private void postOnNotificationRefreshRequiredRunnable() {
-    sessionImpl.getApplicationHandler().removeCallbacks(callOnNotificationRefreshRequiredRunnable);
-    sessionImpl.getApplicationHandler().post(callOnNotificationRefreshRequiredRunnable);
-  }
-
   private static <T> void ignoreFuture(@Nullable Future<T> unused) {
     // no-op
-  }
-
-  private <T> void requestNotificationRefreshWhenDone(
-      ListenableFuture<T> future, boolean postRunnable) {
-    future.addListener(
-        () -> requestNotificationRefresh(postRunnable), sessionImpl.getApplicationHandler()::post);
   }
 
   private boolean isQueueEnabled() {
@@ -1439,7 +1410,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       }
       PlayerWrapper playerWrapper = sessionImpl.getPlayerWrapper();
       maybeUpdateFlags(playerWrapper);
-      updateLegacySessionPlaybackState(playerWrapper, false);
+      updateLegacySessionPlaybackState(playerWrapper);
     }
 
     @Override
@@ -1495,7 +1466,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         // If PlaybackStateCompat isn't updated by above if-statement, forcefully update
         // PlaybackStateCompat to tell the latest position and its event
         // time. This would also update playback speed, buffering state, player state, and error.
-        updateLegacySessionPlaybackState(newPlayerWrapper, true);
+        updateLegacySessionPlaybackState(newPlayerWrapper);
       }
     }
 
@@ -1504,17 +1475,17 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       if (skipLegacySessionPlaybackStateUpdates()) {
         return;
       }
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
 
     @Override
     public void setCustomLayout(int seq, List<CommandButton> layout) {
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), true);
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
 
     @Override
     public void setMediaButtonPreferences(int seq, List<CommandButton> mediaButtonPreferences) {
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), true);
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
 
     @Override
@@ -1527,7 +1498,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         updateCustomLayoutAndLegacyExtrasForMediaButtonPreferences();
       }
       sessionCompat.setExtras(legacyExtras);
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
 
     @Override
@@ -1548,7 +1519,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         PlaybackStateCompat playbackStateCompat = createPlaybackStateCompat(playerWrapper);
         sessionCompat.setPlaybackState(playbackStateCompat);
         legacyError = null;
-        updateLegacySessionPlaybackState(playerWrapper, false);
+        updateLegacySessionPlaybackState(playerWrapper);
       }
     }
 
@@ -1573,7 +1544,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         return;
       }
       // Note: This method does not use any of the given arguments.
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), true);
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
 
     @Override
@@ -1582,7 +1553,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       if (skipLegacySessionPlaybackStateUpdates()) {
         return;
       }
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
 
     @Override
@@ -1592,7 +1563,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         return;
       }
       // Note: This method does not use any of the given arguments.
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), true);
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
 
     @Override
@@ -1600,7 +1571,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       if (skipLegacySessionPlaybackStateUpdates()) {
         return;
       }
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
 
     @Override
@@ -1613,7 +1584,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         return;
       }
       // Note: This method does not use any of the given arguments.
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
 
     @Override
@@ -1622,7 +1593,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         return;
       }
       // Note: This method does not use any of the given arguments.
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
 
     @Override
@@ -1632,16 +1603,14 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         return;
       }
       // MediaMetadataCompat needs to be updated when the media ID or URI of the media item changes.
-      updateMetadataIfChanged(false);
+      updateMetadataIfChanged();
       if (mediaItem == null) {
         sessionCompat.setRatingType(RatingCompat.RATING_NONE);
       } else {
         sessionCompat.setRatingType(
             LegacyConversions.getRatingCompatStyle(mediaItem.mediaMetadata.userRating));
       }
-      requestNotificationRefreshWhenDone(
-          sessionCompat.setPlaybackState(createPlaybackStateCompat(sessionImpl.getPlayerWrapper())),
-          true);
+      sessionCompat.setPlaybackState(createPlaybackStateCompat(sessionImpl.getPlayerWrapper()));
     }
 
     @Override
@@ -1649,7 +1618,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       if (skipLegacySessionPlaybackStateUpdates()) {
         return;
       }
-      updateMetadataIfChanged(true);
+      updateMetadataIfChanged();
     }
 
     @Override
@@ -1658,14 +1627,16 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       if (skipLegacySessionPlaybackStateUpdates()) {
         return;
       }
-      updateQueue(timeline, false);
+      updateQueue(timeline);
       // Duration might be unknown at onMediaItemTransition and become available afterward.
-      updateMetadataIfChanged(true);
+      updateMetadataIfChanged();
     }
 
-    private void updateQueue(Timeline timeline, boolean notify) {
+    private void updateQueue(Timeline timeline) {
       if (!isQueueEnabled() || timeline.isEmpty()) {
-        requestNotificationRefreshWhenDone(sessionCompat.computeAndSetQueue(null), notify);
+        ListenableFuture<Void> completion = sessionCompat.computeAndSetQueue(null);
+        completion.addListener(
+            sessionImpl::onNotificationRefreshRequired, MoreExecutors.directExecutor());
         return;
       }
       List<MediaItem> mediaItemList = LegacyConversions.convertToMediaItemList(timeline);
@@ -1675,7 +1646,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
           () -> {
             int completedBitmapFutureCount = resultCount.incrementAndGet();
             if (completedBitmapFutureCount == mediaItemList.size()) {
-              handleBitmapFuturesAllCompletedAndSetQueue(bitmapFutures, mediaItemList, notify);
+              handleBitmapFuturesAllCompletedAndSetQueue(bitmapFutures, mediaItemList);
             }
           };
 
@@ -1696,12 +1667,13 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     }
 
     private void handleBitmapFuturesAllCompletedAndSetQueue(
-        List<@NullableType ListenableFuture<Bitmap>> bitmapFutures,
-        List<MediaItem> mediaItems,
-        boolean notify) {
+        List<@NullableType ListenableFuture<Bitmap>> bitmapFutures, List<MediaItem> mediaItems) {
       // Framework MediaSession#setQueue() uses ParceledListSlice,
       // which means we can safely send long lists.
-      requestNotificationRefreshWhenDone(
+      // Do conversions on a background thread instead of the session thread, as we may
+      // have a lot
+      // of media items to convert.
+      ListenableFuture<Void> completion =
           sessionCompat.computeAndSetQueue(
               () -> {
                 // Do conversions on a background thread instead of the session thread, as we may
@@ -1722,8 +1694,12 @@ import org.checkerframework.checker.initialization.qual.Initialized;
                       LegacyConversions.convertToQueueItem(mediaItems.get(i), i, bitmap));
                 }
                 return queueItemList;
-              }),
-          notify);
+              });
+      // Because we had to wait for futures to complete before we can switch to the background
+      // thread, we have to manually notify SystemUI that the notification should be updated,
+      // MediaNotificationManager cannot do it for us.
+      completion.addListener(
+          sessionImpl::onNotificationRefreshRequired, MoreExecutors.directExecutor());
     }
 
     @Override
@@ -1788,11 +1764,11 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         boolean unusedCanAccessTimeline,
         int controllerInterfaceVersion) {
       if (!skipLegacySessionPlaybackStateUpdates()) {
-        updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
+        updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
       }
     }
 
-    private void updateMetadataIfChanged(boolean notify) {
+    private void updateMetadataIfChanged() {
       PlayerWrapper player = sessionImpl.getPlayerWrapper();
       @Nullable MediaItem currentMediaItem = player.getCurrentMediaItemWithCommandCheck();
       MediaMetadata newMediaMetadata = player.getMediaMetadataWithCommandCheck();
@@ -1812,9 +1788,6 @@ import org.checkerframework.checker.initialization.qual.Initialized;
           && Objects.equals(lastMediaId, newMediaId)
           && Objects.equals(lastMediaUri, newMediaUri)
           && lastDurationMs == newDurationMs) {
-        if (notify) {
-          postOnNotificationRefreshRequiredRunnable();
-        }
         return;
       }
 
@@ -1842,15 +1815,16 @@ import org.checkerframework.checker.initialization.qual.Initialized;
                   if (this != pendingBitmapLoadCallback) {
                     return;
                   }
-                  requestNotificationRefreshWhenDone(
+                  ListenableFuture<Void> completion =
                       sessionCompat.setMetadata(
                           LegacyConversions.convertToMediaMetadataCompat(
                               newMediaMetadata,
                               newMediaId,
                               newMediaUri,
                               newDurationMs,
-                              /* artworkBitmap= */ result)),
-                      true);
+                              /* artworkBitmap= */ result));
+                  completion.addListener(
+                      sessionImpl::onNotificationRefreshRequired, MoreExecutors.directExecutor());
                 }
 
                 @Override
@@ -1867,11 +1841,9 @@ import org.checkerframework.checker.initialization.qual.Initialized;
               /* executor= */ sessionImpl.getApplicationHandler()::post);
         }
       }
-      requestNotificationRefreshWhenDone(
-          sessionCompat.setMetadata(
-              LegacyConversions.convertToMediaMetadataCompat(
-                  newMediaMetadata, newMediaId, newMediaUri, newDurationMs, artworkBitmap)),
-          notify);
+      sessionCompat.setMetadata(
+          LegacyConversions.convertToMediaMetadataCompat(
+              newMediaMetadata, newMediaId, newMediaUri, newDurationMs, artworkBitmap));
     }
   }
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
@@ -147,13 +147,13 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   private final MediaSessionCompat sessionCompat;
   @Nullable private final MediaButtonReceiver runtimeBroadcastReceiver;
   @Nullable private final ComponentName broadcastReceiverComponentName;
-  @Nullable private VolumeProviderCompat volumeProviderCompat;
   private final boolean playIfSuppressed;
   private final HandlerThread compatSessionInteractionThread;
   private final Handler compatSessionInteractionHandler;
 
   private volatile long connectionTimeoutMs;
   @Nullable private FutureCallback<Bitmap> pendingBitmapLoadCallback;
+  @Nullable private VolumeProviderCompat volumeProviderCompat;
   private int sessionFlags;
   @Nullable private LegacyError legacyError;
   private Bundle legacyExtras;
@@ -1813,7 +1813,13 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       int playbackType = sessionImpl.getPlayerWrapper().getDeviceInfo().playbackType;
       if (playbackType == DeviceInfo.PLAYBACK_TYPE_LOCAL) {
         postOrRunForCompatSession(
-            () -> sessionCompat.setPlaybackToLocal(audioAttributes));
+            () -> {
+              if (volumeProviderCompat != null) {
+                // Stale event.
+                return;
+              }
+              sessionCompat.setPlaybackToLocal(audioAttributes);
+            });
       }
     }
 
@@ -1823,9 +1829,21 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       volumeProviderCompat = createVolumeProviderCompat(player);
       if (volumeProviderCompat == null) {
         AudioAttributes audioAttributes = player.getAudioAttributesWithCommandCheck();
-        postOrRunForCompatSession(() -> sessionCompat.setPlaybackToLocal(audioAttributes));
+        postOrRunForCompatSession(() -> {
+          if (volumeProviderCompat != null) {
+            // Stale event.
+            return;
+          }
+          sessionCompat.setPlaybackToLocal(audioAttributes);
+        });
       } else {
-        postOrRunForCompatSession(() -> sessionCompat.setPlaybackToRemote(volumeProviderCompat));
+        postOrRunForCompatSession(() -> {
+          if (volumeProviderCompat == null) {
+            // Stale event.
+            return;
+          }
+          sessionCompat.setPlaybackToRemote(volumeProviderCompat);
+        });
       }
     }
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
@@ -62,7 +62,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.Message;
 import android.os.RemoteException;
@@ -146,7 +145,6 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   @Nullable private final MediaButtonReceiver runtimeBroadcastReceiver;
   @Nullable private final ComponentName broadcastReceiverComponentName;
   private final boolean playIfSuppressed;
-  private final HandlerThread compatSessionInteractionThread;
   private final Runnable callOnNotificationRefreshRequiredRunnable =
       this::callOnNotificationRefreshRequiredIfNeeded;
 
@@ -179,7 +177,8 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       SessionCommands availableSessionCommands,
       Player.Commands availablePlayerCommands,
       Bundle legacyExtras,
-      @Nullable String packageNameOverride) {
+      @Nullable String packageNameOverride,
+      Looper backgroundLooper) {
     this.sessionImpl = session;
     this.playIfSuppressed = playIfSuppressed;
     this.customLayout = customLayout;
@@ -197,8 +196,6 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     connectionTimeoutHandler =
         new ConnectionTimeoutHandler(
             session.getApplicationHandler().getLooper(), connectedControllersManager);
-    compatSessionInteractionThread = new HandlerThread("MSLegacyStub:CompatSIT");
-    compatSessionInteractionThread.start();
     mayNeedButtonReservationWorkaroundForSeekbar =
         mayNeedButtonReservationWorkaroundForSeekbar(context);
 
@@ -268,7 +265,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
             sessionActivity,
             /* sessionInfo= */ tokenExtras,
             packageNameOverride,
-            compatSessionInteractionThread.getLooper());
+            backgroundLooper);
     if (SDK_INT >= 31 && broadcastReceiverComponentName != null) {
       Api31.setMediaButtonBroadcastReceiver(sessionCompat, broadcastReceiverComponentName);
     }
@@ -477,7 +474,6 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     }
     // No check for COMMAND_RELEASE needed as MediaControllers can always be released.
     sessionCompat.release();
-    compatSessionInteractionThread.quitSafely();
     connectedControllersManager.release();
   }
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
@@ -316,9 +316,9 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     }
 
     if (commandGetTimelineChanged) {
-      updateLegacySessionPlaybackStateAndQueue(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackStateAndQueue(sessionImpl.getPlayerWrapper(), true);
     } else {
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), true);
     }
   }
 
@@ -376,8 +376,8 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     customPlaybackException = playbackException;
     this.playerCommandsForErrorState = playerCommandsForErrorState;
     if (playbackException != null) {
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
       maybeUpdateFlags(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
     }
   }
 
@@ -418,7 +418,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       bundle = result.sessionError.extras;
     }
     legacyError = new LegacyError(isFatal, legacyErrorCode, errorMessage, bundle);
-    updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+    updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
   }
 
   /**
@@ -428,7 +428,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   public void clearLegacyErrorStatus() {
     if (legacyError != null) {
       legacyError = null;
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
     }
   }
 
@@ -1154,23 +1154,31 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     connectionTimeoutMs = timeoutMs;
   }
 
-  public void updateLegacySessionPlaybackState(PlayerWrapper playerWrapper) {
+  public void updateLegacySessionPlaybackState(PlayerWrapper playerWrapper, boolean notify) {
     postOrRunOnApplicationHandler(
         () -> {
           PlaybackStateCompat playbackStateCompat = createPlaybackStateCompat(playerWrapper);
-          postOrRunForCompatSession(() -> sessionCompat.setPlaybackState(playbackStateCompat));
+          postOrRunForCompatSession(
+              () -> {
+                sessionCompat.setPlaybackState(playbackStateCompat);
+                if (notify) {
+                  sessionImpl.onNotificationRefreshRequired();
+                }
+              });
         });
   }
 
-  public void updateLegacySessionPlaybackStateAndQueue(PlayerWrapper playerWrapper) {
-    postOrRunOnApplicationHandler(
+  public void updateLegacySessionPlaybackStateAndQueue(
+      PlayerWrapper playerWrapper, boolean notify) {
+      postOrRunOnApplicationHandler(
         () -> {
           PlaybackStateCompat playbackStateCompat = createPlaybackStateCompat(playerWrapper);
           postOrRunForCompatSession(() -> sessionCompat.setPlaybackState(playbackStateCompat));
           controllerLegacyCbForBroadcast.updateQueue(
               playerWrapper.getAvailableCommands().contains(Player.COMMAND_GET_TIMELINE)
                   ? playerWrapper.getCurrentTimeline()
-                  : Timeline.EMPTY);
+                  : Timeline.EMPTY,
+              notify);
         });
   }
 
@@ -1303,7 +1311,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
   @SuppressWarnings("nullness:argument") // MediaSessionCompat didn't annotate @Nullable.
   private void setMetadata(@Nullable MediaMetadataCompat metadataCompat) {
-    postOrRunForCompatSession(() -> sessionCompat.setMetadata(metadataCompat));
+    sessionCompat.setMetadata(metadataCompat);
   }
 
   @SuppressWarnings("nullness:argument") // MediaSessionCompat didn't annotate @Nullable.
@@ -1313,7 +1321,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
   @SuppressWarnings("nullness:argument") // MediaSessionCompat didn't annotate @Nullable.
   private void setQueue(@Nullable List<QueueItem> queue) {
-    postOrRunForCompatSession(() -> sessionCompat.setQueue(queue));
+    sessionCompat.setQueue(queue);
   }
 
   @SuppressWarnings("nullness:argument") // MediaSessionCompat didn't annotate @Nullable.
@@ -1473,7 +1481,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       }
       PlayerWrapper playerWrapper = sessionImpl.getPlayerWrapper();
       maybeUpdateFlags(playerWrapper);
-      updateLegacySessionPlaybackState(playerWrapper);
+      updateLegacySessionPlaybackState(playerWrapper, false);
     }
 
     @Override
@@ -1529,7 +1537,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         // If PlaybackStateCompat isn't updated by above if-statement, forcefully update
         // PlaybackStateCompat to tell the latest position and its event
         // time. This would also update playback speed, buffering state, player state, and error.
-        updateLegacySessionPlaybackState(newPlayerWrapper);
+        updateLegacySessionPlaybackState(newPlayerWrapper, true);
       }
     }
 
@@ -1538,17 +1546,17 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       if (skipLegacySessionPlaybackStateUpdates()) {
         return;
       }
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
     }
 
     @Override
     public void setCustomLayout(int seq, List<CommandButton> layout) {
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), true);
     }
 
     @Override
     public void setMediaButtonPreferences(int seq, List<CommandButton> mediaButtonPreferences) {
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), true);
     }
 
     @Override
@@ -1561,7 +1569,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         updateCustomLayoutAndLegacyExtrasForMediaButtonPreferences();
       }
       postOrRunForCompatSession(() -> sessionCompat.setExtras(legacyExtras));
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
     }
 
     @Override
@@ -1582,7 +1590,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         PlaybackStateCompat playbackStateCompat = createPlaybackStateCompat(playerWrapper);
         postOrRunForCompatSession(() -> sessionCompat.setPlaybackState(playbackStateCompat));
         legacyError = null;
-        updateLegacySessionPlaybackState(playerWrapper);
+        updateLegacySessionPlaybackState(playerWrapper, false);
       }
     }
 
@@ -1607,7 +1615,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         return;
       }
       // Note: This method does not use any of the given arguments.
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), true);
     }
 
     @Override
@@ -1616,7 +1624,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       if (skipLegacySessionPlaybackStateUpdates()) {
         return;
       }
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
     }
 
     @Override
@@ -1626,7 +1634,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         return;
       }
       // Note: This method does not use any of the given arguments.
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), true);
     }
 
     @Override
@@ -1634,7 +1642,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       if (skipLegacySessionPlaybackStateUpdates()) {
         return;
       }
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
     }
 
     @Override
@@ -1647,7 +1655,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         return;
       }
       // Note: This method does not use any of the given arguments.
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
     }
 
     @Override
@@ -1656,7 +1664,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         return;
       }
       // Note: This method does not use any of the given arguments.
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
     }
 
     @Override
@@ -1666,7 +1674,9 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         return;
       }
       // MediaMetadataCompat needs to be updated when the media ID or URI of the media item changes.
-      updateMetadataIfChanged();
+      updateMetadataIfChanged(false);
+      PlaybackStateCompat playbackStateCompat =
+          createPlaybackStateCompat(sessionImpl.getPlayerWrapper());
       postOrRunForCompatSession(
           () -> {
             if (mediaItem == null) {
@@ -1675,7 +1685,8 @@ import org.checkerframework.checker.initialization.qual.Initialized;
               sessionCompat.setRatingType(
                   LegacyConversions.getRatingCompatStyle(mediaItem.mediaMetadata.userRating));
             }
-            updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+            sessionCompat.setPlaybackState(playbackStateCompat);
+            sessionImpl.onNotificationRefreshRequired();
           });
     }
 
@@ -1684,7 +1695,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       if (skipLegacySessionPlaybackStateUpdates()) {
         return;
       }
-      updateMetadataIfChanged();
+      updateMetadataIfChanged(true);
     }
 
     @Override
@@ -1693,14 +1704,20 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       if (skipLegacySessionPlaybackStateUpdates()) {
         return;
       }
-      updateQueue(timeline);
+      updateQueue(timeline, false);
       // Duration might be unknown at onMediaItemTransition and become available afterward.
-      updateMetadataIfChanged();
+      updateMetadataIfChanged(true);
     }
 
-    private void updateQueue(Timeline timeline) {
+    private void updateQueue(Timeline timeline, boolean notify) {
       if (!isQueueEnabled() || timeline.isEmpty()) {
-        setQueue(/* queue= */ null);
+        postOrRunForCompatSession(
+            () -> {
+              setQueue(/* queue= */ null);
+              if (notify) {
+                sessionImpl.onNotificationRefreshRequired();
+              }
+            });
         return;
       }
       List<MediaItem> mediaItemList = LegacyConversions.convertToMediaItemList(timeline);
@@ -1710,7 +1727,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
           () -> {
             int completedBitmapFutureCount = resultCount.incrementAndGet();
             if (completedBitmapFutureCount == mediaItemList.size()) {
-              handleBitmapFuturesAllCompletedAndSetQueue(bitmapFutures, mediaItemList);
+              handleBitmapFuturesAllCompletedAndSetQueue(bitmapFutures, mediaItemList, notify);
             }
           };
 
@@ -1719,7 +1736,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         MediaMetadata metadata = mediaItem.mediaMetadata;
         if (metadata.artworkData == null) {
           bitmapFutures.add(null);
-          handleBitmapFuturesTask.run();
+          postOrRunForCompatSession(handleBitmapFuturesTask);
         } else {
           ListenableFuture<Bitmap> bitmapFuture =
               sessionImpl.getBitmapLoader().decodeBitmap(metadata.artworkData);
@@ -1731,7 +1748,9 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     }
 
     private void handleBitmapFuturesAllCompletedAndSetQueue(
-        List<@NullableType ListenableFuture<Bitmap>> bitmapFutures, List<MediaItem> mediaItems) {
+        List<@NullableType ListenableFuture<Bitmap>> bitmapFutures,
+        List<MediaItem> mediaItems,
+        boolean notify) {
       List<QueueItem> queueItemList = new ArrayList<>();
       for (int i = 0; i < bitmapFutures.size(); i++) {
         @Nullable ListenableFuture<Bitmap> future = bitmapFutures.get(i);
@@ -1749,6 +1768,9 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       // Framework MediaSession#setQueue() uses ParceledListSlice,
       // which means we can safely send long lists.
       setQueue(queueItemList);
+      if (notify) {
+        sessionImpl.onNotificationRefreshRequired();
+      }
     }
 
     @Override
@@ -1822,11 +1844,11 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         boolean unusedCanAccessTimeline,
         int controllerInterfaceVersion) {
       if (!skipLegacySessionPlaybackStateUpdates()) {
-        updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+        updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
       }
     }
 
-    private void updateMetadataIfChanged() {
+    private void updateMetadataIfChanged(boolean notify) {
       PlayerWrapper player = sessionImpl.getPlayerWrapper();
       @Nullable MediaItem currentMediaItem = player.getCurrentMediaItemWithCommandCheck();
       MediaMetadata newMediaMetadata = player.getMediaMetadataWithCommandCheck();
@@ -1846,6 +1868,9 @@ import org.checkerframework.checker.initialization.qual.Initialized;
           && Objects.equals(lastMediaId, newMediaId)
           && Objects.equals(lastMediaUri, newMediaUri)
           && lastDurationMs == newDurationMs) {
+        if (notify) {
+          sessionImpl.onNotificationRefreshRequired();
+        }
         return;
       }
 
@@ -1900,9 +1925,16 @@ import org.checkerframework.checker.initialization.qual.Initialized;
               /* executor= */ sessionImpl.getApplicationHandler()::post);
         }
       }
-      setMetadata(
-          LegacyConversions.convertToMediaMetadataCompat(
-              newMediaMetadata, newMediaId, newMediaUri, newDurationMs, artworkBitmap));
+      @Nullable Bitmap artworkBitmapFinal = artworkBitmap;
+      postOrRunForCompatSession(
+          () -> {
+            setMetadata(
+                LegacyConversions.convertToMediaMetadataCompat(
+                    newMediaMetadata, newMediaId, newMediaUri, newDurationMs, artworkBitmapFinal));
+            if (notify) {
+              sessionImpl.onNotificationRefreshRequired();
+            }
+          });
     }
   }
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
@@ -62,6 +62,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.Message;
 import android.os.RemoteException;
@@ -94,6 +95,7 @@ import androidx.media3.session.MediaSession.ControllerCb;
 import androidx.media3.session.MediaSession.ControllerInfo;
 import androidx.media3.session.MediaSession.MediaItemsWithStartPosition;
 import androidx.media3.session.SessionCommand.CommandCode;
+import androidx.media3.session.legacy.MediaControllerCompat;
 import androidx.media3.session.legacy.MediaDescriptionCompat;
 import androidx.media3.session.legacy.MediaMetadataCompat;
 import androidx.media3.session.legacy.MediaSessionCompat;
@@ -108,6 +110,7 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -146,6 +149,8 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   @Nullable private final ComponentName broadcastReceiverComponentName;
   @Nullable private VolumeProviderCompat volumeProviderCompat;
   private final boolean playIfSuppressed;
+  private final HandlerThread compatSessionInteractionThread;
+  private final Handler compatSessionInteractionHandler;
 
   private volatile long connectionTimeoutMs;
   @Nullable private FutureCallback<Bitmap> pendingBitmapLoadCallback;
@@ -166,7 +171,6 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   public MediaSessionLegacyStub(
       MediaSessionImpl session,
       Uri sessionUri,
-      Handler handler,
       Bundle tokenExtras,
       @Nullable PendingIntent sessionActivity,
       boolean playIfSuppressed,
@@ -193,6 +197,9 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     connectionTimeoutHandler =
         new ConnectionTimeoutHandler(
             session.getApplicationHandler().getLooper(), connectedControllersManager);
+    compatSessionInteractionThread = new HandlerThread("MSLegacyStub:CompatSIT");
+    compatSessionInteractionThread.start();
+    compatSessionInteractionHandler = new Handler(compatSessionInteractionThread.getLooper());
     mayNeedButtonReservationWorkaroundForSeekbar =
         mayNeedButtonReservationWorkaroundForSeekbar(context);
 
@@ -260,7 +267,8 @@ import org.checkerframework.checker.initialization.qual.Initialized;
             SDK_INT < 31 ? receiverComponentName : null,
             SDK_INT < 31 ? mediaButtonIntent : null,
             /* sessionInfo= */ tokenExtras,
-            packageNameOverride);
+            packageNameOverride,
+            compatSessionInteractionHandler.getLooper());
     if (SDK_INT >= 31 && broadcastReceiverComponentName != null) {
       Api31.setMediaButtonBroadcastReceiver(sessionCompat, broadcastReceiverComponentName);
     }
@@ -272,13 +280,17 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     @SuppressWarnings("nullness:assignment")
     @Initialized
     MediaSessionLegacyStub thisRef = this;
-    sessionCompat.setCallback(thisRef, handler);
+    sessionCompat.setCallback(thisRef, compatSessionInteractionHandler);
 
     androidAutoObserver =
         mayNeedButtonReservationWorkaroundForSeekbar
             ? new AndroidAutoConnectionStateObserver(
                 context, thisRef::onAndroidAutoConnectionStateChanged)
             : null;
+  }
+
+  private void postOrRunForCompatSession(Runnable r) {
+    postOrRun(compatSessionInteractionHandler, r);
   }
 
   /**
@@ -443,41 +455,49 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
   /** Starts to receive commands. */
   public void start() {
-    sessionCompat.setActive(true);
+    postOrRunForCompatSession(() -> sessionCompat.setActive(true));
   }
 
   @SuppressWarnings("PendingIntentMutability") // We can't use SaferPendingIntent.
   public void release() {
-    if (SDK_INT < 31) {
-      if (broadcastReceiverComponentName == null) {
-        // No broadcast receiver available. Playback resumption not supported.
-        setMediaButtonReceiver(sessionCompat, /* mediaButtonReceiverIntent= */ null);
-      } else {
-        // Override the runtime receiver with the broadcast receiver for playback resumption.
-        Intent intent = new Intent(Intent.ACTION_MEDIA_BUTTON, sessionImpl.getUri());
-        intent.setComponent(broadcastReceiverComponentName);
-        PendingIntent mediaButtonReceiverIntent =
-            PendingIntent.getBroadcast(
-                sessionImpl.getContext(),
-                /* requestCode= */ 0,
-                intent,
-                PENDING_INTENT_FLAG_MUTABLE);
-        setMediaButtonReceiver(sessionCompat, mediaButtonReceiverIntent);
-      }
-    }
     if (runtimeBroadcastReceiver != null) {
       sessionImpl.getContext().unregisterReceiver(runtimeBroadcastReceiver);
     }
     if (androidAutoObserver != null) {
       androidAutoObserver.release();
     }
-    // No check for COMMAND_RELEASE needed as MediaControllers can always be released.
-    sessionCompat.release();
+    postOrRunForCompatSession(
+        () -> {
+          if (SDK_INT < 31) {
+            if (broadcastReceiverComponentName == null) {
+              // No broadcast receiver available. Playback resumption not supported.
+              setMediaButtonReceiver(/* mediaButtonReceiverIntent= */ null);
+            } else {
+              // Override the runtime receiver with the broadcast receiver for playback resumption.
+              Intent intent = new Intent(Intent.ACTION_MEDIA_BUTTON, sessionImpl.getUri());
+              intent.setComponent(broadcastReceiverComponentName);
+              PendingIntent mediaButtonReceiverIntent =
+                  PendingIntent.getBroadcast(
+                      sessionImpl.getContext(),
+                      /* requestCode= */ 0,
+                      intent,
+                      PENDING_INTENT_FLAG_MUTABLE);
+              setMediaButtonReceiver(mediaButtonReceiverIntent);
+            }
+          }
+          // No check for COMMAND_RELEASE needed as MediaControllers can always be released.
+          sessionCompat.release();
+        });
+    compatSessionInteractionThread.quitSafely();
     connectedControllersManager.release();
   }
 
-  public MediaSessionCompat getSessionCompat() {
-    return sessionCompat;
+  public MediaSessionCompat.Token getSessionToken() {
+    return sessionCompat.getSessionToken(); // Safe to call on any thread.
+  }
+
+  public MediaControllerCompat getControllerCompat() {
+    return sessionCompat.getController(); // Safe to call on any thread.
   }
 
   @Override
@@ -532,6 +552,18 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
   @Override
   public boolean onMediaButtonEvent(Intent intent) {
+    if (Looper.myLooper() != sessionImpl.getApplicationHandler().getLooper()) {
+      SettableFuture<Boolean> settableFuture = SettableFuture.create();
+      sessionImpl
+          .getApplicationHandler()
+          .post(() -> settableFuture.set(onMediaButtonEvent(intent)));
+      // Block compatSessionInteractionThread until we have a decision.
+      try {
+        return settableFuture.get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    }
     return sessionImpl.onMediaButtonEvent(
         new ControllerInfo(
             checkNotNull(sessionCompat.getCurrentControllerInfo()),
@@ -552,7 +584,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
             : 0;
     if (sessionFlags != newFlags) {
       sessionFlags = newFlags;
-      sessionCompat.setFlags(sessionFlags);
+      postOrRunForCompatSession(() -> sessionCompat.setFlags(sessionFlags));
     }
   }
 
@@ -655,36 +687,46 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
   @Override
   public void onSkipToNext() {
-    if (sessionImpl.getPlayerWrapper().isCommandAvailable(COMMAND_SEEK_TO_NEXT)) {
-      dispatchSessionTaskWithPlayerCommand(
-          COMMAND_SEEK_TO_NEXT,
-          controller -> sessionImpl.getPlayerWrapper().seekToNext(),
-          sessionCompat.getCurrentControllerInfo(),
-          /* callOnPlayerInteractionFinished= */ true);
-    } else {
-      dispatchSessionTaskWithPlayerCommand(
-          COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
-          controller -> sessionImpl.getPlayerWrapper().seekToNextMediaItem(),
-          sessionCompat.getCurrentControllerInfo(),
-          /* callOnPlayerInteractionFinished= */ true);
-    }
+    RemoteUserInfo controllerInfo = sessionCompat.getCurrentControllerInfo();
+    postOrRun(
+        sessionImpl.getApplicationHandler(),
+        () -> {
+          if (sessionImpl.getPlayerWrapper().isCommandAvailable(COMMAND_SEEK_TO_NEXT)) {
+            dispatchSessionTaskWithPlayerCommand(
+                COMMAND_SEEK_TO_NEXT,
+                controller -> sessionImpl.getPlayerWrapper().seekToNext(),
+                controllerInfo,
+                /* callOnPlayerInteractionFinished= */ true);
+          } else {
+            dispatchSessionTaskWithPlayerCommand(
+                COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
+                controller -> sessionImpl.getPlayerWrapper().seekToNextMediaItem(),
+                controllerInfo,
+                /* callOnPlayerInteractionFinished= */ true);
+          }
+        });
   }
 
   @Override
   public void onSkipToPrevious() {
-    if (sessionImpl.getPlayerWrapper().isCommandAvailable(COMMAND_SEEK_TO_PREVIOUS)) {
-      dispatchSessionTaskWithPlayerCommand(
-          COMMAND_SEEK_TO_PREVIOUS,
-          controller -> sessionImpl.getPlayerWrapper().seekToPrevious(),
-          sessionCompat.getCurrentControllerInfo(),
-          /* callOnPlayerInteractionFinished= */ true);
-    } else {
-      dispatchSessionTaskWithPlayerCommand(
-          COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
-          controller -> sessionImpl.getPlayerWrapper().seekToPreviousMediaItem(),
-          sessionCompat.getCurrentControllerInfo(),
-          /* callOnPlayerInteractionFinished= */ true);
-    }
+    RemoteUserInfo controllerInfo = sessionCompat.getCurrentControllerInfo();
+    postOrRun(
+        sessionImpl.getApplicationHandler(),
+        () -> {
+          if (sessionImpl.getPlayerWrapper().isCommandAvailable(COMMAND_SEEK_TO_PREVIOUS)) {
+            dispatchSessionTaskWithPlayerCommand(
+                COMMAND_SEEK_TO_PREVIOUS,
+                controller -> sessionImpl.getPlayerWrapper().seekToPrevious(),
+                controllerInfo,
+                /* callOnPlayerInteractionFinished= */ true);
+          } else {
+            dispatchSessionTaskWithPlayerCommand(
+                COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+                controller -> sessionImpl.getPlayerWrapper().seekToPreviousMediaItem(),
+                controllerInfo,
+                /* callOnPlayerInteractionFinished= */ true);
+          }
+        });
   }
 
   @Override
@@ -1114,13 +1156,17 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
   public void updateLegacySessionPlaybackState(PlayerWrapper playerWrapper) {
     postOrRunOnApplicationHandler(
-        () -> sessionCompat.setPlaybackState(createPlaybackStateCompat(playerWrapper)));
+        () -> {
+          PlaybackStateCompat playbackStateCompat = createPlaybackStateCompat(playerWrapper);
+          postOrRunForCompatSession(() -> sessionCompat.setPlaybackState(playbackStateCompat));
+        });
   }
 
   public void updateLegacySessionPlaybackStateAndQueue(PlayerWrapper playerWrapper) {
     postOrRunOnApplicationHandler(
         () -> {
-          sessionCompat.setPlaybackState(createPlaybackStateCompat(playerWrapper));
+          PlaybackStateCompat playbackStateCompat = createPlaybackStateCompat(playerWrapper);
+          postOrRunForCompatSession(() -> sessionCompat.setPlaybackState(playbackStateCompat));
           controllerLegacyCbForBroadcast.updateQueue(
               playerWrapper.getAvailableCommands().contains(Player.COMMAND_GET_TIMELINE)
                   ? playerWrapper.getCurrentTimeline()
@@ -1256,25 +1302,23 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   }
 
   @SuppressWarnings("nullness:argument") // MediaSessionCompat didn't annotate @Nullable.
-  private static void setMetadata(
-      MediaSessionCompat sessionCompat, @Nullable MediaMetadataCompat metadataCompat) {
-    sessionCompat.setMetadata(metadataCompat);
+  private void setMetadata(@Nullable MediaMetadataCompat metadataCompat) {
+    postOrRunForCompatSession(() -> sessionCompat.setMetadata(metadataCompat));
   }
 
   @SuppressWarnings("nullness:argument") // MediaSessionCompat didn't annotate @Nullable.
-  private static void setMediaButtonReceiver(
-      MediaSessionCompat sessionCompat, @Nullable PendingIntent mediaButtonReceiverIntent) {
+  private void setMediaButtonReceiver(@Nullable PendingIntent mediaButtonReceiverIntent) {
     sessionCompat.setMediaButtonReceiver(mediaButtonReceiverIntent);
   }
 
   @SuppressWarnings("nullness:argument") // MediaSessionCompat didn't annotate @Nullable.
-  private static void setQueue(MediaSessionCompat sessionCompat, @Nullable List<QueueItem> queue) {
-    sessionCompat.setQueue(queue);
+  private void setQueue(@Nullable List<QueueItem> queue) {
+    postOrRunForCompatSession(() -> sessionCompat.setQueue(queue));
   }
 
   @SuppressWarnings("nullness:argument") // MediaSessionCompat didn't annotate @Nullable.
-  private void setQueueTitle(MediaSessionCompat sessionCompat, @Nullable CharSequence title) {
-    sessionCompat.setQueueTitle(isQueueEnabled() ? title : null);
+  private void setQueueTitle(boolean isQueueEnabled, @Nullable CharSequence title) {
+    sessionCompat.setQueueTitle(isQueueEnabled ? title : null);
   }
 
   private boolean isQueueEnabled() {
@@ -1306,7 +1350,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
                     /* defaultValue= */ false)
                 != hadNextReservation);
     if (extrasChanged) {
-      getSessionCompat().setExtras(legacyExtras);
+      postOrRunForCompatSession(() -> sessionCompat.setExtras(legacyExtras));
     }
   }
 
@@ -1516,13 +1560,13 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         // Re-calculate custom layout in case we have to set any additional extras.
         updateCustomLayoutAndLegacyExtrasForMediaButtonPreferences();
       }
-      sessionCompat.setExtras(legacyExtras);
+      postOrRunForCompatSession(() -> sessionCompat.setExtras(legacyExtras));
       updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
     }
 
     @Override
     public void onSessionActivityChanged(int seq, @Nullable PendingIntent sessionActivity) {
-      sessionCompat.setSessionActivity(sessionActivity);
+      postOrRunForCompatSession(() -> sessionCompat.setSessionActivity(sessionActivity));
     }
 
     @Override
@@ -1535,9 +1579,10 @@ import org.checkerframework.checker.initialization.qual.Initialized;
               sessionError.message,
               sessionError.extras);
       if (!skipLegacySessionPlaybackStateUpdates()) {
-        sessionCompat.setPlaybackState(createPlaybackStateCompat(playerWrapper));
+        PlaybackStateCompat playbackStateCompat = createPlaybackStateCompat(playerWrapper);
+        postOrRunForCompatSession(() -> sessionCompat.setPlaybackState(playbackStateCompat));
         legacyError = null;
-        sessionCompat.setPlaybackState(createPlaybackStateCompat(playerWrapper));
+        updateLegacySessionPlaybackState(playerWrapper);
       }
     }
 
@@ -1552,7 +1597,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         extras = new Bundle(command.customExtras);
         extras.putAll(args);
       }
-      sessionCompat.sendSessionEvent(command.customAction, extras);
+      postOrRunForCompatSession(() -> sessionCompat.sendSessionEvent(command.customAction, extras));
     }
 
     @Override
@@ -1622,13 +1667,16 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       }
       // MediaMetadataCompat needs to be updated when the media ID or URI of the media item changes.
       updateMetadataIfChanged();
-      if (mediaItem == null) {
-        sessionCompat.setRatingType(RatingCompat.RATING_NONE);
-      } else {
-        sessionCompat.setRatingType(
-            LegacyConversions.getRatingCompatStyle(mediaItem.mediaMetadata.userRating));
-      }
-      updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+      postOrRunForCompatSession(
+          () -> {
+            if (mediaItem == null) {
+              sessionCompat.setRatingType(RatingCompat.RATING_NONE);
+            } else {
+              sessionCompat.setRatingType(
+                  LegacyConversions.getRatingCompatStyle(mediaItem.mediaMetadata.userRating));
+            }
+            updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper());
+          });
     }
 
     @Override
@@ -1652,7 +1700,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
     private void updateQueue(Timeline timeline) {
       if (!isQueueEnabled() || timeline.isEmpty()) {
-        setQueue(sessionCompat, /* queue= */ null);
+        setQueue(/* queue= */ null);
         return;
       }
       List<MediaItem> mediaItemList = LegacyConversions.convertToMediaItemList(timeline);
@@ -1677,7 +1725,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
               sessionImpl.getBitmapLoader().decodeBitmap(metadata.artworkData);
           bitmapFutures.add(bitmapFuture);
           bitmapFuture.addListener(
-              handleBitmapFuturesTask, sessionImpl.getApplicationHandler()::post);
+              handleBitmapFuturesTask, MediaSessionLegacyStub.this::postOrRunForCompatSession);
         }
       }
     }
@@ -1700,7 +1748,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
       // Framework MediaSession#setQueue() uses ParceledListSlice,
       // which means we can safely send long lists.
-      setQueue(sessionCompat, queueItemList);
+      setQueue(queueItemList);
     }
 
     @Override
@@ -1710,23 +1758,31 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         return;
       }
       // Since there is no 'queue metadata', only set title of the queue.
-      @Nullable CharSequence queueTitle = sessionCompat.getController().getQueueTitle();
-      @Nullable CharSequence newTitle = playlistMetadata.title;
-      if (!TextUtils.equals(queueTitle, newTitle)) {
-        setQueueTitle(sessionCompat, newTitle);
-      }
+      final boolean isQueueEnabled = isQueueEnabled();
+      postOrRunForCompatSession(
+          () -> {
+            @Nullable CharSequence queueTitle = sessionCompat.getController().getQueueTitle();
+            @Nullable CharSequence newTitle = playlistMetadata.title;
+            if (!TextUtils.equals(queueTitle, newTitle)) {
+              setQueueTitle(isQueueEnabled, newTitle);
+            }
+          });
     }
 
     @Override
     public void onShuffleModeEnabledChanged(int seq, boolean shuffleModeEnabled) {
-      sessionCompat.setShuffleMode(
-          LegacyConversions.convertToPlaybackStateCompatShuffleMode(shuffleModeEnabled));
+      postOrRunForCompatSession(
+          () ->
+              sessionCompat.setShuffleMode(
+                  LegacyConversions.convertToPlaybackStateCompatShuffleMode(shuffleModeEnabled)));
     }
 
     @Override
     public void onRepeatModeChanged(int seq, @RepeatMode int repeatMode) throws RemoteException {
-      sessionCompat.setRepeatMode(
-          LegacyConversions.convertToPlaybackStateCompatRepeatMode(repeatMode));
+      postOrRunForCompatSession(
+          () ->
+              sessionCompat.setRepeatMode(
+                  LegacyConversions.convertToPlaybackStateCompatRepeatMode(repeatMode)));
     }
 
     @Override
@@ -1734,7 +1790,8 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       @DeviceInfo.PlaybackType
       int playbackType = sessionImpl.getPlayerWrapper().getDeviceInfo().playbackType;
       if (playbackType == DeviceInfo.PLAYBACK_TYPE_LOCAL) {
-        sessionCompat.setPlaybackToLocal(audioAttributes);
+        postOrRunForCompatSession(
+            () -> sessionCompat.setPlaybackToLocal(audioAttributes));
       }
     }
 
@@ -1743,9 +1800,10 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       PlayerWrapper player = sessionImpl.getPlayerWrapper();
       volumeProviderCompat = createVolumeProviderCompat(player);
       if (volumeProviderCompat == null) {
-        sessionCompat.setPlaybackToLocal(player.getAudioAttributesWithCommandCheck());
+        AudioAttributes audioAttributes = player.getAudioAttributesWithCommandCheck();
+        postOrRunForCompatSession(() -> sessionCompat.setPlaybackToLocal(audioAttributes));
       } else {
-        sessionCompat.setPlaybackToRemote(volumeProviderCompat);
+        postOrRunForCompatSession(() -> sessionCompat.setPlaybackToRemote(volumeProviderCompat));
       }
     }
 
@@ -1815,15 +1873,17 @@ import org.checkerframework.checker.initialization.qual.Initialized;
                   if (this != pendingBitmapLoadCallback) {
                     return;
                   }
-                  setMetadata(
-                      sessionCompat,
-                      LegacyConversions.convertToMediaMetadataCompat(
-                          newMediaMetadata,
-                          newMediaId,
-                          newMediaUri,
-                          newDurationMs,
-                          /* artworkBitmap= */ result));
-                  sessionImpl.onNotificationRefreshRequired();
+                  postOrRunForCompatSession(
+                      () -> {
+                        setMetadata(
+                            LegacyConversions.convertToMediaMetadataCompat(
+                                newMediaMetadata,
+                                newMediaId,
+                                newMediaUri,
+                                newDurationMs,
+                                /* artworkBitmap= */ result));
+                        sessionImpl.onNotificationRefreshRequired();
+                      });
                 }
 
                 @Override
@@ -1841,7 +1901,6 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         }
       }
       setMetadata(
-          sessionCompat,
           LegacyConversions.convertToMediaMetadataCompat(
               newMediaMetadata, newMediaId, newMediaUri, newDurationMs, artworkBitmap));
     }

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
@@ -97,7 +97,6 @@ import androidx.media3.session.MediaSession.MediaItemsWithStartPosition;
 import androidx.media3.session.SessionCommand.CommandCode;
 import androidx.media3.session.legacy.MediaControllerCompat;
 import androidx.media3.session.legacy.MediaDescriptionCompat;
-import androidx.media3.session.legacy.MediaMetadataCompat;
 import androidx.media3.session.legacy.MediaSessionCompat;
 import androidx.media3.session.legacy.MediaSessionCompat.QueueItem;
 import androidx.media3.session.legacy.MediaSessionManager;
@@ -110,7 +109,6 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.SettableFuture;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -149,11 +147,8 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   @Nullable private final ComponentName broadcastReceiverComponentName;
   private final boolean playIfSuppressed;
   private final HandlerThread compatSessionInteractionThread;
-  private final Handler compatSessionInteractionHandler;
   private final Runnable callOnNotificationRefreshRequiredRunnable =
       this::callOnNotificationRefreshRequiredIfNeeded;
-  private final Runnable requestNotificationRefreshRunnable =
-      () -> notificationRefreshRequiredPending = true;
 
   private volatile long connectionTimeoutMs;
   @Nullable private FutureCallback<Bitmap> pendingBitmapLoadCallback;
@@ -204,7 +199,6 @@ import org.checkerframework.checker.initialization.qual.Initialized;
             session.getApplicationHandler().getLooper(), connectedControllersManager);
     compatSessionInteractionThread = new HandlerThread("MSLegacyStub:CompatSIT");
     compatSessionInteractionThread.start();
-    compatSessionInteractionHandler = new Handler(compatSessionInteractionThread.getLooper());
     mayNeedButtonReservationWorkaroundForSeekbar =
         mayNeedButtonReservationWorkaroundForSeekbar(context);
 
@@ -271,31 +265,24 @@ import org.checkerframework.checker.initialization.qual.Initialized;
             sessionCompatId,
             SDK_INT < 31 ? receiverComponentName : null,
             SDK_INT < 31 ? mediaButtonIntent : null,
+            sessionActivity,
             /* sessionInfo= */ tokenExtras,
             packageNameOverride,
-            compatSessionInteractionHandler.getLooper());
+            compatSessionInteractionThread.getLooper());
     if (SDK_INT >= 31 && broadcastReceiverComponentName != null) {
       Api31.setMediaButtonBroadcastReceiver(sessionCompat, broadcastReceiverComponentName);
-    }
-
-    if (sessionActivity != null) {
-      sessionCompat.setSessionActivity(sessionActivity);
     }
 
     @SuppressWarnings("nullness:assignment")
     @Initialized
     MediaSessionLegacyStub thisRef = this;
-    sessionCompat.setCallback(thisRef, compatSessionInteractionHandler);
+    sessionCompat.setCallback(thisRef, session.getApplicationHandler());
 
     androidAutoObserver =
         mayNeedButtonReservationWorkaroundForSeekbar
             ? new AndroidAutoConnectionStateObserver(
                 context, thisRef::onAndroidAutoConnectionStateChanged)
             : null;
-  }
-
-  private void postOrRunForCompatSession(Runnable r) {
-    postOrRun(compatSessionInteractionHandler, r);
   }
 
   /**
@@ -460,7 +447,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
   /** Starts to receive commands. */
   public void start() {
-    postOrRunForCompatSession(() -> sessionCompat.setActive(true));
+    sessionCompat.setActive(true);
   }
 
   @SuppressWarnings("PendingIntentMutability") // We can't use SaferPendingIntent.
@@ -468,31 +455,28 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     if (runtimeBroadcastReceiver != null) {
       sessionImpl.getContext().unregisterReceiver(runtimeBroadcastReceiver);
     }
+    if (SDK_INT < 31) {
+      if (broadcastReceiverComponentName == null) {
+        // No broadcast receiver available. Playback resumption not supported.
+        /* mediaButtonReceiverIntent= */ sessionCompat.setMediaButtonReceiver(null);
+      } else {
+        // Override the runtime receiver with the broadcast receiver for playback resumption.
+        Intent intent = new Intent(Intent.ACTION_MEDIA_BUTTON, sessionImpl.getUri());
+        intent.setComponent(broadcastReceiverComponentName);
+        PendingIntent mediaButtonReceiverIntent =
+            PendingIntent.getBroadcast(
+                sessionImpl.getContext(),
+                /* requestCode= */ 0,
+                intent,
+                PENDING_INTENT_FLAG_MUTABLE);
+        sessionCompat.setMediaButtonReceiver(mediaButtonReceiverIntent);
+      }
+    }
     if (androidAutoObserver != null) {
       androidAutoObserver.release();
     }
-    postOrRunForCompatSession(
-        () -> {
-          if (SDK_INT < 31) {
-            if (broadcastReceiverComponentName == null) {
-              // No broadcast receiver available. Playback resumption not supported.
-              setMediaButtonReceiver(/* mediaButtonReceiverIntent= */ null);
-            } else {
-              // Override the runtime receiver with the broadcast receiver for playback resumption.
-              Intent intent = new Intent(Intent.ACTION_MEDIA_BUTTON, sessionImpl.getUri());
-              intent.setComponent(broadcastReceiverComponentName);
-              PendingIntent mediaButtonReceiverIntent =
-                  PendingIntent.getBroadcast(
-                      sessionImpl.getContext(),
-                      /* requestCode= */ 0,
-                      intent,
-                      PENDING_INTENT_FLAG_MUTABLE);
-              setMediaButtonReceiver(mediaButtonReceiverIntent);
-            }
-          }
-          // No check for COMMAND_RELEASE needed as MediaControllers can always be released.
-          sessionCompat.release();
-        });
+    // No check for COMMAND_RELEASE needed as MediaControllers can always be released.
+    sessionCompat.release();
     compatSessionInteractionThread.quitSafely();
     connectedControllersManager.release();
   }
@@ -557,18 +541,6 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
   @Override
   public boolean onMediaButtonEvent(Intent intent) {
-    if (Looper.myLooper() != sessionImpl.getApplicationHandler().getLooper()) {
-      SettableFuture<Boolean> settableFuture = SettableFuture.create();
-      sessionImpl
-          .getApplicationHandler()
-          .post(() -> settableFuture.set(onMediaButtonEvent(intent)));
-      // Block compatSessionInteractionThread until we have a decision.
-      try {
-        return settableFuture.get();
-      } catch (InterruptedException | ExecutionException e) {
-        throw new RuntimeException(e);
-      }
-    }
     return sessionImpl.onMediaButtonEvent(
         new ControllerInfo(
             checkNotNull(sessionCompat.getCurrentControllerInfo()),
@@ -589,7 +561,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
             : 0;
     if (sessionFlags != newFlags) {
       sessionFlags = newFlags;
-      postOrRunForCompatSession(() -> sessionCompat.setFlags(sessionFlags));
+      sessionCompat.setFlags(sessionFlags);
     }
   }
 
@@ -692,46 +664,36 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
   @Override
   public void onSkipToNext() {
-    RemoteUserInfo controllerInfo = sessionCompat.getCurrentControllerInfo();
-    postOrRun(
-        sessionImpl.getApplicationHandler(),
-        () -> {
-          if (sessionImpl.getPlayerWrapper().isCommandAvailable(COMMAND_SEEK_TO_NEXT)) {
-            dispatchSessionTaskWithPlayerCommand(
-                COMMAND_SEEK_TO_NEXT,
-                controller -> sessionImpl.getPlayerWrapper().seekToNext(),
-                controllerInfo,
-                /* callOnPlayerInteractionFinished= */ true);
-          } else {
-            dispatchSessionTaskWithPlayerCommand(
-                COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
-                controller -> sessionImpl.getPlayerWrapper().seekToNextMediaItem(),
-                controllerInfo,
-                /* callOnPlayerInteractionFinished= */ true);
-          }
-        });
+    if (sessionImpl.getPlayerWrapper().isCommandAvailable(COMMAND_SEEK_TO_NEXT)) {
+      dispatchSessionTaskWithPlayerCommand(
+          COMMAND_SEEK_TO_NEXT,
+          controller -> sessionImpl.getPlayerWrapper().seekToNext(),
+          sessionCompat.getCurrentControllerInfo(),
+          /* callOnPlayerInteractionFinished= */ true);
+    } else {
+      dispatchSessionTaskWithPlayerCommand(
+          COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
+          controller -> sessionImpl.getPlayerWrapper().seekToNextMediaItem(),
+          sessionCompat.getCurrentControllerInfo(),
+          /* callOnPlayerInteractionFinished= */ true);
+    }
   }
 
   @Override
   public void onSkipToPrevious() {
-    RemoteUserInfo controllerInfo = sessionCompat.getCurrentControllerInfo();
-    postOrRun(
-        sessionImpl.getApplicationHandler(),
-        () -> {
-          if (sessionImpl.getPlayerWrapper().isCommandAvailable(COMMAND_SEEK_TO_PREVIOUS)) {
-            dispatchSessionTaskWithPlayerCommand(
-                COMMAND_SEEK_TO_PREVIOUS,
-                controller -> sessionImpl.getPlayerWrapper().seekToPrevious(),
-                controllerInfo,
-                /* callOnPlayerInteractionFinished= */ true);
-          } else {
-            dispatchSessionTaskWithPlayerCommand(
-                COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
-                controller -> sessionImpl.getPlayerWrapper().seekToPreviousMediaItem(),
-                controllerInfo,
-                /* callOnPlayerInteractionFinished= */ true);
-          }
-        });
+    if (sessionImpl.getPlayerWrapper().isCommandAvailable(COMMAND_SEEK_TO_PREVIOUS)) {
+      dispatchSessionTaskWithPlayerCommand(
+          COMMAND_SEEK_TO_PREVIOUS,
+          controller -> sessionImpl.getPlayerWrapper().seekToPrevious(),
+          sessionCompat.getCurrentControllerInfo(),
+          /* callOnPlayerInteractionFinished= */ true);
+    } else {
+      dispatchSessionTaskWithPlayerCommand(
+          COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+          controller -> sessionImpl.getPlayerWrapper().seekToPreviousMediaItem(),
+          sessionCompat.getCurrentControllerInfo(),
+          /* callOnPlayerInteractionFinished= */ true);
+    }
   }
 
   @Override
@@ -920,50 +882,49 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       Log.d(TAG, "RemoteUserInfo is null, ignoring command=" + command);
       return;
     }
-    postOrRunOnApplicationHandler(
-        () ->
-            handleControllerTaskOnHandler(
-                remoteUserInfo,
-                controller -> {
-                  if (!connectedControllersManager.isPlayerCommandAvailable(controller, command)) {
-                    if (command == COMMAND_PLAY_PAUSE
-                        && !sessionImpl.getPlayerWrapper().getPlayWhenReady()) {
-                      Log.w(
-                          TAG,
-                          "Calling play() omitted due to COMMAND_PLAY_PAUSE not being available."
-                              + " If this play command has started the service for instance for"
-                              + " playback resumption, this may prevent the service from being"
-                              + " started into the foreground.");
-                    }
-                    return;
-                  }
-                  int resultCode = sessionImpl.onPlayerCommandRequestOnHandler(controller, command);
-                  if (resultCode != RESULT_SUCCESS) {
-                    // Don't run rejected command.
-                    return;
-                  }
 
-                  sessionImpl
-                      .callWithControllerForCurrentRequestSet(
-                          controller,
-                          () -> {
-                            try {
-                              task.run(controller);
-                            } catch (RemoteException e) {
-                              // That's TransactionTooLargeException or DeadSystemException.
-                              // We'd better to leave log for those cases because
-                              //   - TransactionTooLargeException means that we may need to fix our
-                              //     code (e.g. add pagination or special way to deliver Bitmap).
-                              //   - DeadSystemException means that errors around it can be ignored.
-                              Log.w(TAG, "Exception in " + controller, e);
-                            }
-                          })
-                      .run();
-                  if (callOnPlayerInteractionFinished) {
-                    sessionImpl.onPlayerInteractionFinishedOnHandler(
-                        controller, new Player.Commands.Builder().add(command).build());
-                  }
-                }));
+    handleControllerTaskOnHandler(
+        remoteUserInfo,
+        controller -> {
+          if (!connectedControllersManager.isPlayerCommandAvailable(controller, command)) {
+            if (command == COMMAND_PLAY_PAUSE
+                && !sessionImpl.getPlayerWrapper().getPlayWhenReady()) {
+              Log.w(
+                  TAG,
+                  "Calling play() omitted due to COMMAND_PLAY_PAUSE not being available."
+                      + " If this play command has started the service for instance for"
+                      + " playback resumption, this may prevent the service from being"
+                      + " started into the foreground.");
+            }
+            return;
+          }
+          int resultCode = sessionImpl.onPlayerCommandRequestOnHandler(controller, command);
+          if (resultCode != RESULT_SUCCESS) {
+            // Don't run rejected command.
+            return;
+          }
+
+          sessionImpl
+              .callWithControllerForCurrentRequestSet(
+                  controller,
+                  () -> {
+                    try {
+                      task.run(controller);
+                    } catch (RemoteException e) {
+                      // That's TransactionTooLargeException or DeadSystemException.
+                      // We'd better to leave log for those cases because
+                      //   - TransactionTooLargeException means that we may need to fix our
+                      //     code (e.g. add pagination or special way to deliver Bitmap).
+                      //   - DeadSystemException means that errors around it can be ignored.
+                      Log.w(TAG, "Exception in " + controller, e);
+                    }
+                  })
+              .run();
+          if (callOnPlayerInteractionFinished) {
+            sessionImpl.onPlayerInteractionFinishedOnHandler(
+                controller, new Player.Commands.Builder().add(command).build());
+          }
+        });
   }
 
   private void dispatchSessionTaskWithSetRatingSessionCommand(Rating rating) {
@@ -1001,33 +962,31 @@ import org.checkerframework.checker.initialization.qual.Initialized;
               + (sessionCommand == null ? commandCode : sessionCommand));
       return;
     }
-    postOrRunOnApplicationHandler(
-        () ->
-            handleControllerTaskOnHandler(
-                remoteUserInfo,
-                controller -> {
-                  if (sessionCommand != null) {
-                    if (!connectedControllersManager.isSessionCommandAvailable(
-                        controller, sessionCommand)) {
-                      return;
-                    }
-                  } else {
-                    if (!connectedControllersManager.isSessionCommandAvailable(
-                        controller, commandCode)) {
-                      return;
-                    }
-                  }
-                  try {
-                    task.run(controller);
-                  } catch (RemoteException e) {
-                    // That's TransactionTooLargeException or DeadSystemException.
-                    // We'd better to leave log for those cases because
-                    //   - TransactionTooLargeException means that we may need to fix our code (e.g.
-                    //     add pagination or special way to deliver Bitmap).
-                    //   - DeadSystemException means that errors around it can be ignored.
-                    Log.w(TAG, "Exception in " + controller, e);
-                  }
-                }));
+    handleControllerTaskOnHandler(
+        remoteUserInfo,
+        controller -> {
+          if (sessionCommand != null) {
+            if (!connectedControllersManager.isSessionCommandAvailable(
+                controller, sessionCommand)) {
+              return;
+            }
+          } else {
+            if (!connectedControllersManager.isSessionCommandAvailable(
+                controller, commandCode)) {
+              return;
+            }
+          }
+          try {
+            task.run(controller);
+          } catch (RemoteException e) {
+            // That's TransactionTooLargeException or DeadSystemException.
+            // We'd better to leave log for those cases because
+            //   - TransactionTooLargeException means that we may need to fix our code (e.g.
+            //     add pagination or special way to deliver Bitmap).
+            //   - DeadSystemException means that errors around it can be ignored.
+            Log.w(TAG, "Exception in " + controller, e);
+          }
+        });
   }
 
   private void dispatchCustomCommandAsPredefinedCommand(SessionCommand command) {
@@ -1162,12 +1121,8 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   public void updateLegacySessionPlaybackState(PlayerWrapper playerWrapper, boolean notify) {
     postOrRunOnApplicationHandler(
         () -> {
-          PlaybackStateCompat playbackStateCompat = createPlaybackStateCompat(playerWrapper);
-          postOrRunForCompatSession(
-              () -> {
-                sessionCompat.setPlaybackState(playbackStateCompat);
-                requestNotificationRefresh(notify);
-              });
+          requestNotificationRefreshWhenDone(
+              sessionCompat.setPlaybackState(createPlaybackStateCompat(playerWrapper)), notify);
         });
   }
 
@@ -1175,8 +1130,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       PlayerWrapper playerWrapper, boolean notify) {
       postOrRunOnApplicationHandler(
         () -> {
-          PlaybackStateCompat playbackStateCompat = createPlaybackStateCompat(playerWrapper);
-          postOrRunForCompatSession(() -> sessionCompat.setPlaybackState(playbackStateCompat));
+          sessionCompat.setPlaybackState(createPlaybackStateCompat(playerWrapper));
           controllerLegacyCbForBroadcast.updateQueue(
               playerWrapper.getAvailableCommands().contains(Player.COMMAND_GET_TIMELINE)
                   ? playerWrapper.getCurrentTimeline()
@@ -1316,43 +1270,25 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   }
 
   private void requestNotificationRefresh(boolean postRunnable) {
-    if (compatSessionInteractionHandler.getLooper().isCurrentThread()) {
-      notificationRefreshRequiredPending = true;
-    } else {
-      compatSessionInteractionHandler.post(requestNotificationRefreshRunnable);
-    }
+    notificationRefreshRequiredPending = true;
     if (postRunnable) {
       postOnNotificationRefreshRequiredRunnable();
     }
   }
 
   private void postOnNotificationRefreshRequiredRunnable() {
-    compatSessionInteractionHandler.removeCallbacks(callOnNotificationRefreshRequiredRunnable);
-    compatSessionInteractionHandler.post(callOnNotificationRefreshRequiredRunnable);
+    sessionImpl.getApplicationHandler().removeCallbacks(callOnNotificationRefreshRequiredRunnable);
+    sessionImpl.getApplicationHandler().post(callOnNotificationRefreshRequiredRunnable);
   }
 
   private static <T> void ignoreFuture(@Nullable Future<T> unused) {
     // no-op
   }
 
-  @SuppressWarnings("nullness:argument") // MediaSessionCompat didn't annotate @Nullable.
-  private void setMetadata(@Nullable MediaMetadataCompat metadataCompat) {
-    sessionCompat.setMetadata(metadataCompat);
-  }
-
-  @SuppressWarnings("nullness:argument") // MediaSessionCompat didn't annotate @Nullable.
-  private void setMediaButtonReceiver(@Nullable PendingIntent mediaButtonReceiverIntent) {
-    sessionCompat.setMediaButtonReceiver(mediaButtonReceiverIntent);
-  }
-
-  @SuppressWarnings("nullness:argument") // MediaSessionCompat didn't annotate @Nullable.
-  private void setQueue(@Nullable List<QueueItem> queue) {
-    sessionCompat.setQueue(queue);
-  }
-
-  @SuppressWarnings("nullness:argument") // MediaSessionCompat didn't annotate @Nullable.
-  private void setQueueTitle(boolean isQueueEnabled, @Nullable CharSequence title) {
-    sessionCompat.setQueueTitle(isQueueEnabled ? title : null);
+  private <T> void requestNotificationRefreshWhenDone(
+      ListenableFuture<T> future, boolean postRunnable) {
+    future.addListener(
+        () -> requestNotificationRefresh(postRunnable), sessionImpl.getApplicationHandler()::post);
   }
 
   private boolean isQueueEnabled() {
@@ -1384,7 +1320,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
                     /* defaultValue= */ false)
                 != hadNextReservation);
     if (extrasChanged) {
-      postOrRunForCompatSession(() -> sessionCompat.setExtras(legacyExtras));
+      sessionCompat.setExtras(legacyExtras);
     }
   }
 
@@ -1594,13 +1530,13 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         // Re-calculate custom layout in case we have to set any additional extras.
         updateCustomLayoutAndLegacyExtrasForMediaButtonPreferences();
       }
-      postOrRunForCompatSession(() -> sessionCompat.setExtras(legacyExtras));
+      sessionCompat.setExtras(legacyExtras);
       updateLegacySessionPlaybackState(sessionImpl.getPlayerWrapper(), false);
     }
 
     @Override
     public void onSessionActivityChanged(int seq, @Nullable PendingIntent sessionActivity) {
-      postOrRunForCompatSession(() -> sessionCompat.setSessionActivity(sessionActivity));
+      sessionCompat.setSessionActivity(sessionActivity);
     }
 
     @Override
@@ -1614,7 +1550,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
               sessionError.extras);
       if (!skipLegacySessionPlaybackStateUpdates()) {
         PlaybackStateCompat playbackStateCompat = createPlaybackStateCompat(playerWrapper);
-        postOrRunForCompatSession(() -> sessionCompat.setPlaybackState(playbackStateCompat));
+        sessionCompat.setPlaybackState(playbackStateCompat);
         legacyError = null;
         updateLegacySessionPlaybackState(playerWrapper, false);
       }
@@ -1631,7 +1567,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         extras = new Bundle(command.customExtras);
         extras.putAll(args);
       }
-      postOrRunForCompatSession(() -> sessionCompat.sendSessionEvent(command.customAction, extras));
+      sessionCompat.sendSessionEvent(command.customAction, extras);
     }
 
     @Override
@@ -1701,19 +1637,15 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       }
       // MediaMetadataCompat needs to be updated when the media ID or URI of the media item changes.
       updateMetadataIfChanged(false);
-      PlaybackStateCompat playbackStateCompat =
-          createPlaybackStateCompat(sessionImpl.getPlayerWrapper());
-      postOrRunForCompatSession(
-          () -> {
-            if (mediaItem == null) {
-              sessionCompat.setRatingType(RatingCompat.RATING_NONE);
-            } else {
-              sessionCompat.setRatingType(
-                  LegacyConversions.getRatingCompatStyle(mediaItem.mediaMetadata.userRating));
-            }
-            sessionCompat.setPlaybackState(playbackStateCompat);
-            requestNotificationRefresh(true);
-          });
+      if (mediaItem == null) {
+        sessionCompat.setRatingType(RatingCompat.RATING_NONE);
+      } else {
+        sessionCompat.setRatingType(
+            LegacyConversions.getRatingCompatStyle(mediaItem.mediaMetadata.userRating));
+      }
+      requestNotificationRefreshWhenDone(
+          sessionCompat.setPlaybackState(createPlaybackStateCompat(sessionImpl.getPlayerWrapper())),
+          true);
     }
 
     @Override
@@ -1737,11 +1669,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
     private void updateQueue(Timeline timeline, boolean notify) {
       if (!isQueueEnabled() || timeline.isEmpty()) {
-        postOrRunForCompatSession(
-            () -> {
-              setQueue(/* queue= */ null);
-              requestNotificationRefresh(notify);
-            });
+        requestNotificationRefreshWhenDone(sessionCompat.computeAndSetQueue(null), notify);
         return;
       }
       List<MediaItem> mediaItemList = LegacyConversions.convertToMediaItemList(timeline);
@@ -1760,13 +1688,13 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         MediaMetadata metadata = mediaItem.mediaMetadata;
         if (metadata.artworkData == null) {
           bitmapFutures.add(null);
-          postOrRunForCompatSession(handleBitmapFuturesTask);
+          handleBitmapFuturesTask.run();
         } else {
           ListenableFuture<Bitmap> bitmapFuture =
               sessionImpl.getBitmapLoader().decodeBitmap(metadata.artworkData);
           bitmapFutures.add(bitmapFuture);
           bitmapFuture.addListener(
-              handleBitmapFuturesTask, MediaSessionLegacyStub.this::postOrRunForCompatSession);
+              handleBitmapFuturesTask, sessionImpl.getApplicationHandler()::post);
         }
       }
     }
@@ -1775,24 +1703,31 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         List<@NullableType ListenableFuture<Bitmap>> bitmapFutures,
         List<MediaItem> mediaItems,
         boolean notify) {
-      List<QueueItem> queueItemList = new ArrayList<>();
-      for (int i = 0; i < bitmapFutures.size(); i++) {
-        @Nullable ListenableFuture<Bitmap> future = bitmapFutures.get(i);
-        @Nullable Bitmap bitmap = null;
-        if (future != null) {
-          try {
-            bitmap = Futures.getDone(future);
-          } catch (CancellationException | ExecutionException e) {
-            Log.d(TAG, "Failed to get bitmap", e);
-          }
-        }
-        queueItemList.add(LegacyConversions.convertToQueueItem(mediaItems.get(i), i, bitmap));
-      }
-
       // Framework MediaSession#setQueue() uses ParceledListSlice,
       // which means we can safely send long lists.
-      setQueue(queueItemList);
-      requestNotificationRefresh(notify);
+      requestNotificationRefreshWhenDone(
+          sessionCompat.computeAndSetQueue(
+              () -> {
+                // Do conversions on a background thread instead of the session thread, as we may
+                // have a lot
+                // of media items to convert.
+                List<QueueItem> queueItemList = new ArrayList<>(bitmapFutures.size());
+                for (int i = 0; i < bitmapFutures.size(); i++) {
+                  @Nullable ListenableFuture<Bitmap> future = bitmapFutures.get(i);
+                  @Nullable Bitmap bitmap = null;
+                  if (future != null) {
+                    try {
+                      bitmap = Futures.getDone(future);
+                    } catch (CancellationException | ExecutionException e) {
+                      Log.d(TAG, "Failed to get bitmap", e);
+                    }
+                  }
+                  queueItemList.add(
+                      LegacyConversions.convertToQueueItem(mediaItems.get(i), i, bitmap));
+                }
+                return queueItemList;
+              }),
+          notify);
     }
 
     @Override
@@ -1802,31 +1737,23 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         return;
       }
       // Since there is no 'queue metadata', only set title of the queue.
-      final boolean isQueueEnabled = isQueueEnabled();
-      postOrRunForCompatSession(
-          () -> {
-            @Nullable CharSequence queueTitle = sessionCompat.getController().getQueueTitle();
-            @Nullable CharSequence newTitle = playlistMetadata.title;
-            if (!TextUtils.equals(queueTitle, newTitle)) {
-              setQueueTitle(isQueueEnabled, newTitle);
-            }
-          });
+      @Nullable CharSequence queueTitle = sessionCompat.getController().getQueueTitle();
+      @Nullable CharSequence newTitle = isQueueEnabled() ? playlistMetadata.title : null;
+      if (!TextUtils.equals(queueTitle, newTitle)) {
+        sessionCompat.setQueueTitle(newTitle);
+      }
     }
 
     @Override
     public void onShuffleModeEnabledChanged(int seq, boolean shuffleModeEnabled) {
-      postOrRunForCompatSession(
-          () ->
-              sessionCompat.setShuffleMode(
-                  LegacyConversions.convertToPlaybackStateCompatShuffleMode(shuffleModeEnabled)));
+      sessionCompat.setShuffleMode(
+          LegacyConversions.convertToPlaybackStateCompatShuffleMode(shuffleModeEnabled));
     }
 
     @Override
     public void onRepeatModeChanged(int seq, @RepeatMode int repeatMode) throws RemoteException {
-      postOrRunForCompatSession(
-          () ->
-              sessionCompat.setRepeatMode(
-                  LegacyConversions.convertToPlaybackStateCompatRepeatMode(repeatMode)));
+      sessionCompat.setRepeatMode(
+          LegacyConversions.convertToPlaybackStateCompatRepeatMode(repeatMode));
     }
 
     @Override
@@ -1834,14 +1761,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       @DeviceInfo.PlaybackType
       int playbackType = sessionImpl.getPlayerWrapper().getDeviceInfo().playbackType;
       if (playbackType == DeviceInfo.PLAYBACK_TYPE_LOCAL) {
-        postOrRunForCompatSession(
-            () -> {
-              if (volumeProviderCompat != null) {
-                // Stale event.
-                return;
-              }
-              sessionCompat.setPlaybackToLocal(audioAttributes);
-            });
+        sessionCompat.setPlaybackToLocal(audioAttributes);
       }
     }
 
@@ -1851,21 +1771,9 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       volumeProviderCompat = createVolumeProviderCompat(player);
       if (volumeProviderCompat == null) {
         AudioAttributes audioAttributes = player.getAudioAttributesWithCommandCheck();
-        postOrRunForCompatSession(() -> {
-          if (volumeProviderCompat != null) {
-            // Stale event.
-            return;
-          }
-          sessionCompat.setPlaybackToLocal(audioAttributes);
-        });
+        sessionCompat.setPlaybackToLocal(audioAttributes);
       } else {
-        postOrRunForCompatSession(() -> {
-          if (volumeProviderCompat == null) {
-            // Stale event.
-            return;
-          }
-          sessionCompat.setPlaybackToRemote(volumeProviderCompat);
-        });
+        sessionCompat.setPlaybackToRemote(volumeProviderCompat);
       }
     }
 
@@ -1938,17 +1846,15 @@ import org.checkerframework.checker.initialization.qual.Initialized;
                   if (this != pendingBitmapLoadCallback) {
                     return;
                   }
-                  postOrRunForCompatSession(
-                      () -> {
-                        setMetadata(
-                            LegacyConversions.convertToMediaMetadataCompat(
-                                newMediaMetadata,
-                                newMediaId,
-                                newMediaUri,
-                                newDurationMs,
-                                /* artworkBitmap= */ result));
-                        requestNotificationRefresh(true);
-                      });
+                  requestNotificationRefreshWhenDone(
+                      sessionCompat.setMetadata(
+                          LegacyConversions.convertToMediaMetadataCompat(
+                              newMediaMetadata,
+                              newMediaId,
+                              newMediaUri,
+                              newDurationMs,
+                              /* artworkBitmap= */ result)),
+                      true);
                 }
 
                 @Override
@@ -1965,14 +1871,11 @@ import org.checkerframework.checker.initialization.qual.Initialized;
               /* executor= */ sessionImpl.getApplicationHandler()::post);
         }
       }
-      @Nullable Bitmap artworkBitmapFinal = artworkBitmap;
-      postOrRunForCompatSession(
-          () -> {
-            setMetadata(
-                LegacyConversions.convertToMediaMetadataCompat(
-                    newMediaMetadata, newMediaId, newMediaUri, newDurationMs, artworkBitmapFinal));
-            requestNotificationRefresh(notify);
-          });
+      requestNotificationRefreshWhenDone(
+          sessionCompat.setMetadata(
+              LegacyConversions.convertToMediaMetadataCompat(
+                  newMediaMetadata, newMediaId, newMediaUri, newDurationMs, artworkBitmap)),
+          notify);
     }
   }
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
@@ -1516,8 +1516,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
               sessionError.message,
               sessionError.extras);
       if (!skipLegacySessionPlaybackStateUpdates()) {
-        PlaybackStateCompat playbackStateCompat = createPlaybackStateCompat(playerWrapper);
-        sessionCompat.setPlaybackState(playbackStateCompat);
+        sessionCompat.setPlaybackState(createPlaybackStateCompat(playerWrapper));
         legacyError = null;
         updateLegacySessionPlaybackState(playerWrapper);
       }
@@ -1671,14 +1670,12 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       // Framework MediaSession#setQueue() uses ParceledListSlice,
       // which means we can safely send long lists.
       // Do conversions on a background thread instead of the session thread, as we may
-      // have a lot
-      // of media items to convert.
+      // have a lot of media items to convert.
       ListenableFuture<Void> completion =
           sessionCompat.computeAndSetQueue(
               () -> {
                 // Do conversions on a background thread instead of the session thread, as we may
-                // have a lot
-                // of media items to convert.
+                // have a lot of media items to convert.
                 List<QueueItem> queueItemList = new ArrayList<>(bitmapFutures.size());
                 for (int i = 0; i < bitmapFutures.size(); i++) {
                   @Nullable ListenableFuture<Bitmap> future = bitmapFutures.get(i);

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
@@ -150,6 +150,10 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   private final boolean playIfSuppressed;
   private final HandlerThread compatSessionInteractionThread;
   private final Handler compatSessionInteractionHandler;
+  private final Runnable callOnNotificationRefreshRequiredRunnable =
+      this::callOnNotificationRefreshRequiredIfNeeded;
+  private final Runnable requestNotificationRefreshRunnable =
+      () -> notificationRefreshRequiredPending = true;
 
   private volatile long connectionTimeoutMs;
   @Nullable private FutureCallback<Bitmap> pendingBitmapLoadCallback;
@@ -157,6 +161,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   private int sessionFlags;
   @Nullable private LegacyError legacyError;
   private Bundle legacyExtras;
+  private boolean notificationRefreshRequiredPending;
   private ImmutableList<CommandButton> customLayout;
   private ImmutableList<CommandButton> mediaButtonPreferences;
   private SessionCommands availableSessionCommands;
@@ -1161,9 +1166,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
           postOrRunForCompatSession(
               () -> {
                 sessionCompat.setPlaybackState(playbackStateCompat);
-                if (notify) {
-                  sessionImpl.onNotificationRefreshRequired();
-                }
+                requestNotificationRefresh(notify);
               });
         });
   }
@@ -1303,6 +1306,29 @@ import org.checkerframework.checker.initialization.qual.Initialized;
           receiver.send(result.resultCode, result.extras);
         },
         MoreExecutors.directExecutor());
+  }
+
+  private void callOnNotificationRefreshRequiredIfNeeded() {
+    if (notificationRefreshRequiredPending) {
+      sessionImpl.onNotificationRefreshRequired();
+      notificationRefreshRequiredPending = false;
+    }
+  }
+
+  private void requestNotificationRefresh(boolean postRunnable) {
+    if (compatSessionInteractionHandler.getLooper().isCurrentThread()) {
+      notificationRefreshRequiredPending = true;
+    } else {
+      compatSessionInteractionHandler.post(requestNotificationRefreshRunnable);
+    }
+    if (postRunnable) {
+      postOnNotificationRefreshRequiredRunnable();
+    }
+  }
+
+  private void postOnNotificationRefreshRequiredRunnable() {
+    compatSessionInteractionHandler.removeCallbacks(callOnNotificationRefreshRequiredRunnable);
+    compatSessionInteractionHandler.post(callOnNotificationRefreshRequiredRunnable);
   }
 
   private static <T> void ignoreFuture(@Nullable Future<T> unused) {
@@ -1686,7 +1712,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
                   LegacyConversions.getRatingCompatStyle(mediaItem.mediaMetadata.userRating));
             }
             sessionCompat.setPlaybackState(playbackStateCompat);
-            sessionImpl.onNotificationRefreshRequired();
+            requestNotificationRefresh(true);
           });
     }
 
@@ -1714,9 +1740,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         postOrRunForCompatSession(
             () -> {
               setQueue(/* queue= */ null);
-              if (notify) {
-                sessionImpl.onNotificationRefreshRequired();
-              }
+              requestNotificationRefresh(notify);
             });
         return;
       }
@@ -1768,9 +1792,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       // Framework MediaSession#setQueue() uses ParceledListSlice,
       // which means we can safely send long lists.
       setQueue(queueItemList);
-      if (notify) {
-        sessionImpl.onNotificationRefreshRequired();
-      }
+      requestNotificationRefresh(notify);
     }
 
     @Override
@@ -1887,7 +1909,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
           && Objects.equals(lastMediaUri, newMediaUri)
           && lastDurationMs == newDurationMs) {
         if (notify) {
-          sessionImpl.onNotificationRefreshRequired();
+          postOnNotificationRefreshRequiredRunnable();
         }
         return;
       }
@@ -1925,7 +1947,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
                                 newMediaUri,
                                 newDurationMs,
                                 /* artworkBitmap= */ result));
-                        sessionImpl.onNotificationRefreshRequired();
+                        requestNotificationRefresh(true);
                       });
                 }
 
@@ -1949,9 +1971,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
             setMetadata(
                 LegacyConversions.convertToMediaMetadataCompat(
                     newMediaMetadata, newMediaId, newMediaUri, newDurationMs, artworkBitmapFinal));
-            if (notify) {
-              sessionImpl.onNotificationRefreshRequired();
-            }
+            requestNotificationRefresh(notify);
           });
     }
   }

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
@@ -305,20 +305,15 @@ import org.checkerframework.checker.initialization.qual.Initialized;
     postOrRun(
         sessionImpl.getApplicationHandler(),
         () -> {
-          // Because setAvailableCommands can be called from any thread and processing the updated
-          // state requires going through both player and background thread, we must manually
-          // trigger a refresh of the notification and cannot rely on MediaNotificationManager.
           ListenableFuture<Void> completion =
               sessionCompat.setPlaybackState(createPlaybackStateCompat(playerWrapper));
+          completion.addListener(
+              sessionImpl::onNotificationRefreshRequired, MoreExecutors.directExecutor());
           if (commandGetTimelineChanged) {
-            // will refresh notification once all bitmaps are loaded
             controllerLegacyCbForBroadcast.updateQueue(
                 playerWrapper.getAvailableCommands().contains(Player.COMMAND_GET_TIMELINE)
                     ? playerWrapper.getCurrentTimeline()
                     : Timeline.EMPTY);
-          } else {
-            completion.addListener(
-                sessionImpl::onNotificationRefreshRequired, MoreExecutors.directExecutor());
           }
         });
   }
@@ -1633,9 +1628,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 
     private void updateQueue(Timeline timeline) {
       if (!isQueueEnabled() || timeline.isEmpty()) {
-        ListenableFuture<Void> completion = sessionCompat.computeAndSetQueue(null);
-        completion.addListener(
-            sessionImpl::onNotificationRefreshRequired, MoreExecutors.directExecutor());
+        sessionCompat.computeAndSetQueue(null);
         return;
       }
       List<MediaItem> mediaItemList = LegacyConversions.convertToMediaItemList(timeline);
@@ -1671,32 +1664,26 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       // which means we can safely send long lists.
       // Do conversions on a background thread instead of the session thread, as we may
       // have a lot of media items to convert.
-      ListenableFuture<Void> completion =
-          sessionCompat.computeAndSetQueue(
-              () -> {
-                // Do conversions on a background thread instead of the session thread, as we may
-                // have a lot of media items to convert.
-                List<QueueItem> queueItemList = new ArrayList<>(bitmapFutures.size());
-                for (int i = 0; i < bitmapFutures.size(); i++) {
-                  @Nullable ListenableFuture<Bitmap> future = bitmapFutures.get(i);
-                  @Nullable Bitmap bitmap = null;
-                  if (future != null) {
-                    try {
-                      bitmap = Futures.getDone(future);
-                    } catch (CancellationException | ExecutionException e) {
-                      Log.d(TAG, "Failed to get bitmap", e);
-                    }
-                  }
-                  queueItemList.add(
-                      LegacyConversions.convertToQueueItem(mediaItems.get(i), i, bitmap));
+      sessionCompat.computeAndSetQueue(
+          () -> {
+            // Do conversions on a background thread instead of the session thread, as we may
+            // have a lot of media items to convert.
+            List<QueueItem> queueItemList = new ArrayList<>(bitmapFutures.size());
+            for (int i = 0; i < bitmapFutures.size(); i++) {
+              @Nullable ListenableFuture<Bitmap> future = bitmapFutures.get(i);
+              @Nullable Bitmap bitmap = null;
+              if (future != null) {
+                try {
+                  bitmap = Futures.getDone(future);
+                } catch (CancellationException | ExecutionException e) {
+                  Log.d(TAG, "Failed to get bitmap", e);
                 }
-                return queueItemList;
-              });
-      // Because we had to wait for futures to complete before we can switch to the background
-      // thread, we have to manually notify SystemUI that the notification should be updated,
-      // MediaNotificationManager cannot do it for us.
-      completion.addListener(
-          sessionImpl::onNotificationRefreshRequired, MoreExecutors.directExecutor());
+              }
+              queueItemList.add(
+                  LegacyConversions.convertToQueueItem(mediaItems.get(i), i, bitmap));
+            }
+            return queueItemList;
+          });
     }
 
     @Override

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionService.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionService.java
@@ -51,6 +51,7 @@ import androidx.core.content.ContextCompat;
 import androidx.lifecycle.LifecycleService;
 import androidx.media3.common.MediaLibraryInfo;
 import androidx.media3.common.Player;
+import androidx.media3.common.util.BackgroundExecutor;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.NullableType;
 import androidx.media3.common.util.UnstableApi;
@@ -60,6 +61,8 @@ import androidx.media3.session.legacy.MediaBrowserServiceCompat;
 import androidx.media3.session.legacy.MediaSessionManager;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -73,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /**
@@ -125,17 +129,17 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
  * controller. If it's accepted, the controller will be available and keep the binding. If it's
  * rejected, the controller will unbind.
  *
- * <p>{@link #onUpdateNotification(MediaSession, boolean)} will be called whenever a notification
- * needs to be shown, updated or cancelled. The default implementation will display notifications
- * using a default UI or using a {@link MediaNotification.Provider} that's set with {@link
- * #setMediaNotificationProvider}. In addition, when playback starts, the service will become a <a
- * href="https://developer.android.com/guide/components/foreground-services">foreground service</a>.
- * It's required to keep the playback after the controller is destroyed. The service will become a
- * background service when all playbacks are stopped. Apps targeting {@code SDK_INT >= 28} must
- * request the permission, {@link android.Manifest.permission#FOREGROUND_SERVICE}, in order to make
- * the service foreground. You can control when to show or hide notifications by overriding {@link
- * #onUpdateNotification(MediaSession, boolean)}. In this case, you must also start or stop the
- * service from the foreground, when playback starts or stops respectively.
+ * <p>{@link #onUpdateNotificationAsync(MediaSession, boolean)} will be called whenever a
+ * notification needs to be shown, updated or cancelled. The default implementation will display
+ * notifications using a default UI or using a {@link MediaNotification.Provider} that's set with
+ * {@link #setMediaNotificationProvider}. In addition, when playback starts, the service will become
+ * a <a href="https://developer.android.com/guide/components/foreground-services">foreground
+ * service</a>. It's required to keep the playback after the controller is destroyed. The service
+ * will become a background service when all playbacks are stopped. Apps targeting {@code SDK_INT >=
+ * 28} must request the permission, {@link android.Manifest.permission#FOREGROUND_SERVICE}, in order
+ * to make the service foreground. You can control when to show or hide notifications by overriding
+ * {@link #onUpdateNotificationAsync(MediaSession, boolean)}. In this case, you must also start or
+ * stop the service from the foreground, when playback starts or stops respectively.
  *
  * <p>The service will be destroyed when all sessions are {@linkplain MediaController#release()
  * released}, or no controller is binding to the service while the service is in the background.
@@ -704,10 +708,12 @@ public abstract class MediaSessionService extends LifecycleService {
    */
   @UnstableApi
   public final void pauseAllPlayersAndStopSelf() {
-    getMediaNotificationManager().disableUserEngagedTimeout();
     List<MediaSession> sessionList = getSessions();
+    getMediaNotificationManager().stopForegroundServiceAndDisableNotifications();
     for (int i = 0; i < sessionList.size(); i++) {
-      sessionList.get(i).getPlayer().setPlayWhenReady(false);
+      Player player = sessionList.get(i).getPlayer();
+      Util.postOrRun(
+          new Handler(player.getApplicationLooper()), () -> player.setPlayWhenReady(false));
     }
     stopSelf();
   }
@@ -770,7 +776,7 @@ public abstract class MediaSessionService extends LifecycleService {
   }
 
   /**
-   * @deprecated Use {@link #onUpdateNotification(MediaSession, boolean)} instead.
+   * @deprecated Use {@link #onUpdateNotificationAsync(MediaSession, boolean)} instead.
    */
   @Deprecated
   public void onUpdateNotification(MediaSession session) {
@@ -778,40 +784,10 @@ public abstract class MediaSessionService extends LifecycleService {
   }
 
   /**
-   * Called when a notification needs to be updated. Override this method to show or cancel your own
-   * notifications.
-   *
-   * <p>This method is replaced by {@link #onUpdateNotificationAsync(MediaSession, boolean)} to
-   * enable the default implementation of the library to provide multi thread scenarios. An app must
-   * not override both methods. While this method is still supported, we recommend migrating to the
-   * newer version and return an {@linkplain Futures#immediateFuture(Object) immediate future} if no
-   * real async execution is required for your app.
-   *
-   * <p>Note: This method must not be called directly by app code.
-   *
-   * <p>This method is called whenever the service has detected a change that requires to show,
-   * update or cancel a notification with a flag {@code startInForegroundRequired} suggested by the
-   * service whether starting in the foreground is required. The method will be called on the
-   * application thread of the app that the service belongs to.
-   *
-   * <p>Override this method to create your own notification and customize the foreground handling
-   * of your service.
-   *
-   * <p>The default implementation will present a default notification or the notification provided
-   * by the {@link MediaNotification.Provider} that is {@link
-   * #setMediaNotificationProvider(MediaNotification.Provider) set} by the app. Further, the service
-   * is started in the <a
-   * href="https://developer.android.com/guide/components/foreground-services">foreground</a> when
-   * playback is ongoing and put back into background otherwise.
-   *
-   * <p>Apps targeting {@code SDK_INT >= 28} must request the permission, {@link
-   * android.Manifest.permission#FOREGROUND_SERVICE}.
-   *
-   * <p>This method will be called on the main thread.
-   *
-   * @param session A session that needs notification update.
-   * @param startInForegroundRequired Whether the service is required to start in the foreground.
+   * @deprecated Use {@link #onUpdateNotificationAsync(MediaSession, boolean)} instead.
    */
+  @Deprecated
+  @SuppressWarnings("deprecation") // Calling deprecated method.
   public void onUpdateNotification(MediaSession session, boolean startInForegroundRequired) {
     onUpdateNotification(session);
   }
@@ -840,7 +816,7 @@ public abstract class MediaSessionService extends LifecycleService {
    * <p>Apps targeting {@code SDK_INT >= 28} must request the permission, {@link
    * android.Manifest.permission#FOREGROUND_SERVICE}.
    *
-   * <p>This method will be called on the main thread.
+   * <p>This method can be called on any thread.
    *
    * <p>This method is replacing {@link #onUpdateNotification(MediaSession, boolean)} to enable the
    * default implementation of the library to provide multi thread setup scenarios. An app must not
@@ -853,10 +829,32 @@ public abstract class MediaSessionService extends LifecycleService {
   @UnstableApi
   public ListenableFuture<@NullableType Void> onUpdateNotificationAsync(
       MediaSession session, boolean startInForegroundRequired) {
-    onUpdateNotification(session, startInForegroundRequired);
-    return defaultMethodCalled
-        ? getMediaNotificationManager().updateNotification(session, startInForegroundRequired)
-        : immediateVoidFuture();
+    SettableFuture<Boolean> resultFuture = SettableFuture.create();
+    Util.postOrRun(
+        mainHandler,
+        () -> {
+          onUpdateNotification(session, startInForegroundRequired);
+          resultFuture.set(defaultMethodCalled);
+        });
+    SettableFuture<Void> completion = SettableFuture.create();
+    resultFuture.addListener(
+        () -> {
+          boolean result;
+          try {
+            result = resultFuture.get();
+          } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+          }
+          if (result) { // Super was called, so use new implementation.
+            ListenableFuture<Void> completionInner =
+                getMediaNotificationManager().updateNotification(session, startInForegroundRequired);
+            completion.setFuture(completionInner);
+          } else { // Method was overridden without super call.
+            completion.set(null);
+          }
+        },
+        BackgroundExecutor.get());
+    return completion;
   }
 
   /**
@@ -895,28 +893,30 @@ public abstract class MediaSessionService extends LifecycleService {
   }
 
   /**
-   * Triggers notification update and handles {@code ForegroundServiceStartNotAllowedException}.
+   * Triggers notification update.
    *
-   * <p>This method will be called on the main thread.
+   * <p>This method can be called on any thread.
    */
   @CanIgnoreReturnValue
   /* package */ ListenableFuture<Boolean> onUpdateNotificationInternal(
       MediaSession session, boolean startInForegroundWhenPaused) {
-    boolean startInForegroundRequired =
+    ListenableFuture<Boolean> startInForegroundRequiredFuture =
         getMediaNotificationManager().shouldRunInForeground(startInForegroundWhenPaused);
-    return Futures.catching(
-        Futures.transform(
-            onUpdateNotificationAsync(session, startInForegroundRequired),
-            aVoid -> true,
-            ContextCompat.getMainExecutor(/* context= */ this)),
-        Throwable.class,
-        t -> {
-          if (SDK_INT >= 31 && t instanceof ForegroundServiceStartNotAllowedException) {
-            onForegroundServiceStartNotAllowedException();
-          }
-          return false;
-        },
-        ContextCompat.getMainExecutor(/* context= */ this));
+    return Futures.transformAsync(startInForegroundRequiredFuture,
+        startInForegroundRequired -> Futures.catching(
+            Futures.transform(
+                onUpdateNotificationAsync(session, startInForegroundRequired),
+                aVoid -> true,
+                MoreExecutors.directExecutor()),
+            Throwable.class,
+            t -> {
+              if (SDK_INT >= 31 && t instanceof ForegroundServiceStartNotAllowedException) {
+                onForegroundServiceStartNotAllowedException();
+              }
+              return false;
+            },
+            MoreExecutors.directExecutor()),
+        MoreExecutors.directExecutor());
   }
 
   private MediaNotificationManager getMediaNotificationManager() {
@@ -987,9 +987,6 @@ public abstract class MediaSessionService extends LifecycleService {
     public ListenableFuture<Boolean> onPlayRequested(MediaSession session) {
       if (SDK_INT < 31 || SDK_INT >= 33) {
         return immediateFuture(true);
-      }
-      if (Looper.myLooper() != Looper.getMainLooper()) {
-        return Futures.submitAsync(() -> onPlayRequested(session), mainHandler::post);
       }
       // Check if service can start foreground successfully on Android 12 and 12L.
       if (!getMediaNotificationManager().isStartedInForeground()) {

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionService.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionService.java
@@ -701,10 +701,6 @@ public abstract class MediaSessionService extends LifecycleService {
    * override to release the sessions and other resources.
    *
    * <p>This method must be called on the main thread.
-   *
-   * @throws IllegalStateException if the {@linkplain Player#getApplicationLooper() application
-   *     looper of the player} is not the looper of the main thread. In such a case, the service
-   *     needs to be stopped manually.
    */
   @UnstableApi
   public final void pauseAllPlayersAndStopSelf() {

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionService.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionService.java
@@ -51,6 +51,7 @@ import androidx.core.content.ContextCompat;
 import androidx.lifecycle.LifecycleService;
 import androidx.media3.common.MediaLibraryInfo;
 import androidx.media3.common.Player;
+import androidx.media3.common.util.BackgroundExecutor;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.NullableType;
 import androidx.media3.common.util.UnstableApi;
@@ -60,6 +61,8 @@ import androidx.media3.session.legacy.MediaBrowserServiceCompat;
 import androidx.media3.session.legacy.MediaSessionManager;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -73,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /**
@@ -125,17 +129,17 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
  * controller. If it's accepted, the controller will be available and keep the binding. If it's
  * rejected, the controller will unbind.
  *
- * <p>{@link #onUpdateNotification(MediaSession, boolean)} will be called whenever a notification
- * needs to be shown, updated or cancelled. The default implementation will display notifications
- * using a default UI or using a {@link MediaNotification.Provider} that's set with {@link
- * #setMediaNotificationProvider}. In addition, when playback starts, the service will become a <a
- * href="https://developer.android.com/guide/components/foreground-services">foreground service</a>.
- * It's required to keep the playback after the controller is destroyed. The service will become a
- * background service when all playbacks are stopped. Apps targeting {@code SDK_INT >= 28} must
- * request the permission, {@link android.Manifest.permission#FOREGROUND_SERVICE}, in order to make
- * the service foreground. You can control when to show or hide notifications by overriding {@link
- * #onUpdateNotification(MediaSession, boolean)}. In this case, you must also start or stop the
- * service from the foreground, when playback starts or stops respectively.
+ * <p>{@link #onUpdateNotificationAsync(MediaSession, boolean)} will be called whenever a
+ * notification needs to be shown, updated or cancelled. The default implementation will display
+ * notifications using a default UI or using a {@link MediaNotification.Provider} that's set with
+ * {@link #setMediaNotificationProvider}. In addition, when playback starts, the service will become
+ * a <a href="https://developer.android.com/guide/components/foreground-services">foreground
+ * service</a>. It's required to keep the playback after the controller is destroyed. The service
+ * will become a background service when all playbacks are stopped. Apps targeting {@code SDK_INT >=
+ * 28} must request the permission, {@link android.Manifest.permission#FOREGROUND_SERVICE}, in order
+ * to make the service foreground. You can control when to show or hide notifications by overriding
+ * {@link #onUpdateNotificationAsync(MediaSession, boolean)}. In this case, you must also start or
+ * stop the service from the foreground, when playback starts or stops respectively.
  *
  * <p>The service will be destroyed when all sessions are {@linkplain MediaController#release()
  * released}, or no controller is binding to the service while the service is in the background.
@@ -713,10 +717,12 @@ public abstract class MediaSessionService extends LifecycleService {
    */
   @UnstableApi
   public final void pauseAllPlayersAndStopSelf() {
-    getMediaNotificationManager().disableUserEngagedTimeout();
     List<MediaSession> sessionList = getSessions();
+    getMediaNotificationManager().stopForegroundServiceAndDisableNotifications();
     for (int i = 0; i < sessionList.size(); i++) {
-      sessionList.get(i).getPlayer().setPlayWhenReady(false);
+      Player player = sessionList.get(i).getPlayer();
+      Util.postOrRun(
+          new Handler(player.getApplicationLooper()), () -> player.setPlayWhenReady(false));
     }
     stopSelf();
   }
@@ -779,7 +785,7 @@ public abstract class MediaSessionService extends LifecycleService {
   }
 
   /**
-   * @deprecated Use {@link #onUpdateNotification(MediaSession, boolean)} instead.
+   * @deprecated Use {@link #onUpdateNotificationAsync(MediaSession, boolean)} instead.
    */
   @Deprecated
   public void onUpdateNotification(MediaSession session) {
@@ -787,40 +793,10 @@ public abstract class MediaSessionService extends LifecycleService {
   }
 
   /**
-   * Called when a notification needs to be updated. Override this method to show or cancel your own
-   * notifications.
-   *
-   * <p>This method is replaced by {@link #onUpdateNotificationAsync(MediaSession, boolean)} to
-   * enable the default implementation of the library to provide multi thread scenarios. An app must
-   * not override both methods. While this method is still supported, we recommend migrating to the
-   * newer version and return an {@linkplain Futures#immediateFuture(Object) immediate future} if no
-   * real async execution is required for your app.
-   *
-   * <p>Note: This method must not be called directly by app code.
-   *
-   * <p>This method is called whenever the service has detected a change that requires to show,
-   * update or cancel a notification with a flag {@code startInForegroundRequired} suggested by the
-   * service whether starting in the foreground is required. The method will be called on the
-   * application thread of the app that the service belongs to.
-   *
-   * <p>Override this method to create your own notification and customize the foreground handling
-   * of your service.
-   *
-   * <p>The default implementation will present a default notification or the notification provided
-   * by the {@link MediaNotification.Provider} that is {@link
-   * #setMediaNotificationProvider(MediaNotification.Provider) set} by the app. Further, the service
-   * is started in the <a
-   * href="https://developer.android.com/guide/components/foreground-services">foreground</a> when
-   * playback is ongoing and put back into background otherwise.
-   *
-   * <p>Apps targeting {@code SDK_INT >= 28} must request the permission, {@link
-   * android.Manifest.permission#FOREGROUND_SERVICE}.
-   *
-   * <p>This method will be called on the main thread.
-   *
-   * @param session A session that needs notification update.
-   * @param startInForegroundRequired Whether the service is required to start in the foreground.
+   * @deprecated Use {@link #onUpdateNotificationAsync(MediaSession, boolean)} instead.
    */
+  @Deprecated
+  @SuppressWarnings("deprecation") // Calling deprecated method.
   public void onUpdateNotification(MediaSession session, boolean startInForegroundRequired) {
     onUpdateNotification(session);
   }
@@ -849,7 +825,7 @@ public abstract class MediaSessionService extends LifecycleService {
    * <p>Apps targeting {@code SDK_INT >= 28} must request the permission, {@link
    * android.Manifest.permission#FOREGROUND_SERVICE}.
    *
-   * <p>This method will be called on the main thread.
+   * <p>This method can be called on any thread.
    *
    * <p>This method is replacing {@link #onUpdateNotification(MediaSession, boolean)} to enable the
    * default implementation of the library to provide multi thread setup scenarios. An app must not
@@ -862,10 +838,32 @@ public abstract class MediaSessionService extends LifecycleService {
   @UnstableApi
   public ListenableFuture<@NullableType Void> onUpdateNotificationAsync(
       MediaSession session, boolean startInForegroundRequired) {
-    onUpdateNotification(session, startInForegroundRequired);
-    return defaultMethodCalled
-        ? getMediaNotificationManager().updateNotification(session, startInForegroundRequired)
-        : immediateVoidFuture();
+    SettableFuture<Boolean> resultFuture = SettableFuture.create();
+    Util.postOrRun(
+        mainHandler,
+        () -> {
+          onUpdateNotification(session, startInForegroundRequired);
+          resultFuture.set(defaultMethodCalled);
+        });
+    SettableFuture<Void> completion = SettableFuture.create();
+    resultFuture.addListener(
+        () -> {
+          boolean result;
+          try {
+            result = resultFuture.get();
+          } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+          }
+          if (result) { // Super was called, so use new implementation.
+            ListenableFuture<Void> completionInner =
+                getMediaNotificationManager().updateNotification(session, startInForegroundRequired);
+            completion.setFuture(completionInner);
+          } else { // Method was overridden without super call.
+            completion.set(null);
+          }
+        },
+        BackgroundExecutor.get());
+    return completion;
   }
 
   /**
@@ -904,28 +902,30 @@ public abstract class MediaSessionService extends LifecycleService {
   }
 
   /**
-   * Triggers notification update and handles {@code ForegroundServiceStartNotAllowedException}.
+   * Triggers notification update.
    *
-   * <p>This method will be called on the main thread.
+   * <p>This method can be called on any thread.
    */
   @CanIgnoreReturnValue
   /* package */ ListenableFuture<Boolean> onUpdateNotificationInternal(
       MediaSession session, boolean startInForegroundWhenPaused) {
-    boolean startInForegroundRequired =
+    ListenableFuture<Boolean> startInForegroundRequiredFuture =
         getMediaNotificationManager().shouldRunInForeground(startInForegroundWhenPaused);
-    return Futures.catching(
-        Futures.transform(
-            onUpdateNotificationAsync(session, startInForegroundRequired),
-            aVoid -> true,
-            ContextCompat.getMainExecutor(/* context= */ this)),
-        Throwable.class,
-        t -> {
-          if (SDK_INT >= 31 && t instanceof ForegroundServiceStartNotAllowedException) {
-            onForegroundServiceStartNotAllowedException();
-          }
-          return false;
-        },
-        ContextCompat.getMainExecutor(/* context= */ this));
+    return Futures.transformAsync(startInForegroundRequiredFuture,
+        startInForegroundRequired -> Futures.catching(
+            Futures.transform(
+                onUpdateNotificationAsync(session, startInForegroundRequired),
+                aVoid -> true,
+                MoreExecutors.directExecutor()),
+            Throwable.class,
+            t -> {
+              if (SDK_INT >= 31 && t instanceof ForegroundServiceStartNotAllowedException) {
+                onForegroundServiceStartNotAllowedException();
+              }
+              return false;
+            },
+            MoreExecutors.directExecutor()),
+        MoreExecutors.directExecutor());
   }
 
   @RequiresApi(31)
@@ -996,9 +996,6 @@ public abstract class MediaSessionService extends LifecycleService {
     public ListenableFuture<Boolean> onPlayRequested(MediaSession session) {
       if (SDK_INT < 31 || SDK_INT >= 33) {
         return immediateFuture(true);
-      }
-      if (Looper.myLooper() != Looper.getMainLooper()) {
-        return Futures.submitAsync(() -> onPlayRequested(session), mainHandler::post);
       }
       // Check if service can start foreground successfully on Android 12 and 12L.
       if (!getMediaNotificationManager().isStartedInForeground()) {

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionService.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionService.java
@@ -710,10 +710,6 @@ public abstract class MediaSessionService extends LifecycleService {
    * override to release the sessions and other resources.
    *
    * <p>This method must be called on the main thread.
-   *
-   * @throws IllegalStateException if the {@linkplain Player#getApplicationLooper() application
-   *     looper of the player} is not the looper of the main thread. In such a case, the service
-   *     needs to be stopped manually.
    */
   @UnstableApi
   public final void pauseAllPlayersAndStopSelf() {

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
@@ -838,15 +838,10 @@ import java.util.concurrent.ExecutionException;
         controller,
         sequenceNumber,
         COMMAND_PLAY_PAUSE,
-        sendSessionResultSuccess(
-            player -> {
-              @Nullable MediaSessionImpl impl = sessionImpl.get();
-              if (impl == null || impl.isReleased()) {
-                return;
-              }
-              impl.handleMediaControllerPlayRequest(
-                  controller, /* callOnPlayerInteractionFinished= */ false);
-            }));
+        sendSessionResultWhenReady(
+            (session, theController, sequenceId) ->
+                session.handleMediaControllerPlayRequest(
+                    theController, /* callOnPlayerInteractionFinished= */ false)));
   }
 
   @Override

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionStub.java
@@ -826,15 +826,10 @@ import java.util.concurrent.ExecutionException;
         controller,
         sequenceNumber,
         COMMAND_PLAY_PAUSE,
-        sendSessionResultSuccess(
-            player -> {
-              @Nullable MediaSessionImpl impl = sessionImpl.get();
-              if (impl == null || impl.isReleased()) {
-                return;
-              }
-              impl.handleMediaControllerPlayRequest(
-                  controller, /* callOnPlayerInteractionFinished= */ false);
-            }));
+        sendSessionResultWhenReady(
+            (session, theController, sequenceId) ->
+                session.handleMediaControllerPlayRequest(
+                    theController, /* callOnPlayerInteractionFinished= */ false)));
   }
 
   @Override

--- a/libraries/session/src/main/java/androidx/media3/session/legacy/MediaSessionCompat.java
+++ b/libraries/session/src/main/java/androidx/media3/session/legacy/MediaSessionCompat.java
@@ -331,7 +331,8 @@ public class MediaSessionCompat {
       @Nullable ComponentName mbrComponent,
       @Nullable PendingIntent mbrIntent,
       @Nullable Bundle sessionInfo,
-      @Nullable String packageNameOverride) {
+      @Nullable String packageNameOverride,
+      @Nullable Looper callbackLooper) {
     if (TextUtils.isEmpty(tag)) {
       throw new IllegalArgumentException("tag must not be null or empty");
     }
@@ -371,7 +372,7 @@ public class MediaSessionCompat {
       impl = new MediaSessionImplApi23(context, tag, sessionInfo, packageNameOverride);
     }
     // Set default callback to respond to controllers' extra binder requests.
-    Looper myLooper = Looper.myLooper();
+    Looper myLooper = callbackLooper != null ? callbackLooper : Looper.myLooper();
     Handler handler = new Handler(myLooper != null ? myLooper : Looper.getMainLooper());
     setCallback(new Callback() {}, handler);
     impl.setMediaButtonReceiver(mbrIntent);

--- a/libraries/session/src/main/java/androidx/media3/session/legacy/MediaSessionCompat.java
+++ b/libraries/session/src/main/java/androidx/media3/session/legacy/MediaSessionCompat.java
@@ -571,9 +571,9 @@ public class MediaSessionCompat {
    * @param queueSupplier A supplier of a list of items in the play queue, which will be executed on
    *     a background thread.
    */
-  public ListenableFuture<Void> computeAndSetQueue(
+  public void computeAndSetQueue(
       @Nullable Supplier<List<QueueItem>> queueSupplier) {
-    return Util.postOrRunWithCompletion(
+    Util.postOrRun(
         internalHandler,
         () -> {
           @Nullable List<QueueItem> queue = queueSupplier != null ? queueSupplier.get() : null;
@@ -590,8 +590,7 @@ public class MediaSessionCompat {
             }
           }
           impl.setQueue(queue);
-        },
-        null);
+        });
   }
 
   /**

--- a/libraries/session/src/main/java/androidx/media3/session/legacy/MediaSessionCompat.java
+++ b/libraries/session/src/main/java/androidx/media3/session/legacy/MediaSessionCompat.java
@@ -60,9 +60,12 @@ import androidx.annotation.RestrictTo;
 import androidx.media3.common.AudioAttributes;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.NullableType;
+import androidx.media3.common.util.Util;
 import androidx.media3.session.legacy.MediaSessionManager.RemoteUserInfo;
 import androidx.versionedparcelable.ParcelUtils;
 import androidx.versionedparcelable.VersionedParcelable;
+import com.google.common.base.Supplier;
+import com.google.common.util.concurrent.ListenableFuture;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.ref.WeakReference;
@@ -108,6 +111,7 @@ public class MediaSessionCompat {
 
   private final MediaSessionImpl impl;
   private final MediaControllerCompat controller;
+  private final Handler internalHandler;
 
   @IntDef(
       flag = true,
@@ -330,9 +334,10 @@ public class MediaSessionCompat {
       String tag,
       @Nullable ComponentName mbrComponent,
       @Nullable PendingIntent mbrIntent,
+      @Nullable PendingIntent sessionActivity,
       @Nullable Bundle sessionInfo,
       @Nullable String packageNameOverride,
-      @Nullable Looper callbackLooper) {
+      Looper internalLooper) {
     if (TextUtils.isEmpty(tag)) {
       throw new IllegalArgumentException("tag must not be null or empty");
     }
@@ -372,12 +377,22 @@ public class MediaSessionCompat {
       impl = new MediaSessionImplApi23(context, tag, sessionInfo, packageNameOverride);
     }
     // Set default callback to respond to controllers' extra binder requests.
-    Looper myLooper = callbackLooper != null ? callbackLooper : Looper.myLooper();
-    Handler handler = new Handler(myLooper != null ? myLooper : Looper.getMainLooper());
-    setCallback(new Callback() {}, handler);
+    internalHandler = new Handler(internalLooper);
+    setCallback(new Callback() {}, internalHandler);
     impl.setMediaButtonReceiver(mbrIntent);
+    if (sessionActivity != null) {
+      impl.setSessionActivity(sessionActivity);
+    }
 
     controller = new MediaControllerCompat(context, this);
+  }
+
+  private void postOrRunOnPlatformSessionThread(Runnable r) {
+    Util.postOrRun(internalHandler, r);
+  }
+
+  private ListenableFuture<Object> postOrRunOnPlatformSessionThreadWithCompletion(Runnable r) {
+    return Util.postOrRunWithCompletion(internalHandler, r, new Object());
   }
 
   /**
@@ -402,7 +417,7 @@ public class MediaSessionCompat {
    * @param pi The intent to launch to show UI for this Session.
    */
   public void setSessionActivity(@Nullable PendingIntent pi) {
-    impl.setSessionActivity(pi);
+    postOrRunOnPlatformSessionThread(() -> impl.setSessionActivity(pi));
   }
 
   /**
@@ -415,8 +430,8 @@ public class MediaSessionCompat {
    *
    * @param mbr The {@link PendingIntent} to send the media button event to.
    */
-  public void setMediaButtonReceiver(PendingIntent mbr) {
-    impl.setMediaButtonReceiver(mbr);
+  public void setMediaButtonReceiver(@Nullable PendingIntent mbr) {
+    postOrRunOnPlatformSessionThread(() -> impl.setMediaButtonReceiver(mbr));
   }
 
   /**
@@ -425,7 +440,7 @@ public class MediaSessionCompat {
    * @param flags The flags to set for this session.
    */
   public void setFlags(@SessionFlags int flags) {
-    impl.setFlags(flags);
+    postOrRunOnPlatformSessionThread(() -> impl.setFlags(flags));
   }
 
   /**
@@ -438,7 +453,7 @@ public class MediaSessionCompat {
    * @param audioAttributes The {@link AudioAttributes} this session is using.
    */
   public void setPlaybackToLocal(AudioAttributes audioAttributes) {
-    impl.setPlaybackToLocal(audioAttributes);
+    postOrRunOnPlatformSessionThread(() -> impl.setPlaybackToLocal(audioAttributes));
   }
 
   /**
@@ -454,7 +469,7 @@ public class MediaSessionCompat {
    * @param volumeProvider The provider that will handle volume changes. May not be null.
    */
   public void setPlaybackToRemote(VolumeProviderCompat volumeProvider) {
-    impl.setPlaybackToRemote(volumeProvider);
+    postOrRunOnPlatformSessionThread(() -> impl.setPlaybackToRemote(volumeProvider));
   }
 
   /**
@@ -468,7 +483,7 @@ public class MediaSessionCompat {
    * @param active Whether this session is active or not.
    */
   public void setActive(boolean active) {
-    impl.setActive(active);
+    postOrRunOnPlatformSessionThread(() -> impl.setActive(active));
   }
 
   /**
@@ -491,7 +506,7 @@ public class MediaSessionCompat {
     if (TextUtils.isEmpty(event)) {
       throw new IllegalArgumentException("event cannot be null or empty");
     }
-    impl.sendSessionEvent(event, extras);
+    postOrRunOnPlatformSessionThread(() -> impl.sendSessionEvent(event, extras));
   }
 
   /**
@@ -500,7 +515,7 @@ public class MediaSessionCompat {
    * service is being destroyed.
    */
   public void release() {
-    impl.release();
+    postOrRunOnPlatformSessionThread(impl::release);
   }
 
   /**
@@ -533,8 +548,8 @@ public class MediaSessionCompat {
    *
    * @param state The current state of playback
    */
-  public void setPlaybackState(PlaybackStateCompat state) {
-    impl.setPlaybackState(state);
+  public ListenableFuture<Object> setPlaybackState(PlaybackStateCompat state) {
+    return postOrRunOnPlatformSessionThreadWithCompletion(() -> impl.setPlaybackState(state));
   }
 
   /**
@@ -545,8 +560,8 @@ public class MediaSessionCompat {
    * @param metadata The new metadata
    * @see androidx.media3.session.legacy.MediaMetadataCompat.Builder#putBitmap
    */
-  public void setMetadata(@Nullable MediaMetadataCompat metadata) {
-    impl.setMetadata(metadata);
+  public ListenableFuture<Object> setMetadata(@Nullable MediaMetadataCompat metadata) {
+    return postOrRunOnPlatformSessionThreadWithCompletion(() -> impl.setMetadata(metadata));
   }
 
   /**
@@ -557,22 +572,28 @@ public class MediaSessionCompat {
    * <p>The queue should be of reasonable size. If the play queue is unbounded within your app, it
    * is better to send a reasonable amount in a sliding window instead.
    *
-   * @param queue A list of items in the play queue.
+   * @param queueSupplier A supplier of a list of items in the play queue, which will be executed on
+   *     a background thread.
    */
-  public void setQueue(@Nullable List<QueueItem> queue) {
-    if (queue != null) {
-      Set<Long> set = new HashSet<>();
-      for (QueueItem item : queue) {
-        if (set.contains(item.getQueueId())) {
-          Log.e(
-              TAG,
-              "Found duplicate queue id: " + item.getQueueId(),
-              new IllegalArgumentException("id of each queue item should be unique"));
-        }
-        set.add(item.getQueueId());
-      }
-    }
-    impl.setQueue(queue);
+  public ListenableFuture<Object> computeAndSetQueue(
+      @Nullable Supplier<List<QueueItem>> queueSupplier) {
+    return postOrRunOnPlatformSessionThreadWithCompletion(
+        () -> {
+          @Nullable List<QueueItem> queue = queueSupplier != null ? queueSupplier.get() : null;
+          if (queue != null) {
+            Set<Long> set = new HashSet<>();
+            for (QueueItem item : queue) {
+              if (set.contains(item.getQueueId())) {
+                Log.e(
+                    TAG,
+                    "Found duplicate queue id: " + item.getQueueId(),
+                    new IllegalArgumentException("id of each queue item should be unique"));
+              }
+              set.add(item.getQueueId());
+            }
+          }
+          impl.setQueue(queue);
+        });
   }
 
   /**
@@ -581,8 +602,8 @@ public class MediaSessionCompat {
    *
    * @param title The title of the play queue.
    */
-  public void setQueueTitle(CharSequence title) {
-    impl.setQueueTitle(title);
+  public void setQueueTitle(@Nullable CharSequence title) {
+    postOrRunOnPlatformSessionThread(() -> impl.setQueueTitle(title));
   }
 
   /**
@@ -600,7 +621,7 @@ public class MediaSessionCompat {
    * </ul>
    */
   public void setRatingType(@RatingCompat.Style int type) {
-    impl.setRatingType(type);
+    postOrRunOnPlatformSessionThread(() -> impl.setRatingType(type));
   }
 
   /**
@@ -614,7 +635,7 @@ public class MediaSessionCompat {
    *     PlaybackStateCompat#REPEAT_MODE_ALL}, {@link PlaybackStateCompat#REPEAT_MODE_GROUP}
    */
   public void setRepeatMode(@PlaybackStateCompat.RepeatMode int repeatMode) {
-    impl.setRepeatMode(repeatMode);
+    postOrRunOnPlatformSessionThread(() -> impl.setRepeatMode(repeatMode));
   }
 
   /**
@@ -628,7 +649,7 @@ public class MediaSessionCompat {
    *     {@link PlaybackStateCompat#SHUFFLE_MODE_GROUP}
    */
   public void setShuffleMode(@PlaybackStateCompat.ShuffleMode int shuffleMode) {
-    impl.setShuffleMode(shuffleMode);
+    postOrRunOnPlatformSessionThread(() -> impl.setShuffleMode(shuffleMode));
   }
 
   /**
@@ -639,7 +660,7 @@ public class MediaSessionCompat {
    * @param extras The extras associated with the session.
    */
   public void setExtras(@Nullable Bundle extras) {
-    impl.setExtras(extras);
+    postOrRunOnPlatformSessionThread(() -> impl.setExtras(extras));
   }
 
   /**
@@ -1791,42 +1812,6 @@ public class MediaSessionCompat {
     }
   }
 
-  /**
-   * This is a wrapper for {@link ResultReceiver} for sending over aidl interfaces. The framework
-   * version was not exposed to aidls until {@link android.os.Build.VERSION_CODES#LOLLIPOP}.
-   */
-  @SuppressLint("BanParcelableUsage")
-  /* package */ static final class ResultReceiverWrapper implements Parcelable {
-    ResultReceiver resultReceiver;
-
-    ResultReceiverWrapper(Parcel in) {
-      resultReceiver = ResultReceiver.CREATOR.createFromParcel(in);
-    }
-
-    public static final Creator<ResultReceiverWrapper> CREATOR =
-        new Creator<ResultReceiverWrapper>() {
-          @Override
-          public ResultReceiverWrapper createFromParcel(Parcel p) {
-            return new ResultReceiverWrapper(p);
-          }
-
-          @Override
-          public ResultReceiverWrapper[] newArray(int size) {
-            return new ResultReceiverWrapper[size];
-          }
-        };
-
-    @Override
-    public int describeContents() {
-      return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-      resultReceiver.writeToParcel(dest, flags);
-    }
-  }
-
   interface MediaSessionImpl {
     void setCallback(@Nullable Callback callback, @Nullable Handler handler);
 
@@ -1859,7 +1844,7 @@ public class MediaSessionCompat {
 
     void setQueue(@Nullable List<QueueItem> queue);
 
-    void setQueueTitle(CharSequence title);
+    void setQueueTitle(@Nullable CharSequence title);
 
     void setRatingType(@RatingCompat.Style int type);
 
@@ -2068,7 +2053,7 @@ public class MediaSessionCompat {
     }
 
     @Override
-    public void setQueueTitle(CharSequence title) {
+    public void setQueueTitle(@Nullable CharSequence title) {
       sessionFwk.setQueueTitle(title);
     }
 

--- a/libraries/session/src/main/java/androidx/media3/session/legacy/MediaSessionCompat.java
+++ b/libraries/session/src/main/java/androidx/media3/session/legacy/MediaSessionCompat.java
@@ -391,8 +391,8 @@ public class MediaSessionCompat {
     Util.postOrRun(internalHandler, r);
   }
 
-  private ListenableFuture<Object> postOrRunOnPlatformSessionThreadWithCompletion(Runnable r) {
-    return Util.postOrRunWithCompletion(internalHandler, r, new Object());
+  private ListenableFuture<Void> postOrRunOnPlatformSessionThreadWithCompletion(Runnable r) {
+    return Util.postOrRunWithCompletion(internalHandler, r, null);
   }
 
   /**
@@ -548,7 +548,7 @@ public class MediaSessionCompat {
    *
    * @param state The current state of playback
    */
-  public ListenableFuture<Object> setPlaybackState(PlaybackStateCompat state) {
+  public ListenableFuture<Void> setPlaybackState(PlaybackStateCompat state) {
     return postOrRunOnPlatformSessionThreadWithCompletion(() -> impl.setPlaybackState(state));
   }
 
@@ -560,7 +560,7 @@ public class MediaSessionCompat {
    * @param metadata The new metadata
    * @see androidx.media3.session.legacy.MediaMetadataCompat.Builder#putBitmap
    */
-  public ListenableFuture<Object> setMetadata(@Nullable MediaMetadataCompat metadata) {
+  public ListenableFuture<Void> setMetadata(@Nullable MediaMetadataCompat metadata) {
     return postOrRunOnPlatformSessionThreadWithCompletion(() -> impl.setMetadata(metadata));
   }
 
@@ -575,7 +575,7 @@ public class MediaSessionCompat {
    * @param queueSupplier A supplier of a list of items in the play queue, which will be executed on
    *     a background thread.
    */
-  public ListenableFuture<Object> computeAndSetQueue(
+  public ListenableFuture<Void> computeAndSetQueue(
       @Nullable Supplier<List<QueueItem>> queueSupplier) {
     return postOrRunOnPlatformSessionThreadWithCompletion(
         () -> {

--- a/libraries/session/src/main/java/androidx/media3/session/legacy/MediaSessionCompat.java
+++ b/libraries/session/src/main/java/androidx/media3/session/legacy/MediaSessionCompat.java
@@ -391,10 +391,6 @@ public class MediaSessionCompat {
     Util.postOrRun(internalHandler, r);
   }
 
-  private ListenableFuture<Void> postOrRunOnPlatformSessionThreadWithCompletion(Runnable r) {
-    return Util.postOrRunWithCompletion(internalHandler, r, null);
-  }
-
   /**
    * Sets the callback to receive updates for the MediaSession. This includes media button and
    * volume events. Set the callback to null to stop receiving events.
@@ -549,7 +545,7 @@ public class MediaSessionCompat {
    * @param state The current state of playback
    */
   public ListenableFuture<Void> setPlaybackState(PlaybackStateCompat state) {
-    return postOrRunOnPlatformSessionThreadWithCompletion(() -> impl.setPlaybackState(state));
+    return Util.postOrRunWithCompletion(internalHandler, () -> impl.setPlaybackState(state), null);
   }
 
   /**
@@ -561,7 +557,7 @@ public class MediaSessionCompat {
    * @see androidx.media3.session.legacy.MediaMetadataCompat.Builder#putBitmap
    */
   public ListenableFuture<Void> setMetadata(@Nullable MediaMetadataCompat metadata) {
-    return postOrRunOnPlatformSessionThreadWithCompletion(() -> impl.setMetadata(metadata));
+    return Util.postOrRunWithCompletion(internalHandler, () -> impl.setMetadata(metadata), null);
   }
 
   /**
@@ -577,7 +573,8 @@ public class MediaSessionCompat {
    */
   public ListenableFuture<Void> computeAndSetQueue(
       @Nullable Supplier<List<QueueItem>> queueSupplier) {
-    return postOrRunOnPlatformSessionThreadWithCompletion(
+    return Util.postOrRunWithCompletion(
+        internalHandler,
         () -> {
           @Nullable List<QueueItem> queue = queueSupplier != null ? queueSupplier.get() : null;
           if (queue != null) {
@@ -593,7 +590,8 @@ public class MediaSessionCompat {
             }
           }
           impl.setQueue(queue);
-        });
+        },
+        null);
   }
 
   /**

--- a/libraries/session/src/test/java/androidx/media3/session/MediaSessionServiceTest.java
+++ b/libraries/session/src/test/java/androidx/media3/session/MediaSessionServiceTest.java
@@ -325,6 +325,8 @@ public class MediaSessionServiceTest {
     player1.release();
     player2.release();
     serviceController.destroy();
+    assertThat(getStatusBarNotification(2001)).isNull();
+    assertThat(getStatusBarNotification(2002)).isNull();
   }
 
   @Test
@@ -372,9 +374,11 @@ public class MediaSessionServiceTest {
     session2.release();
     new Handler(thread1.getLooper()).post(player1::release);
     new Handler(thread2.getLooper()).post(player2::release);
-    thread1.quit();
-    thread2.quit();
+    thread1.quitSafely();
+    thread2.quitSafely();
     serviceController.destroy();
+    assertThat(getStatusBarNotification(2001)).isNull();
+    assertThat(getStatusBarNotification(2002)).isNull();
   }
 
   @Test

--- a/libraries/session/src/test/java/androidx/media3/session/MediaSessionServiceTest.java
+++ b/libraries/session/src/test/java/androidx/media3/session/MediaSessionServiceTest.java
@@ -121,7 +121,7 @@ public class MediaSessionServiceTest {
   }
 
   @Test
-  public void service_sessionIdleWithMediaShowAlways_createsNotification() {
+  public void service_sessionIdleWithMediaShowAlways_createsNotification() throws TimeoutException {
     ExoPlayer player = new TestExoPlayerBuilder(context).build();
     MediaSession session = new MediaSession.Builder(context, player).build();
     ServiceController<TestService> serviceController = Robolectric.buildService(TestService.class);
@@ -138,7 +138,7 @@ public class MediaSessionServiceTest {
     player.setMediaItem(MediaItem.fromUri("asset:///media/mp4/sample.mp4"));
     service.setShowNotificationForIdlePlayer(
         MediaSessionService.SHOW_NOTIFICATION_FOR_IDLE_PLAYER_ALWAYS);
-    ShadowLooper.idleMainLooper();
+    runMainLooperUntil(() -> getStatusBarNotification(2000) != null);
 
     assertThat(getStatusBarNotification(2000)).isNotNull();
 
@@ -175,7 +175,8 @@ public class MediaSessionServiceTest {
   }
 
   @Test
-  public void service_sessionIdleAfterNonIdleWithMedia_createsNotification() {
+  public void service_sessionIdleAfterNonIdleWithMedia_createsNotification()
+      throws TimeoutException {
     ExoPlayer player = new TestExoPlayerBuilder(context).build();
     MediaSession session = new MediaSession.Builder(context, player).build();
     ServiceController<TestService> serviceController = Robolectric.buildService(TestService.class);
@@ -193,7 +194,7 @@ public class MediaSessionServiceTest {
     player.prepare();
     ShadowLooper.idleMainLooper();
     player.stop();
-    ShadowLooper.idleMainLooper();
+    runMainLooperUntil(() -> getStatusBarNotification(2000) != null);
 
     assertThat(getStatusBarNotification(2000)).isNotNull();
 
@@ -233,7 +234,8 @@ public class MediaSessionServiceTest {
   }
 
   @Test
-  public void service_sessionIdleAfterNonIdleWithMediaShowNever_clearsNotification() {
+  public void service_sessionIdleAfterNonIdleWithMediaShowNever_clearsNotification()
+      throws TimeoutException {
     ExoPlayer player = new TestExoPlayerBuilder(context).build();
     MediaSession session = new MediaSession.Builder(context, player).build();
     ServiceController<TestService> serviceController = Robolectric.buildService(TestService.class);
@@ -253,7 +255,7 @@ public class MediaSessionServiceTest {
     player.stop();
     service.setShowNotificationForIdlePlayer(
         MediaSessionService.SHOW_NOTIFICATION_FOR_IDLE_PLAYER_NEVER);
-    ShadowLooper.idleMainLooper();
+    runMainLooperUntil(() -> getStatusBarNotification(2001) == null);
 
     assertThat(getStatusBarNotification(2000)).isNull();
 
@@ -263,7 +265,8 @@ public class MediaSessionServiceTest {
   }
 
   @Test
-  public void service_sessionIdleAfterNonIdleWithoutMedia_clearsNotification() {
+  public void service_sessionIdleAfterNonIdleWithoutMedia_clearsNotification()
+      throws TimeoutException {
     ExoPlayer player = new TestExoPlayerBuilder(context).build();
     MediaSession session = new MediaSession.Builder(context, player).build();
     ServiceController<TestService> serviceController = Robolectric.buildService(TestService.class);
@@ -282,7 +285,7 @@ public class MediaSessionServiceTest {
     ShadowLooper.idleMainLooper();
     player.stop();
     player.clearMediaItems();
-    ShadowLooper.idleMainLooper();
+    runMainLooperUntil(() -> getStatusBarNotification(2000) == null);
 
     assertThat(getStatusBarNotification(2000)).isNull();
 
@@ -292,7 +295,8 @@ public class MediaSessionServiceTest {
   }
 
   @Test
-  public void service_multipleSessionsOnMainThread_createsNotificationForEachSession() {
+  public void service_multipleSessionsOnMainThread_createsNotificationForEachSession()
+      throws TimeoutException {
     ExoPlayer player1 = new TestExoPlayerBuilder(context).build();
     ExoPlayer player2 = new TestExoPlayerBuilder(context).build();
     MediaSession session1 = new MediaSession.Builder(context, player1).setId("1").build();
@@ -315,7 +319,8 @@ public class MediaSessionServiceTest {
     player2.setMediaItem(MediaItem.fromUri("asset:///media/mp4/sample.mp4"));
     player2.prepare();
     player2.play();
-    ShadowLooper.idleMainLooper();
+    runMainLooperUntil(() -> getStatusBarNotification(2001) != null
+        && getStatusBarNotification(2002) != null);
 
     assertThat(getStatusBarNotification(2001)).isNotNull();
     assertThat(getStatusBarNotification(2002)).isNotNull();
@@ -325,6 +330,8 @@ public class MediaSessionServiceTest {
     player1.release();
     player2.release();
     serviceController.destroy();
+    runMainLooperUntil(() -> getStatusBarNotification(2001) == null
+        && getStatusBarNotification(2002) == null);
     assertThat(getStatusBarNotification(2001)).isNull();
     assertThat(getStatusBarNotification(2002)).isNull();
   }
@@ -377,6 +384,8 @@ public class MediaSessionServiceTest {
     thread1.quitSafely();
     thread2.quitSafely();
     serviceController.destroy();
+    runMainLooperUntil(() -> getStatusBarNotification(2001) == null
+        && getStatusBarNotification(2002) == null);
     assertThat(getStatusBarNotification(2001)).isNull();
     assertThat(getStatusBarNotification(2002)).isNull();
   }
@@ -475,7 +484,10 @@ public class MediaSessionServiceTest {
     player.pause();
     session.setCustomLayout(
         session.getMediaNotificationControllerInfo(), ImmutableList.of(button2));
-    ShadowLooper.idleMainLooper();
+    runMainLooperUntil(() -> {
+      StatusBarNotification innerNotification = getStatusBarNotification(2000);
+      return innerNotification != null && innerNotification.getNotification().actions.length == 4;
+    });
     mediaNotification = getStatusBarNotification(2000);
 
     assertThat(mediaNotification.getNotification().actions).hasLength(4);
@@ -585,7 +597,10 @@ public class MediaSessionServiceTest {
     player.pause();
     session.setMediaButtonPreferences(
         session.getMediaNotificationControllerInfo(), ImmutableList.of(button2));
-    ShadowLooper.idleMainLooper();
+    runMainLooperUntil(() -> {
+      StatusBarNotification innerNotification = getStatusBarNotification(2000);
+      return innerNotification != null && innerNotification.getNotification().actions.length == 4;
+    });
     mediaNotification = getStatusBarNotification(2000);
 
     assertThat(mediaNotification.getNotification().actions).hasLength(4);
@@ -678,7 +693,10 @@ public class MediaSessionServiceTest {
             .add(command2)
             .build(),
         MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS);
-    ShadowLooper.idleMainLooper();
+    runMainLooperUntil(() -> {
+      StatusBarNotification innerNotification = getStatusBarNotification(2000);
+      return innerNotification != null && innerNotification.getNotification().actions.length == 4;
+    });
     mediaNotification = getStatusBarNotification(2000);
 
     assertThat(mediaNotification.getNotification().actions).hasLength(4);
@@ -813,7 +831,7 @@ public class MediaSessionServiceTest {
 
   @Test
   public void onStartCommand_customCommands_deliveredByMediaNotificationController()
-      throws InterruptedException {
+      throws InterruptedException, TimeoutException {
     ExoPlayer player = new TestExoPlayerBuilder(context).build();
     AtomicReference<MediaSession> sessionRef = new AtomicReference<>();
     SessionCommand expectedCustomCommand = new SessionCommand("enable_shuffle", Bundle.EMPTY);
@@ -875,6 +893,7 @@ public class MediaSessionServiceTest {
 
     serviceController.startCommand(/* flags= */ 0, /* startId= */ 0);
 
+    runMainLooperUntil(() -> latch.getCount() == 0);
     assertThat(latch.await(TIMEOUT_MS, MILLISECONDS)).isTrue();
     session.release();
     player.release();
@@ -882,7 +901,7 @@ public class MediaSessionServiceTest {
   }
 
   @Test
-  public void triggerNotificationUpdate_callsNotificationProvider() {
+  public void triggerNotificationUpdate_callsNotificationProvider() throws TimeoutException {
     ExoPlayer player = new TestExoPlayerBuilder(context).build();
     MediaSession session = new MediaSession.Builder(context, player).build();
     ServiceController<TestService> serviceController = Robolectric.buildService(TestService.class);
@@ -932,12 +951,13 @@ public class MediaSessionServiceTest {
     // Add media and give the service a chance to create an initial notification.
     player.setMediaItem(MediaItem.fromUri("asset:///media/mp4/sample.mp4"));
     player.prepare();
-    ShadowLooper.idleMainLooper();
+    runMainLooperUntil(() -> getStatusBarNotification(2000) != null);
 
     String tickerBeforeTriggerNotificationUpdate =
         getStatusBarNotification(2000).getNotification().tickerText.toString();
     service.triggerNotificationUpdate();
-    ShadowLooper.idleMainLooper();
+    runMainLooperUntil(() -> !getStatusBarNotification(2000).getNotification()
+        .tickerText.equals(tickerBeforeTriggerNotificationUpdate));
     String tickerAfterTriggerNotificationUpdate =
         getStatusBarNotification(2000).getNotification().tickerText.toString();
 

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionServiceTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionServiceTest.java
@@ -39,6 +39,7 @@ import android.graphics.Color;
 import android.graphics.Point;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.ParcelFileDescriptor;
 import android.os.SystemClock;
@@ -48,9 +49,11 @@ import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
 import android.view.WindowManager;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.media3.common.ForwardingPlayer;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MediaMetadata;
+import androidx.media3.common.PlaybackParameters;
 import androidx.media3.common.Player;
 import androidx.media3.common.Player.Listener;
 import androidx.media3.common.Player.PositionInfo;
@@ -73,6 +76,8 @@ import androidx.test.filters.MediumTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import java.io.BufferedReader;
@@ -278,6 +283,70 @@ public class MediaSessionServiceTest {
     mediaItemsAdded.block(TIMEOUT_MS);
     assertThat(controllerBoundWhenMediaItemsAdded.get()).isEqualTo(true);
     service.blockUntilAllControllersUnbind(TIMEOUT_MS);
+  }
+
+  @Test
+  public void onPlayRequested_doesNotCauseDeadlock_ifPlaybackThreadIsNotMain() throws Exception {
+    HandlerThread ht = new HandlerThread("MSSTest:PlaybackThread");
+    ht.start();
+    TestServiceRegistry testServiceRegistry = TestServiceRegistry.getInstance();
+    ConditionVariable playerToldToSpeedUp = new ConditionVariable();
+    AtomicReference<MediaController> mediaController = new AtomicReference<>();
+    AtomicReference<MediaSession> mediaSession = new AtomicReference<>();
+    testServiceRegistry.setOnGetSessionHandler(
+        controllerInfo -> {
+          MockMediaSessionService service =
+              (MockMediaSessionService) testServiceRegistry.getServiceInstance();
+          Player player = new ExoPlayer.Builder(service).setLooper(ht.getLooper()).build();
+          player.addListener(
+              new Player.Listener() {
+                @Override
+                public void onPlaybackParametersChanged(PlaybackParameters playbackParameters) {
+                  if (playbackParameters.speed == 2f) {
+                    playerToldToSpeedUp.open();
+                  }
+                }
+              });
+          mediaSession.set(new MediaSession.Builder(service, player).build());
+          return mediaSession.get();
+        });
+    TestHandler handler = new TestHandler(Looper.getMainLooper());
+    TestHandler bgHandler = new TestHandler(ht.getLooper());
+    handler.post(
+        () -> {
+          ListenableFuture<MediaController> controllerFuture =
+              new MediaController.Builder(context, token).buildAsync();
+          Futures.addCallback(
+              controllerFuture,
+              new FutureCallback<MediaController>() {
+                @Override
+                public void onSuccess(MediaController controller) {
+                  controller.addMediaItem(new MediaItem.Builder().setMediaId("media_id").build());
+                  controller.play();
+                  bgHandler.post(
+                      () ->
+                          handler.post(
+                              () -> {
+                                controller.setPlaybackSpeed(2f);
+                                mediaController.set(controller);
+                              }));
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
+                  throw new RuntimeException(t);
+                }
+              },
+              ContextCompat.getMainExecutor(context));
+        });
+    playerToldToSpeedUp.block(TIMEOUT_MS);
+    if (!playerToldToSpeedUp.isOpen()) {
+      ht.interrupt(); // avoid deadlocking the test forever.
+    }
+    assertThat(playerToldToSpeedUp.isOpen()).isTrue();
+    handler.postAndSync(() -> mediaController.get().release());
+    mediaSession.get().release();
+    ht.quitSafely();
   }
 
   @Test

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionServiceWithNonMainApplicationThreadTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionServiceWithNonMainApplicationThreadTest.java
@@ -25,6 +25,7 @@ import android.app.ForegroundServiceStartNotAllowedException;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
 import androidx.media3.common.C;
@@ -94,6 +95,7 @@ public class MediaSessionServiceWithNonMainApplicationThreadTest {
     Looper appLooper = appThread.getLooper();
 
     SettableFuture<Looper> playFuture = SettableFuture.create();
+    SettableFuture<Void> setVolumeWasCalled = SettableFuture.create();
     testServiceRegistry.setOnGetSessionHandler(
         controllerInfo -> {
           ExoPlayer exoPlayer =
@@ -106,6 +108,17 @@ public class MediaSessionServiceWithNonMainApplicationThreadTest {
                 @Override
                 public void play() {
                   playFuture.set(Looper.myLooper());
+                }
+
+                @Override
+                public void setVolume(float volume) {
+                  // Must be already done as setVolume() is called after play() on the controller.
+                  try {
+                    assertThat(playFuture.get(0, MILLISECONDS)).isNotNull();
+                  } catch (Exception e) {
+                    throw new RuntimeException(e);
+                  }
+                  setVolumeWasCalled.set(null);
                 }
               };
           return new MediaSession.Builder(context, player)
@@ -133,9 +146,13 @@ public class MediaSessionServiceWithNonMainApplicationThreadTest {
     RemoteMediaController controller = controllerTestRule.createRemoteController(token);
 
     controller.play();
+    // Send a command after play to assert they are processed in the correct order even if play
+    // takes a moment. See setVolume above.
+    controller.setVolume(0.5f);
 
     // Verify that playback starts on the application looper.
     assertThat(playFuture.get(TIMEOUT_MS, MILLISECONDS)).isEqualTo(appLooper);
+    assertThat(setVolumeWasCalled.get(TIMEOUT_MS, MILLISECONDS)).isEqualTo(null);
     appThread.quitSafely();
   }
 

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionServiceWithNonMainApplicationThreadTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaSessionServiceWithNonMainApplicationThreadTest.java
@@ -94,6 +94,7 @@ public class MediaSessionServiceWithNonMainApplicationThreadTest {
     Looper appLooper = appThread.getLooper();
 
     SettableFuture<Looper> playFuture = SettableFuture.create();
+    SettableFuture<Void> setVolumeWasCalled = SettableFuture.create();
     testServiceRegistry.setOnGetSessionHandler(
         controllerInfo -> {
           ExoPlayer exoPlayer =
@@ -106,6 +107,17 @@ public class MediaSessionServiceWithNonMainApplicationThreadTest {
                 @Override
                 public void play() {
                   playFuture.set(Looper.myLooper());
+                }
+
+                @Override
+                public void setVolume(float volume) {
+                  // Must be already done as setVolume() is called after play() on the controller.
+                  try {
+                    assertThat(playFuture.get(0, MILLISECONDS)).isNotNull();
+                  } catch (Exception e) {
+                    throw new RuntimeException(e);
+                  }
+                  setVolumeWasCalled.set(null);
                 }
               };
           return new MediaSession.Builder(context, player)
@@ -133,9 +145,13 @@ public class MediaSessionServiceWithNonMainApplicationThreadTest {
     RemoteMediaController controller = controllerTestRule.createRemoteController(token);
 
     controller.play();
+    // Send a command after play to assert they are processed in the correct order even if play
+    // takes a moment. See setVolume above.
+    controller.setVolume(0.5f);
 
     // Verify that playback starts on the application looper.
     assertThat(playFuture.get(TIMEOUT_MS, MILLISECONDS)).isEqualTo(appLooper);
+    assertThat(setVolumeWasCalled.get(TIMEOUT_MS, MILLISECONDS)).isEqualTo(null);
     appThread.quitSafely();
   }
 


### PR DESCRIPTION
Issue: https://github.com/androidx/media/issues/2577
Test: add Thread.sleep(5000) to setMetadata(), app stays responsive