### PR TITLE
Ask the audio output whether it wants to be reused

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioOutput.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioOutput.java
@@ -22,6 +22,8 @@ import androidx.media3.common.C;
 import androidx.media3.common.PlaybackParameters;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.analytics.PlayerId;
+import androidx.media3.exoplayer.audio.AudioOutputProvider.FormatConfig;
+import androidx.media3.exoplayer.audio.AudioOutputProvider.OutputConfig;
 import java.nio.ByteBuffer;
 
 /** An interface to wrap an object that can play audio, like an {@link AudioTrack}. */
@@ -169,6 +171,13 @@ public interface AudioOutput {
   /** Sets the {@link PlayerId} on the audio output. */
   @UnstableApi
   default void setPlayerId(PlayerId playerId) {}
+
+  /** Returns if the configurations are sufficiently compatible to reuse this audio output. */
+  @UnstableApi
+  default boolean canReuseAudioOutput(
+      OutputConfig currentConfig, FormatConfig newFormat, OutputConfig newConfig) {
+    return newConfig.equals(currentConfig);
+  }
 
   /** Attaches an auxiliary effect to the output. */
   void attachAuxEffect(int effectId);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -914,10 +914,11 @@ public final class DefaultAudioSink implements AudioSink {
       if (!drainToEndOfStream()) {
         // There's still pending data in audio processors to write to the output.
         return false;
-      } else if (!audioOutput.canReuseAudioOutput(
-          configuration.outputConfig,
-          getFormatConfig(pendingConfiguration.afterProcessingInputFormat),
-          pendingConfiguration.outputConfig)) {
+      } else if (audioOutput != null
+          && !audioOutput.canReuseAudioOutput(
+              configuration.outputConfig,
+              getFormatConfig(pendingConfiguration.afterProcessingInputFormat),
+              pendingConfiguration.outputConfig)) {
         playPendingData();
         if (hasPendingData()) {
           // We're waiting for playout on the current audio output to finish.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -914,7 +914,10 @@ public final class DefaultAudioSink implements AudioSink {
       if (!drainToEndOfStream()) {
         // There's still pending data in audio processors to write to the output.
         return false;
-      } else if (!pendingConfiguration.canReuseAudioOutput(configuration)) {
+      } else if (!audioOutput.canReuseAudioOutput(
+          configuration.outputConfig,
+          getFormatConfig(pendingConfiguration.afterProcessingInputFormat),
+          pendingConfiguration.outputConfig)) {
         playPendingData();
         if (hasPendingData()) {
           // We're waiting for playout on the current audio output to finish.
@@ -2032,11 +2035,6 @@ public final class DefaultAudioSink implements AudioSink {
           outputPcmFrameSize,
           outputConfig,
           audioProcessingPipeline);
-    }
-
-    /** Returns if the configurations are sufficiently compatible to reuse the audio output. */
-    private boolean canReuseAudioOutput(Configuration newConfiguration) {
-      return newConfiguration.outputConfig.equals(outputConfig);
     }
 
     private long inputFramesToDurationUs(long frameCount) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ForwardingAudioOutput.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/ForwardingAudioOutput.java
@@ -152,4 +152,12 @@ public class ForwardingAudioOutput implements AudioOutput {
   public void setPreferredDevice(@Nullable AudioDeviceInfo preferredDevice) {
     audioOutput.setPreferredDevice(preferredDevice);
   }
+
+  @Override
+  public boolean canReuseAudioOutput(
+      AudioOutputProvider.OutputConfig currentConfig,
+      AudioOutputProvider.FormatConfig newFormat,
+      AudioOutputProvider.OutputConfig newConfig) {
+    return audioOutput.canReuseAudioOutput(currentConfig, newFormat, newConfig);
+  }
 }


### PR DESCRIPTION
as discussed with @andrewlewis, this is required for ReplayGain in offload mode to sometimes prevent gapless mode to avoid music being too loud for a short amount of time (as there is no way to change effect settings during gapless track transition). To detect the ReplayGain data, Format.metadata is required which is available through FormatConfig parameter.