### PR TITLE
Enable detection of DVB subtitles and audio tracks in TS container (.ts)

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/DvbSubtitleReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/DvbSubtitleReader.java
@@ -81,7 +81,7 @@ public final class DvbSubtitleReader implements ElementaryStreamReader {
   @Override
   public void packetStarted(long pesTimeUs, @TsPayloadReader.Flags int flags) {
     if ((flags & FLAG_DATA_ALIGNMENT_INDICATOR) == 0) {
-      return;
+      //return; [Remove this able to Detect DVB Subtittles & Mutiple Audio Tracks in TS Container (.ts)
     }
     writingSample = true;
     sampleTimeUs = pesTimeUs;


### PR DESCRIPTION
Removed early return to enable detection of DVB subtitles and multiple audio tracks in TS container. 

Sloutions for my Issue: https://github.com/androidx/media/issues/2968

@Override
  public void packetStarted(long pesTimeUs, @TsPayloadReader.Flags int flags) {
    if ((flags & FLAG_DATA_ALIGNMENT_INDICATOR) == 0) {
      //return; [Remove this able to Detect DVB Subtittles & Mutiple Audio Tracks in TS Container (.ts)
    }
    writingSample = true;
    sampleTimeUs = pesTimeUs;
    sampleBytesWritten = 0;
    bytesToCheck = 2;
  }