### PR TITLE
Fix text color in `:demo:session`

### DIFF
--- a/demos/session/src/main/res/layout/activity_playable_folder.xml
+++ b/demos/session/src/main/res/layout/activity_playable_folder.xml
@@ -55,6 +55,7 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:layout_margin="10dp"
+        android:textColor="@color/white"
         android:drawableLeft="@drawable/exo_icon_play"
         android:text="@string/play_button" />
 


### PR DESCRIPTION
The text color of the `Play` button in `:demo:session` was using the default text color, while the `Shuffle` button has a white text color.
This aligns the two buttons to use white in both cases.

-----

Here's a before/after of this change:

| Description | `main` | This PR |
|--------|--------|--------|
| Dark mode | <img width="1344" height="2992" alt="Screenshot_20250804_105838" src="https://github.com/user-attachments/assets/3291aa1d-e99f-4855-98e9-822bf7d6c7bc" /> | <img width="1344" height="2992" alt="Screenshot_20250804_105933" src="https://github.com/user-attachments/assets/be229e4f-b11f-44a1-91c2-c0c9a5cbd0f3" /> |
| Light mode | <img width="1344" height="2992" alt="Screenshot_20250804_105849" src="https://github.com/user-attachments/assets/e68244ea-92b3-4576-9b16-41ee94ac0295" /> | <img width="1344" height="2992" alt="Screenshot_20250804_105939" src="https://github.com/user-attachments/assets/a978ba82-9d5b-478c-bf07-0f87b274c3c3" /> |
