### PR TITLE
media3: utils: Do not check for GL error without GL context/

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/GlUtil.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/GlUtil.java
@@ -276,7 +276,6 @@ public final class GlUtil {
             /* unusedMinor */ new int[1],
             /* minorOffset= */ 0),
         "Error in eglInitialize.");
-    checkGlError();
     return eglDisplay;
   }
 
@@ -328,7 +327,6 @@ public final class GlUtil {
               + " version "
               + openGlVersion);
     }
-    checkGlError();
     return eglContext;
   }
 


### PR DESCRIPTION
GlUtil.java's helper functions createEglContext and getDefaultEglDisplay unconditionally invoke checkGlError for checking any GL errors.

Unfortunately, since a valid EGLContext would not have been made current before executing the aformentioned helper functions, the function pointer for the GL API glGetError would be pointing to a default "gl_no_context" function inside AOSP's libEGL.so that will log a "call to OpenGL ES API with no current context" message in logcat.

Only as part of eglMakeCurrent does libEGL.so replace all GL API function pointers to "gl_no_context" with pointers to the actual functions implementing the APIs.

This PR removes the invocation of checkGlError as part of createEglContext and getDefaultEglDisplay to avoid prints of the aforementioned message from libEGL.so.

Fixes Issue #2910.