### PR TITLE
Add Compose-based SubtitleView for rendering CueGroup in Jetpack Compose

### DIFF
--- a/libraries/ui_compose_material3/src/main/java/androidx/media3/ui/compose/material3/PlayerSubtitleView.kt
+++ b/libraries/ui_compose_material3/src/main/java/androidx/media3/ui/compose/material3/PlayerSubtitleView.kt
@@ -66,7 +66,7 @@ import androidx.media3.common.util.UnstableApi
  * @param backgroundColor The background color behind text cues. Defaults to fully
  *   transparent black ([Color.Black.copy(alpha = 0.0f)]).(Only affects SRT subtitles)
  *
- * @sample
+ * @sample androidx.media3.ui.compose.material3.SubtitleViewSample
  *
  * Here is a basic usage example:
  *


### PR DESCRIPTION
### Summary

This PR introduces a new Jetpack Compose composable, `SubtitleView`, designed to render subtitles provided by Media3's `CueGroup`. It supports both text cues (e.g., SRT, SSA/ASS converted by ExoPlayer) and bitmap cues (e.g., PNG images), respecting their layout properties such as position, size, and anchor point.

The component is built using Material 3 guidelines and provides customizable styling for text subtitles, including text style and background color. It is intended for use within Compose-based media player UIs.

### Features

- Renders both text and bitmap cues from a `CueGroup`.
- Supports positioning, sizing, and anchoring based on cue metadata.
- Customizable `TextStyle` and background for text cues.
- Aligns subtitle area to the bottom center by default.
- Includes KDoc with usage example.

### Example Usage

```kotlin
@Composable
fun VideoPlayerWithSubtitles(exoPlayer: ExoPlayer) {
  var currentCueGroup: CueGroup? by remember { mutableStateOf(null) }

  DisposableEffect(exoPlayer) {
    val listener = object : Player.Listener {
      override fun onCues(cueGroup: CueGroup) {
        currentCueGroup = cueGroup
      }
    }
    exoPlayer.addListener(listener)
    onDispose {
      exoPlayer.removeListener(listener)
    }
  }

  Box {
    // Your video surface or PlayerView here
    SubtitleView(
      cueGroup = currentCueGroup,
      subtitleStyle = MaterialTheme.typography.bodyLarge.copy(
        color = Color.White,
        fontSize = 20.sp
      ),
      backgroundColor = Color.Black.copy(alpha = 0.5f),
      modifier = Modifier.align(Alignment.BottomCenter)
    )
  }
}
### Test
<img width="1920" height="530" alt="Screenshot_20251010_105207" src="https://github.com/user-attachments/assets/7955cc9e-c506-415f-961f-4743104eea66" />
