### PR TITLE
Fix Refactor file path handling to use Path API

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -125,6 +125,7 @@ import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -401,12 +402,12 @@ public final class Util {
       if (uriPath == null) {
         return false;
       }
-      String filePath = new File(uriPath).getCanonicalPath();
-      String internalAppDirectoryPath = activity.getFilesDir().getCanonicalPath();
+      Path filePath = new File(uriPath).toPath().toRealPath();
+      Path internalAppDirectoryPath = activity.getFilesDir().toPath().toRealPath();
       @Nullable File externalAppDirectory = activity.getExternalFilesDir(/* type= */ null);
       @Nullable
-      String externalAppDirectoryPath =
-          externalAppDirectory == null ? null : externalAppDirectory.getCanonicalPath();
+      Path externalAppDirectoryPath =
+          externalAppDirectory == null ? null : externalAppDirectory.toPath().toRealPath();
       return filePath.startsWith(internalAppDirectoryPath)
           || (externalAppDirectoryPath != null && filePath.startsWith(externalAppDirectoryPath));
     } catch (IOException e) {


### PR DESCRIPTION
**General fix approach**

When checking whether a user-supplied path is within a given directory, ensure you are comparing normalized `Path` objects or, if using strings, that directory paths are slash-terminated before using `startsWith`. In Java, `Path#startsWith` performs a component-wise check and avoids the partial-prefix issue.

**Best concrete fix here**

We only need to adjust `Util.isAppSpecificStorageFileUri` in `Util.java`. Currently it does:

```java
String filePath = new File(uriPath).getCanonicalPath();
String internalAppDirectoryPath = activity.getFilesDir().getCanonicalPath();
@Nullable File externalAppDirectory = activity.getExternalFilesDir(/* type= */ null);
@Nullable
String externalAppDirectoryPath =
    externalAppDirectory == null ? null : externalAppDirectory.getCanonicalPath();
return filePath.startsWith(internalAppDirectoryPath)
    || (externalAppDirectoryPath != null && filePath.startsWith(externalAppDirectoryPath));
```

We will convert these to `Path` objects and use `startsWith` on normalized paths:

```java
Path filePath = new File(uriPath).toPath().toRealPath();
Path internalAppDirectoryPath = activity.getFilesDir().toPath().toRealPath();
@Nullable File externalAppDirectory = activity.getExternalFilesDir(/* type= */ null);
@Nullable Path externalAppDirectoryPath =
    externalAppDirectory == null ? null : externalAppDirectory.toPath().toRealPath();
return filePath.startsWith(internalAppDirectoryPath)
    || (externalAppDirectoryPath != null && filePath.startsWith(externalAppDirectoryPath));
```

This keeps the original behavior (checking “inside app-specific internal or external storage”) but removes the partial-prefix issue. `toRealPath()` is roughly the `Path` equivalent of `getCanonicalPath()`, resolving symlinks and `..`.

We must add the necessary imports at the top of `Util.java`:

```java
import java.nio.file.Path;
import java.nio.file.Paths;
```

(We actually only need `Path`; `Paths` is not strictly required, so we will only import `Path`.)

### References
[Partial Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
CVE-2022-23457: [ESAPI Vulnerability Report](https://github.com/ESAPI/esapi-java-legacy/blob/develop/documentation/GHSL-2022-008_The_OWASP_Enterprise_Security_API.md)