### PR TITLE
GlUtil.java: Explicitly set GL_DRAW/READ_BUFFER state

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/GlUtil.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/GlUtil.java
@@ -1145,10 +1145,10 @@ public final class GlUtil {
     if (!eglSurface.equals(EGL14.EGL_NO_SURFACE)
         && framebuffer == 0
         && getContextMajorVersion() >= 3) {
-        GLES30.glDrawBuffers(1, new int[] {GLES30.GL_BACK}, 0);
-        checkGlError();
-        GLES30.glReadBuffer(GLES30.GL_BACK);
-        checkGlError();
+      GLES30.glDrawBuffers(1, new int[] {GLES30.GL_BACK}, 0);
+      checkGlError();
+      GLES30.glReadBuffer(GLES30.GL_BACK);
+      checkGlError();
     }
   }
 }


### PR DESCRIPTION
Fixes #2982

GlUtil::focusRenderTarget currently does not explicitly set a specific GL_DRAW/READ_BUFFER state, instead relying on the state set during the creation of the EGL/GL Context.

This leads to a scenario where the GL_DRAW/READ_BUFFER state would be initialized to GL_NONE as part of GlUtil::createFocusedPlaceholderEglSurface if EGL_KHR_surfaceless_context is supported by the vendor EGL ICD and the same state being retained when invoking GlUtil::focusRenderTarget.

If a valid EGLSurface is being passed into focusRenderTarget with the intention of using it as the draw or read surface, such draws or reads would be ignored since GL_DRAW/READ_BUFFER would still be pointing to GL_NONE (1).

The behaviour in (1) is per the EGL spec (Refer to 1 and Issue #4 in (2)) but Media3 seems to be assuming the underlying vendor EGL ICDs would be reinitializing the state of GL_DRAW/READ_BUFFER in the scenario mentioned above which goes against the spec.

This change explicitly setst the GL_DRAW/READ_BUFFER state as part of focusRenderTarget if it is switching from a surfaceless EGL context to one with a surface.

(1): https://www.khronos.org/members/login/bugzilla/show_bug.cgi?id=13534#c24
(2): https://registry.khronos.org/EGL/extensions/KHR/EGL_KHR_no_config_context.txt