### PR TITLE
Align demo apps title

### DIFF
--- a/demos/cast/src/main/res/values/strings.xml
+++ b/demos/cast/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
 
 <resources>
 
-  <string name="application_name">Exo Cast Demo</string>
+  <string name="application_name">Media3 Cast Demo</string>
 
   <string name="media_route_menu_title">Cast</string>
 

--- a/demos/composition/src/main/res/values/strings.xml
+++ b/demos/composition/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
      limitations under the License.
 -->
 <resources>
-  <string name="app_name">Composition Demo</string>
+  <string name="app_name">Media3 Composition Demo</string>
   <string name="edit">Edit</string>
   <string name="add_effects">Add effects</string>
   <string name="add_effects_hint">Click the Media Item to apply effects</string>

--- a/demos/effect/src/main/res/values/strings.xml
+++ b/demos/effect/src/main/res/values/strings.xml
@@ -14,7 +14,7 @@
      limitations under the License.
 -->
 <resources>
-  <string name="app_name">Effect Demo</string>
+  <string name="app_name">Media3 Effect Demo</string>
   <string name="choose_preset_input">Choose preset input</string>
   <string name="choose_local_file">Choose local file</string>
   <string name="apply_effects">Apply effects</string>

--- a/demos/gl/src/main/res/values/strings.xml
+++ b/demos/gl/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
 -->
 <resources>
 
-  <string name="application_name">ExoPlayer GL demo</string>
+  <string name="application_name">Media3 GL Demo</string>
 
   <string name="error_protected_content_extension_not_supported">The GL protected content extension is not supported.</string>
   <string name="gl_error_occurred">GL error occurred.</string>

--- a/demos/main/src/main/res/values/strings.xml
+++ b/demos/main/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-  <string name="application_name">ExoPlayer</string>
+  <string name="application_name">Media3</string>
 
   <string name="track_selection_title">Select tracks</string>
 

--- a/demos/surface/src/main/res/values/strings.xml
+++ b/demos/surface/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
 -->
 <resources>
 
-  <string name="application_name">ExoPlayer SurfaceControl demo</string>
+  <string name="application_name">Media3 SurfaceControl Demo</string>
   <string name="no_output_label">No output</string>
   <string name="full_screen_label">Full screen</string>
   <string name="new_activity_label">New activity</string>

--- a/demos/transformer/src/main/res/values/strings.xml
+++ b/demos/transformer/src/main/res/values/strings.xml
@@ -14,7 +14,7 @@
      limitations under the License.
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-  <string name="app_name" translatable="false">Transformer Demo</string>
+  <string name="app_name" translatable="false">Media3 Transformer Demo</string>
   <string name="configuration" translatable="false">Configuration</string>
   <string name="select_preset_title" translatable="false">Choose preset input</string>
   <string name="select_local_file_title">Choose local file</string>


### PR DESCRIPTION
This PR aligns the demo apps title, by using the `Media3` prefix. With this change, all demo apps are grouped together in the app launcher, making them easier to find.