### PR TITLE
Add com.airbnb.android:lottie in aar_dependencies list in file missing_aar_type_workaround.gradle

### DIFF
--- a/missing_aar_type_workaround.gradle
+++ b/missing_aar_type_workaround.gradle
@@ -54,6 +54,7 @@ def addMissingAarTypeToXml(xml) {
         "com.google.android.gms:play-services-cronet",
         "com.google.android.material:material",
         "io.antmedia:rtmp-client",
+        "com.airbnb.android:lottie"
     ]
     xml.asNode().children().stream()
         .filter { it.name().toString().endsWith("dependencies") }


### PR DESCRIPTION
The lib-effect module was recently added but the gradle task :lib-effect:generatePomFileForReleasePublication fails. 
The error is 
Execution failed for task ':lib-effect:generatePomFileForReleasePublication'.
> Could not apply withXml() to generated POM
   > com.airbnb.android:lottie is not on the JAR or AAR list in missing_aar_type_workaround.gradle

One of the solution is to add com.airbnb.android:lottie in the aar_dependencies list in the file missing_aar_type_workaround.gradle.

This PR adds that entry so that this publish task can succeed.
