### PR TITLE
fix(uri): handle '@' correctly

### DIFF
--- a/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMessageUtil.java
+++ b/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMessageUtil.java
@@ -192,9 +192,14 @@ import java.util.regex.Pattern;
     }
 
     // The Uri must include a "@" if the user info is non-null.
-    String authorityWithUserInfo = checkNotNull(uri.getEncodedAuthority());
-    checkArgument(authorityWithUserInfo.contains("@"));
-    String authority = Util.split(authorityWithUserInfo, "@")[1];
+    String authorityWithUserInfo = uri.getAuthority();
+    checkArgument(authorityWithUserInfo != null && authorityWithUserInfo.contains("@"),
+        "Invalid URI: userInfo is non-null but '@' delimiter is missing");
+
+    String host = uri.getHost();
+    checkNotNull(host, "Invalid URI: missing host after user info");
+    int port = uri.getPort();
+    String authority = port != -1 ? host + ":" + port : host;
     return uri.buildUpon().encodedAuthority(authority).build();
   }
 

--- a/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMessageUtil.java
+++ b/libraries/exoplayer_rtsp/src/main/java/androidx/media3/exoplayer/rtsp/RtspMessageUtil.java
@@ -192,7 +192,7 @@ import java.util.regex.Pattern;
     }
 
     // The Uri must include a "@" if the user info is non-null.
-    String authorityWithUserInfo = uri.getAuthority();
+    String authorityWithUserInfo = uri.getEncodedAuthority();
     checkArgument(authorityWithUserInfo != null && authorityWithUserInfo.contains("@"),
         "Invalid URI: userInfo is non-null but '@' delimiter is missing");
 


### PR DESCRIPTION
### Bug

`UriUtil.removeUserInfo()` uses regex split based on `userInfo + "@"`, which fails when the user info contains special characters such as `@`, `+`, or `.`.  
This can lead to `ArrayIndexOutOfBoundsException` or incorrect authority parsing.

Examples that crash:
rtsp://admin:pa%40%40@example.net

Here, the `%40` sequences are decoded into `@` **before** the split occurs, so the code ends up trying to split on a string that no longer matches the original encoded authority. This breaks when user info itself contains `@`.


### Fix

Replaced the manual split with `uri.getHost()` and `uri.getPort()` to rebuild the authority.  
Also added validation for cases where `userInfo` is non-null but `@` is missing.

This approach is RFC-compliant, works with multiple `@` or IPv6 hosts, and avoids regex issues.

