### PR TITLE
Fix: SUBRIP_TIMECODE #3045

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/subrip/SubripParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/subrip/SubripParser.java
@@ -60,7 +60,7 @@ public final class SubripParser implements SubtitleParser {
   private static final String TAG = "SubripParser";
 
   // Some SRT files don't include hours or milliseconds in the timecode, so we use optional groups.
-  private static final String SUBRIP_TIMECODE = "(?:(\\d+):)?(\\d+):(\\d+)(?:,(\\d{3}))?";
+  private static final String SUBRIP_TIMECODE = "(?:(\\d+):)?(\\d+):(\\d+)(?:[,.](\\d+))?";
   private static final Pattern SUBRIP_TIMING_LINE =
       Pattern.compile("\\s*(" + SUBRIP_TIMECODE + ")\\s*-->\\s*(" + SUBRIP_TIMECODE + ")\\s*");
 


### PR DESCRIPTION
This fixes the subrip regex to allow more valid time encodings. According to the comment above the regex you already allow "non-spec" srt subtitles as: "Some SRT files don't include hours or milliseconds in the timecode, so we use optional groups."

So this pull request is only expands upon this reasoning by allowing "," and "." and more or less than 3 decimals because real world srt files use that sometimes. 

I do not have a google account, so I am unable to accept the CLA, but this pull request is free for anyone to use or create another pull request from. It is mainly to show how simple #3045 is to fix. 