### PR TITLE
Add AdaptiveTrackSelection format priority ordering hooks

### DIFF
--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelectionTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelectionTest.java
@@ -122,6 +122,42 @@ public final class AdaptiveTrackSelectionTest {
   }
 
   @Test
+  public void initial_updateSelectedTrack_withCustomFormatPriorityOrder_selectsFirstEligible() {
+    Format format1 = videoFormat(/* bitrate= */ 500, /* width= */ 320, /* height= */ 240);
+    Format format2 = videoFormat(/* bitrate= */ 1000, /* width= */ 640, /* height= */ 480);
+    Format format3 = videoFormat(/* bitrate= */ 2000, /* width= */ 960, /* height= */ 720);
+    TrackGroup trackGroup = new TrackGroup(format1, format2, format3);
+
+    when(mockBandwidthMeter.getBitrateEstimate()).thenReturn(5000L);
+    AdaptiveTrackSelection adaptiveTrackSelection =
+        prepareTrackSelection(
+            new AdaptiveTrackSelection(
+                trackGroup,
+                selectedAllTracksInGroup(trackGroup),
+                TrackSelection.TYPE_UNSET,
+                mockBandwidthMeter,
+                AdaptiveTrackSelection.DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS,
+                AdaptiveTrackSelection.DEFAULT_MAX_DURATION_FOR_QUALITY_DECREASE_MS,
+                AdaptiveTrackSelection.DEFAULT_MIN_DURATION_TO_RETAIN_AFTER_DISCARD_MS,
+                AdaptiveTrackSelection.DEFAULT_MAX_WIDTH_TO_DISCARD,
+                AdaptiveTrackSelection.DEFAULT_MAX_HEIGHT_TO_DISCARD,
+                /* bandwidthFraction= */ 1.0f,
+                AdaptiveTrackSelection.DEFAULT_BUFFERED_FRACTION_TO_LIVE_EDGE_FOR_QUALITY_INCREASE,
+                /* adaptationCheckpoints= */ ImmutableList.of(),
+                fakeClock) {
+              @Override
+              protected int[] getFormatPriorityOrder(
+                  long nowMs, long chunkDurationUs, long effectiveBitrate) {
+                // Provide explicit priority order: lowest bitrate first.
+                return new int[] {2, 1, 0};
+              }
+            });
+
+    assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format1);
+    assertThat(adaptiveTrackSelection.getSelectionReason()).isEqualTo(C.SELECTION_REASON_INITIAL);
+  }
+
+  @Test
   public void updateSelectedTrackDoNotSwitchUpIfNotBufferedEnough() {
     Format format1 = videoFormat(/* bitrate= */ 500, /* width= */ 320, /* height= */ 240);
     Format format2 = videoFormat(/* bitrate= */ 1000, /* width= */ 640, /* height= */ 480);


### PR DESCRIPTION
### Summary
This change adds extension points to AdaptiveTrackSelection so apps can control candidate format priority beyond default bitrate ordering, while preserving existing ABR behavior by default.

### What Changed

Added [getFormatPriorityOrder(...)](app://-/index.html#) hook to let developers provide an explicit per-update format priority list.
Added [getFormatIndexForPriorityPosition(...)](app://-/index.html#) hook (default bitrate-descending behavior) for position-based custom ordering.
Updated ideal-index selection to use custom priority when provided.
Kept default behavior unchanged when hooks are not overridden.
Added validation/fallback behavior for invalid custom priority order:
invalid order is ignored with a warning
selection falls back to default ordering
Added unit coverage in AdaptiveTrackSelectionTest proving a custom priority order can be applied.
### Why
Current adaptive selection effectively prioritizes higher bitrate first. This makes it hard to prioritize developer-defined rules (for example, quality score ranking). These hooks allow custom ordering without changing core ABR switching logic.

### Compatibility

No behavior change for existing users.
No API break for default usage.
Buffer-based switch-up/switch-down logic remains unchanged.
### Testing

Ran:
[gradlew :lib-exoplayer:testDebugUnitTest --tests androidx.media3.exoplayer.trackselection.AdaptiveTrackSelectionTest](app://-/index.html#)
Result: BUILD SUCCESSFUL