### PR TITLE
Remove duplicated `Modifier` usages in `:demos:compose`

### DIFF
--- a/demos/compose/src/main/java/androidx/media3/demo/compose/buttons/MuteButton.kt
+++ b/demos/compose/src/main/java/androidx/media3/demo/compose/buttons/MuteButton.kt
@@ -38,6 +38,6 @@ internal fun MuteButton(player: Player, modifier: Modifier = Modifier) {
     if (state.showMuted) stringResource(R.string.mute_button_shown_muted)
     else stringResource(R.string.mute_button_shown_unmuted)
   IconButton(onClick = state::onClick, modifier = modifier, enabled = state.isEnabled) {
-    Icon(icon, contentDescription = contentDescription, modifier = modifier)
+    Icon(icon, contentDescription = contentDescription)
   }
 }

--- a/demos/compose/src/main/java/androidx/media3/demo/compose/buttons/RepeatButton.kt
+++ b/demos/compose/src/main/java/androidx/media3/demo/compose/buttons/RepeatButton.kt
@@ -36,7 +36,7 @@ internal fun RepeatButton(player: Player, modifier: Modifier = Modifier) {
   val icon = repeatModeIcon(state.repeatModeState)
   val contentDescription = repeatModeContentDescription(state.repeatModeState)
   IconButton(onClick = state::onClick, modifier = modifier, enabled = state.isEnabled) {
-    Icon(icon, contentDescription = contentDescription, modifier = modifier)
+    Icon(icon, contentDescription = contentDescription)
   }
 }
 

--- a/demos/compose/src/main/java/androidx/media3/demo/compose/buttons/ShuffleButton.kt
+++ b/demos/compose/src/main/java/androidx/media3/demo/compose/buttons/ShuffleButton.kt
@@ -39,6 +39,6 @@ internal fun ShuffleButton(player: Player, modifier: Modifier = Modifier) {
       stringResource(R.string.shuffle_button_shuffle_off)
     }
   IconButton(onClick = state::onClick, modifier = modifier, enabled = state.isEnabled) {
-    Icon(icon, contentDescription = contentDescription, modifier = modifier)
+    Icon(icon, contentDescription = contentDescription)
   }
 }


### PR DESCRIPTION
The `modifier` argument is already applied to the root `IconButton`. It is wrong to also apply it to the child `Icon`.