### PR TITLE
Fix missing link in ExoPlayer API reference.

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayer.java
@@ -78,8 +78,8 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.List;
 
 /**
- * An extensible media player that plays {@link MediaSource}s. Instances can be obtained from {@link
- * Builder}.
+ * An extensible media player that plays {@link MediaSource}s. Instances can be obtained from
+ * {@link Builder}.
  *
  * <h2>Player components</h2>
  *


### PR DESCRIPTION
- This minor change fixes the missing link to `Builder` object in `ExoPlayer` API reference.
- Although the link exists, but due to a bug (as per TW team), the link is not rendered since it is split into two lines.

**PS:** This change also allows me to get familiar with the Developer workflow of this Github repo. Thanks for your time!

<img width="1008" height="488" alt="Screenshot 2025-08-17 at 3 31 51 PM" src="https://github.com/user-attachments/assets/56815112-370a-4f40-8287-b36cb78328aa" />
