### PR TITLE
Update notification when device info changes

### DIFF
--- a/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaNotificationManager.java
@@ -449,7 +449,8 @@ import java.util.concurrent.TimeoutException;
           Player.EVENT_PLAYBACK_STATE_CHANGED,
           Player.EVENT_PLAY_WHEN_READY_CHANGED,
           Player.EVENT_MEDIA_METADATA_CHANGED,
-          Player.EVENT_TIMELINE_CHANGED)) {
+          Player.EVENT_TIMELINE_CHANGED,
+          Player.EVENT_DEVICE_INFO_CHANGED)) {
         mediaSessionService.onUpdateNotificationInternal(
             session, /* startInForegroundWhenPaused= */ false);
       }


### PR DESCRIPTION
Device info determines whether we have cast or normal media notification. It decides whether we can enable playback resumption. To ensure the state is correct, notify SystemUI when device info changed.