### PR TITLE
Remove hardcoded SDK 29 checks in MCAR and DefaultAudioSink

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioSink.java
@@ -22,7 +22,6 @@ import android.media.AudioDeviceInfo;
 import android.media.AudioTrack;
 import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.media3.common.AudioAttributes;
 import androidx.media3.common.AuxEffectInfo;
 import androidx.media3.common.C;
@@ -646,18 +645,16 @@ public interface AudioSink {
   void disableTunneling();
 
   /**
-   * Sets audio offload mode, if possible. Enabling offload is only possible if the sink is based on
-   * a platform {@link AudioTrack}, and requires platform API version 29 onwards.
+   * Sets audio offload mode, if possible. If the sink is based on a platform {@link AudioTrack},
+   * enabling offload requires platform API version 29 onwards.
    */
-  @RequiresApi(29)
   default void setOffloadMode(@OffloadMode int offloadMode) {}
 
   /**
-   * Sets offload delay padding on the {@link AudioTrack}, if possible. Setting the offload delay
-   * padding is only possible if the sink is based on a platform {@link AudioTrack} in offload mode.
-   * Also requires platform API version 29 onwards.
+   * Sets offload delay padding on the {@link AudioTrack}, if possible. If the sink is based on a
+   * platform {@link AudioTrack}, setting the offload delay padding requires platform API version 29
+   * onwards and the {@link AudioTrack} must be in offload mode.
    */
-  @RequiresApi(29)
   default void setOffloadDelayPadding(int delayInFrames, int paddingInFrames) {}
 
   /** Sets the {@link AudioOutputProvider} to use as the output path. */

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -1260,9 +1260,7 @@ public final class DefaultAudioSink implements AudioSink {
   @Override
   public boolean hasPendingData() {
     return isAudioOutputInitialized()
-        && (SDK_INT < 29
-            || !audioOutput.isOffloadedPlayback()
-            || !handledOffloadOnPresentationEnded)
+        && (!audioOutput.isOffloadedPlayback() || !handledOffloadOnPresentationEnded)
         && hasAudioOutputPendingData(getWrittenFrames());
   }
 
@@ -1399,14 +1397,11 @@ public final class DefaultAudioSink implements AudioSink {
     }
   }
 
-  @RequiresApi(29)
   @Override
   public void setOffloadMode(@OffloadMode int offloadMode) {
-    checkState(SDK_INT >= 29);
     this.offloadMode = offloadMode;
   }
 
-  @RequiresApi(29)
   @Override
   public void setOffloadDelayPadding(int delayInFrames, int paddingInFrames) {
     if (audioOutput != null

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ForwardingAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ForwardingAudioSink.java
@@ -17,7 +17,6 @@ package androidx.media3.exoplayer.audio;
 
 import android.media.AudioDeviceInfo;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.media3.common.AudioAttributes;
 import androidx.media3.common.AuxEffectInfo;
 import androidx.media3.common.Format;
@@ -182,13 +181,11 @@ public class ForwardingAudioSink implements AudioSink {
   }
 
   @Override
-  @RequiresApi(29)
   public void setOffloadMode(@OffloadMode int offloadMode) {
     sink.setOffloadMode(offloadMode);
   }
 
   @Override
-  @RequiresApi(29)
   public void setOffloadDelayPadding(int delayInFrames, int paddingInFrames) {
     sink.setOffloadDelayPadding(delayInFrames, paddingInFrames);
   }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
@@ -669,15 +669,13 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
       }
     }
     try {
-      if (SDK_INT >= 29) {
-        if (isBypassEnabled()
-            && getConfiguration().offloadModePreferred != AudioSink.OFFLOAD_MODE_DISABLED) {
-          // TODO(b/280050553): Investigate potential issue where bypass is enabled for passthrough
-          //  but offload is not supported
-          audioSink.setOffloadMode(getConfiguration().offloadModePreferred);
-        } else {
-          audioSink.setOffloadMode(AudioSink.OFFLOAD_MODE_DISABLED);
-        }
+      if (isBypassEnabled()
+          && getConfiguration().offloadModePreferred != AudioSink.OFFLOAD_MODE_DISABLED) {
+        // TODO(b/280050553): Investigate potential issue where bypass is enabled for passthrough
+        //  but offload is not supported
+        audioSink.setOffloadMode(getConfiguration().offloadModePreferred);
+      } else {
+        audioSink.setOffloadMode(AudioSink.OFFLOAD_MODE_DISABLED);
       }
       audioSink.configure(audioSinkInputFormat, /* specifiedBufferSize= */ 0, channelMap);
     } catch (AudioSink.ConfigurationException e) {
@@ -979,8 +977,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
 
   @Override
   protected void handleInputBufferSupplementalData(DecoderInputBuffer buffer) {
-    if (SDK_INT >= 29
-        && buffer.format != null
+    if (buffer.format != null
         && Objects.equals(buffer.format.sampleMimeType, MimeTypes.AUDIO_OPUS)
         && isBypassEnabled()) {
       ByteBuffer data = checkNotNull(buffer.supplementalData);


### PR DESCRIPTION
There are some device specific APIs for offload on earlier APIs. Removing these checks allows these device specific APIs to be used by customizing AudioOutputProvider and AudioOffloadSupportProvider, without having to change MCAR or DefaultAudioSink.

For AudioTrackAudioOutputProvider and DefaultAudioOffloadSupportProvider, this change is a no-op. They check for SDK 29 on their own and will just not do anything related to offload on earlier SDKs.