### PR TITLE
Fix compilation error with android.nonTransitiveRClass=true

### DIFF
--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -2243,11 +2243,11 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         int maxWidth =
             context
                 .getResources()
-                .getDimensionPixelSize(R.dimen.compat_notification_large_icon_max_width);
+                .getDimensionPixelSize(androidx.core.R.dimen.compat_notification_large_icon_max_width);
         int maxHeight =
             context
                 .getResources()
-                .getDimensionPixelSize(R.dimen.compat_notification_large_icon_max_height);
+                .getDimensionPixelSize(androidx.core.R.dimen.compat_notification_large_icon_max_height);
         maxSize = max(maxSize, min(maxWidth, maxHeight));
       } catch (Resources.NotFoundException e) {
         // keep maxSize as is


### PR DESCRIPTION
This change fixes a compilation error that occurs when `android.nonTransitiveRClass=true` is enabled in `gradle.properties`.