### PR TITLE
Use streaminfo block for FLAC files.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -57,6 +57,10 @@
 *   Smooth Streaming extension:
 *   RTSP extension:
 *   Decoder extensions (FFmpeg, VP9, AV1, etc.):
+    *   FFmpeg extension: Fix an issue that prevented some FLAC files from
+        playing by ensuring the `STREAMINFO` block is correctly parsed and
+        passed to the decoder
+        ([#2887](https://github.com/androidx/media/issues/2887)).
 *   MIDI extension:
 *   Leanback extension:
 *   Cast extension:


### PR DESCRIPTION
Some files do not have the sample size in each frame headers, in that case, ffmpeg needs the streaminfo data to properly decode them.

Issue: #2887