### PR TITLE
Refactor PCM format handling to use Util methods

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/audio/ToInt16PcmAudioProcessor.java
+++ b/libraries/common/src/main/java/androidx/media3/common/audio/ToInt16PcmAudioProcessor.java
@@ -44,15 +44,7 @@ public final class ToInt16PcmAudioProcessor extends BaseAudioProcessor {
   public AudioFormat onConfigure(AudioFormat inputAudioFormat)
       throws UnhandledAudioFormatException {
     @C.PcmEncoding int encoding = inputAudioFormat.encoding;
-    if (encoding != C.ENCODING_PCM_8BIT
-        && encoding != C.ENCODING_PCM_16BIT
-        && encoding != C.ENCODING_PCM_16BIT_BIG_ENDIAN
-        && encoding != C.ENCODING_PCM_24BIT
-        && encoding != C.ENCODING_PCM_24BIT_BIG_ENDIAN
-        && encoding != C.ENCODING_PCM_32BIT
-        && encoding != C.ENCODING_PCM_32BIT_BIG_ENDIAN
-        && encoding != C.ENCODING_PCM_FLOAT
-        && encoding != C.ENCODING_PCM_DOUBLE) {
+    if (!Util.isEncodingLinearPcm(encoding)) {
       throw new UnhandledAudioFormatException(inputAudioFormat);
     }
     return encoding != C.ENCODING_PCM_16BIT

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/EventLogger.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/EventLogger.java
@@ -807,6 +807,8 @@ public class EventLogger implements AnalyticsListener {
         return "dts-hd";
       case C.ENCODING_DTS_UHD_P2:
         return "dts-uhd-p2";
+      case C.ENCODING_DSD:
+        return "dsd";
       case C.ENCODING_E_AC3:
         return "eac3";
       case C.ENCODING_E_AC3_JOC:
@@ -829,6 +831,8 @@ public class EventLogger implements AnalyticsListener {
         return "pcm-32";
       case C.ENCODING_PCM_32BIT_BIG_ENDIAN:
         return "pcm-32be";
+      case C.ENCODING_PCM_DOUBLE:
+        return "pcm-double";
       case C.ENCODING_PCM_FLOAT:
         return "pcm-float";
       case C.ENCODING_INVALID:

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
@@ -2437,15 +2437,8 @@ public class MatroskaExtractor implements Extractor {
           break;
         case CODEC_ID_PCM_INT_BIG:
           mimeType = MimeTypes.AUDIO_RAW;
-          if (audioBitDepth == 8) {
-            pcmEncoding = C.ENCODING_PCM_8BIT;
-          } else if (audioBitDepth == 16) {
-            pcmEncoding = C.ENCODING_PCM_16BIT_BIG_ENDIAN;
-          } else if (audioBitDepth == 24) {
-            pcmEncoding = C.ENCODING_PCM_24BIT_BIG_ENDIAN;
-          } else if (audioBitDepth == 32) {
-            pcmEncoding = C.ENCODING_PCM_32BIT_BIG_ENDIAN;
-          } else {
+          pcmEncoding = Util.getPcmEncoding(audioBitDepth, ByteOrder.BIG_ENDIAN);
+          if (pcmEncoding == C.ENCODING_INVALID) {
             pcmEncoding = Format.NO_VALUE;
             mimeType = MimeTypes.AUDIO_UNKNOWN;
             Log.w(

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
@@ -2130,17 +2130,12 @@ public final class BoxParser {
       boolean isFloat = (formatSpecificFlags & 1) != 0;
       boolean isBigEndian = (formatSpecificFlags & (1 << 1)) != 0;
       if (!isFloat) {
-        if (bitsPerSample == 8) {
-          pcmEncoding = C.ENCODING_PCM_8BIT;
-        } else if (bitsPerSample == 16) {
-          pcmEncoding = isBigEndian ? C.ENCODING_PCM_16BIT_BIG_ENDIAN : C.ENCODING_PCM_16BIT;
-        } else if (bitsPerSample == 24) {
-          pcmEncoding = isBigEndian ? C.ENCODING_PCM_24BIT_BIG_ENDIAN : C.ENCODING_PCM_24BIT;
-        } else if (bitsPerSample == 32) {
-          pcmEncoding = isBigEndian ? C.ENCODING_PCM_32BIT_BIG_ENDIAN : C.ENCODING_PCM_32BIT;
-        }
-      } else if (bitsPerSample == 32) {
+        pcmEncoding = Util.getPcmEncoding(bitsPerSample, isBigEndian ? BIG_ENDIAN : LITTLE_ENDIAN);
+      } else if (!isBigEndian && bitsPerSample == 32) {
         pcmEncoding = C.ENCODING_PCM_FLOAT;
+      }
+      if (pcmEncoding == C.ENCODING_INVALID) {
+        pcmEncoding = Format.NO_VALUE;
       }
       parent.skipBytes(8); // constBytesPerAudioPacket, constLPCMFramesPerAudioPacket
     } else {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
@@ -2131,7 +2131,7 @@ public final class BoxParser {
       boolean isBigEndian = (formatSpecificFlags & (1 << 1)) != 0;
       if (!isFloat) {
         pcmEncoding = Util.getPcmEncoding(bitsPerSample, isBigEndian ? BIG_ENDIAN : LITTLE_ENDIAN);
-      } else if (!isBigEndian && bitsPerSample == 32) {
+      } else if (bitsPerSample == 32) {
         pcmEncoding = C.ENCODING_PCM_FLOAT;
       }
       if (pcmEncoding == C.ENCODING_INVALID) {


### PR DESCRIPTION
Tidy up PCM format handling by refactoring a few usages that manually handle all PCM formats to use the Util methods that already exist. 

This also adds missing string representations for existing formats (`C.ENCODING_PCM_DOUBLE` and `C.ENCODING_DSD`) to `EventLogger` to complete format coverage.

This is a pure refactoring change and does not alter existing playback behavior.