### PR TITLE
Remove @Nullable from MediaButtonReceiver.onReceive()

### DIFF
--- a/libraries/session/src/main/java/androidx/media3/session/MediaButtonReceiver.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaButtonReceiver.java
@@ -124,6 +124,7 @@ public class MediaButtonReceiver extends BroadcastReceiver {
    */
   @Override
   public void onReceive(Context context, Intent intent) {
+    checkNotNull(intent);
     handleIntentAndMaybeStartTheService(context, intent);
   }
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaButtonReceiver.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaButtonReceiver.java
@@ -123,7 +123,7 @@ public class MediaButtonReceiver extends BroadcastReceiver {
    * strongly recommended way to handle the intent is using the default implementation.
    */
   @Override
-  public void onReceive(Context context, @Nullable Intent intent) {
+  public void onReceive(Context context, Intent intent) {
     handleIntentAndMaybeStartTheService(context, intent);
   }
 
@@ -136,9 +136,8 @@ public class MediaButtonReceiver extends BroadcastReceiver {
    */
   @UnstableApi
   protected final void handleIntentAndMaybeStartTheService(
-      Context context, @Nullable Intent intent) {
-    if (intent == null
-        || !Objects.equals(intent.getAction(), Intent.ACTION_MEDIA_BUTTON)
+      Context context, Intent intent) {
+    if (!Objects.equals(intent.getAction(), Intent.ACTION_MEDIA_BUTTON)
         || !intent.hasExtra(Intent.EXTRA_KEY_EVENT)) {
       Log.d(TAG, "Ignore unsupported intent: " + intent);
       return;


### PR DESCRIPTION
The [docs](https://developer.android.com/reference/android/content/BroadcastReceiver#onReceive(android.content.Context,%20android.content.Intent)) for `onReceive` state:

> This method is called when the BroadcastReceiver is receiving an Intent broadcast.

So I am proposing to remove this qualifier. I wonder if it's possible to get this method called with a null parameter, other than clients calling this method directly, in which case I think enforcing a non-nullable parameter is all the better.

This prevents all extending kotlin classes from having to nullsafe the intent parameter before continuing.