### PR TITLE
Use stereo channel mask for AC-4 passthrough

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -327,6 +327,11 @@ public final class AudioCapabilities {
         if (channelCount > 10) {
           return null;
         }
+      } else if (format.sampleMimeType.equals(MimeTypes.AUDIO_AC4)) {
+        // AC-4 content may contain channel (or object) count that does not have a matching channel
+        // mask. Override channel count to 2 (mapped to stereo channel masK) which is supported by
+        // all AC-4 offloaded decoders to avoid this limitation and allow track to open.
+        channelCount = 2;
       } else if (!audioProfile.supportsChannelCount(channelCount)) {
         return null;
       }


### PR DESCRIPTION
The Ac4Util format builder can return channel counts up to 21. These channel counts do not have a matching channel mask. To support AC-4 offload/passthrough to offloaded decoders, override the channel count to 2 so that offload/passthrough AudioTracks are built with stereo channel mask so they can reach AC-4 offloaded decoders.

This change restores the channel count used prior to 29bda3bb5ce9ee86225ca8c7f44d24183265ee9c for passthrough.