### PR TITLE
Defer Dolby Vision mimeType assignment

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
@@ -1468,6 +1468,7 @@ public final class BoxParser {
     @C.ColorTransfer int colorTransfer = Format.NO_VALUE;
     // The format of HDR static info is defined in CTA-861-G:2017, Table 45.
     @Nullable ByteBuffer hdrStaticInfo = null;
+    @Nullable DolbyVisionConfig dolbyVisionConfig = null;
 
     while (childPosition - position < size) {
       parent.setPosition(childPosition);
@@ -1607,10 +1608,9 @@ public final class BoxParser {
               false, "initializationData must already be set from hvcC or avcC atom");
         }
         parent.setPosition(childStartPosition + Mp4Box.HEADER_SIZE);
-        @Nullable DolbyVisionConfig dolbyVisionConfig = DolbyVisionConfig.parse(parent);
-        if (dolbyVisionConfig != null) {
-          codecs = dolbyVisionConfig.codecs;
-          mimeType = MimeTypes.VIDEO_DOLBY_VISION;
+        @Nullable DolbyVisionConfig parsedDvConfig = DolbyVisionConfig.parse(parent);
+        if (parsedDvConfig != null) {
+          dolbyVisionConfig = parsedDvConfig;
         }
       } else if (childAtomType == Mp4Box.TYPE_vpcC) {
         ExtractorUtil.checkContainerInput(mimeType == null, /* message= */ null);
@@ -1780,6 +1780,11 @@ public final class BoxParser {
       childPosition += childAtomSize;
     }
 
+    if (dolbyVisionConfig != null) {
+      mimeType = MimeTypes.VIDEO_DOLBY_VISION;
+      codecs = dolbyVisionConfig.codecs;
+    }
+    
     // If the media type was not recognized, ignore the track.
     if (mimeType == null) {
       return;


### PR DESCRIPTION
Certain non-canonical Dolby Vision Profile 20 streams position dvcC/dvvC/dvwC boxes before lhvC, triggering an 'lhvC must follow hvcC atom' parser exception. To accommodate these files, defer Dolby Vision mimeType assignment.