### PR TITLE
Allow renderers capacity reevaluation

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImplInternal.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImplInternal.java
@@ -205,11 +205,8 @@ import java.util.Objects;
    */
   private static final long DURATION_TO_ADVANCE_READING_THRESHOLD_US = 10 * C.MICROS_PER_SECOND;
 
-  private final RendererHolder[] renderers;
-  private final RendererCapabilities[] rendererCapabilities;
-  private final boolean[] rendererReportedReady;
+  private final RenderersCoordinator renderersCoordinator;
   private final TrackSelector trackSelector;
-  private final TrackSelectorResult emptyTrackSelectorResult;
   private final LoadControl loadControl;
   private final BandwidthMeter bandwidthMeter;
   private final HandlerWrapper handler;
@@ -231,7 +228,6 @@ import java.util.Objects;
   private final boolean dynamicSchedulingEnabled;
   private final AnalyticsCollector analyticsCollector;
   private final HandlerWrapper applicationLooperHandler;
-  private final boolean hasSecondaryRenderers;
   private final AudioFocusManager audioFocusManager;
   private final boolean avoidLoadingWhileEnded;
 
@@ -272,10 +268,8 @@ import java.util.Objects;
 
   public ExoPlayerImplInternal(
       Context context,
-      Renderer[] renderers,
-      Renderer[] secondaryRenderers,
+      RenderersCoordinator renderersCoordinator,
       TrackSelector trackSelector,
-      TrackSelectorResult emptyTrackSelectorResult,
       LoadControl loadControl,
       BandwidthMeter bandwidthMeter,
       @Player.RepeatMode int repeatMode,
@@ -295,8 +289,8 @@ import java.util.Objects;
       VideoFrameMetadataListener videoFrameMetadataListener,
       boolean avoidLoadingWhileEnded) {
     this.playbackInfoUpdateListener = playbackInfoUpdateListener;
+    this.renderersCoordinator = renderersCoordinator;
     this.trackSelector = trackSelector;
-    this.emptyTrackSelectorResult = emptyTrackSelectorResult;
     this.loadControl = loadControl;
     this.bandwidthMeter = bandwidthMeter;
     this.repeatMode = repeatMode;
@@ -321,30 +315,8 @@ import java.util.Objects;
     retainBackBufferFromKeyframe = loadControl.retainBackBufferFromKeyframe(playerId);
     lastPreloadPoolInvalidationTimeline = Timeline.EMPTY;
 
-    playbackInfo = PlaybackInfo.createDummy(emptyTrackSelectorResult);
+    playbackInfo = PlaybackInfo.createDummy(renderersCoordinator.emptyTrackSelectorResult);
     playbackInfoUpdate = new PlaybackInfoUpdate(playbackInfo);
-    rendererCapabilities = new RendererCapabilities[renderers.length];
-    rendererReportedReady = new boolean[renderers.length];
-    @Nullable
-    RendererCapabilities.Listener rendererCapabilitiesListener =
-        trackSelector.getRendererCapabilitiesListener();
-
-    boolean hasSecondaryRenderers = false;
-    this.renderers = new RendererHolder[renderers.length];
-    for (int i = 0; i < renderers.length; i++) {
-      renderers[i].init(/* index= */ i, playerId, clock);
-      rendererCapabilities[i] = renderers[i].getCapabilities();
-      if (rendererCapabilitiesListener != null) {
-        rendererCapabilities[i].setListener(rendererCapabilitiesListener);
-      }
-      if (secondaryRenderers[i] != null) {
-        secondaryRenderers[i].init(/* index= */ i, playerId, clock);
-        hasSecondaryRenderers = true;
-      }
-      this.renderers[i] = new RendererHolder(renderers[i], secondaryRenderers[i], /* index= */ i);
-    }
-    this.hasSecondaryRenderers = hasSecondaryRenderers;
-
     mediaClock = new DefaultMediaClock(this, clock);
     pendingMessages = new ArrayList<>();
     window = new Timeline.Window();
@@ -384,13 +356,12 @@ import java.util.Objects;
   private MediaPeriodHolder createMediaPeriodHolder(
       MediaPeriodInfo mediaPeriodInfo, long rendererPositionOffsetUs) {
     return new MediaPeriodHolder(
-        rendererCapabilities,
+        renderersCoordinator,
         rendererPositionOffsetUs,
         trackSelector,
         loadControl.getAllocator(playerId),
         mediaSourceList,
         mediaPeriodInfo,
-        emptyTrackSelectorResult,
         preloadConfiguration.targetPreloadDurationUs);
   }
 
@@ -534,7 +505,7 @@ import java.util.Objects;
 
   private void setVideoFrameMetadataListenerInternal(
       VideoFrameMetadataListener videoFrameMetadataListener) throws ExoPlaybackException {
-    for (RendererHolder renderer : renderers) {
+    for (RendererHolder renderer : renderersCoordinator.rendererHolders) {
       renderer.setVideoFrameMetadataListener(videoFrameMetadataListener);
     }
   }
@@ -708,7 +679,7 @@ import java.util.Objects;
           setPreloadConfigurationInternal((PreloadConfiguration) msg.obj);
           break;
         case MSG_DO_SOME_WORK:
-          doSomeWork();
+          renderersCoordinator.withLock(this::doSomeWork);
           break;
         case MSG_SEEK_TO:
           seekToInternal((SeekPosition) msg.obj);
@@ -748,13 +719,15 @@ import java.util.Objects;
           stopInternal(/* forceResetRenderers= */ false, /* acknowledgeStop= */ true);
           break;
         case MSG_PERIOD_PREPARED:
-          handlePeriodPrepared((MediaPeriod) msg.obj);
+          renderersCoordinator.withLock(() -> {
+            handlePeriodPrepared((MediaPeriod) msg.obj);
+          });
           break;
         case MSG_SOURCE_CONTINUE_LOADING_REQUESTED:
           handleContinueLoadingRequested((MediaPeriod) msg.obj);
           break;
         case MSG_TRACK_SELECTION_INVALIDATED:
-          reselectTracksInternal();
+          renderersCoordinator.withLock(this::reselectTracksInternal);
           break;
         case MSG_PLAYBACK_PARAMETERS_CHANGED_INTERNAL:
           handlePlaybackParameters((PlaybackParameters) msg.obj, /* acknowledgeCommand= */ false);
@@ -787,7 +760,7 @@ import java.util.Objects;
           setPauseAtEndOfWindowInternal(msg.arg1 != 0);
           break;
         case MSG_ATTEMPT_RENDERER_ERROR_RECOVERY:
-          attemptRendererErrorRecovery();
+          renderersCoordinator.withLock(this::attemptRendererErrorRecovery);
           break;
         case MSG_RENDERER_CAPABILITIES_CHANGED:
           reselectTracksInternalAndSeek();
@@ -1057,7 +1030,7 @@ import java.util.Objects;
   private void setVolumeInternal(float volume) throws ExoPlaybackException {
     this.volume = volume;
     float scaledVolume = volume * audioFocusManager.getVolumeMultiplier();
-    for (RendererHolder renderer : renderers) {
+    for (RendererHolder renderer : renderersCoordinator.rendererHolders) {
       renderer.setVolume(scaledVolume);
     }
   }
@@ -1225,6 +1198,7 @@ import java.util.Objects;
       return;
     }
     TrackSelectorResult trackSelectorResult = playingPeriodHolder.getTrackSelectorResult();
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (int i = 0; i < renderers.length; i++) {
       if (!trackSelectorResult.isRendererEnabled(i)) {
         continue;
@@ -1235,6 +1209,7 @@ import java.util.Objects;
 
   private void stopRenderers() throws ExoPlaybackException {
     mediaClock.stop();
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (RendererHolder rendererHolder : renderers) {
       rendererHolder.stop();
     }
@@ -1376,6 +1351,7 @@ import java.util.Objects;
       rendererPositionElapsedRealtimeUs = msToUs(clock.elapsedRealtime());
       playingPeriodHolder.mediaPeriod.discardBuffer(
           playbackInfo.positionUs - backBufferDurationUs, retainBackBufferFromKeyframe);
+      final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
       for (int i = 0; i < renderers.length; i++) {
         RendererHolder renderer = renderers[i];
         if (renderer.getEnabledRendererCount() == 0) {
@@ -1444,6 +1420,7 @@ import java.util.Objects;
 
     boolean playbackMaybeStuck = false;
     if (playbackInfo.playbackState == Player.STATE_BUFFERING) {
+      final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
       for (int i = 0; i < renderers.length; i++) {
         if (renderers[i].isReadingFromPeriod(playingPeriodHolder)) {
           maybeThrowRendererStreamError(/* rendererIndex= */ i);
@@ -1492,8 +1469,9 @@ import java.util.Objects;
   }
 
   private void maybeTriggerOnRendererReadyChanged(int rendererIndex, boolean allowsPlayback) {
-    if (rendererReportedReady[rendererIndex] != allowsPlayback) {
-      rendererReportedReady[rendererIndex] = allowsPlayback;
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
+    if (renderersCoordinator.rendererReportedReady[rendererIndex] != allowsPlayback) {
+      renderersCoordinator.rendererReportedReady[rendererIndex] = allowsPlayback;
       applicationLooperHandler.post(
           () ->
               analyticsCollector.onRendererReadyChanged(
@@ -1540,6 +1518,7 @@ import java.util.Objects;
         playbackInfo.playbackState == Player.STATE_READY
             ? READY_MAXIMUM_INTERVAL_MS
             : BUFFERING_MAXIMUM_INTERVAL_MS;
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (RendererHolder rendererHolder : renderers) {
       wakeUpTimeIntervalMs =
           min(
@@ -1662,6 +1641,7 @@ import java.util.Objects;
         }
 
         if (scrubbingModeEnabled) {
+          final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
           for (RendererHolder renderer : renderers) {
             // TODO: b/451939261 - Remove video-only condition once image-playback scrubbing mode
             //  supports skipping intermittent seeks.
@@ -1814,6 +1794,7 @@ import java.util.Objects;
     }
     long rendererPositionUs = playingPeriod.toRendererTime(periodPositionUs);
     boolean renderersSupportSkipKeyFrameReset = true;
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (RendererHolder renderer : renderers) {
       if (renderer.isRendererEnabled()) {
         renderersSupportSkipKeyFrameReset &=
@@ -1840,6 +1821,7 @@ import java.util.Objects;
             ? MediaPeriodQueue.INITIAL_RENDERER_POSITION_OFFSET_US + periodPositionUs
             : playingMediaPeriod.toRendererTime(periodPositionUs);
     mediaClock.resetPosition(rendererPositionUs);
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (RendererHolder rendererHolder : renderers) {
       rendererHolder.resetPosition(
           playingMediaPeriod, rendererPositionUs, sampleStreamIsResetToKeyFrame);
@@ -1893,6 +1875,7 @@ import java.util.Objects;
   }
 
   private void applyScrubbingModeParameters() throws ExoPlaybackException {
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (RendererHolder renderer : renderers) {
       renderer.setScrubbingMode(scrubbingModeEnabled ? scrubbingModeParameters : null);
     }
@@ -1903,6 +1886,7 @@ import java.util.Objects;
     if (this.foregroundMode != foregroundMode) {
       this.foregroundMode = foregroundMode;
       if (!foregroundMode) {
+        final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
         for (RendererHolder rendererHolder : renderers) {
           rendererHolder.reset();
         }
@@ -1916,6 +1900,7 @@ import java.util.Objects;
   private void setVideoOutputInternal(
       @Nullable Object videoOutput, @Nullable ConditionVariable processedCondition)
       throws ExoPlaybackException {
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (RendererHolder renderer : renderers) {
       renderer.setVideoOutput(videoOutput);
     }
@@ -1981,6 +1966,7 @@ import java.util.Objects;
       Log.e(TAG, "Disable failed.", e);
     }
     if (resetRenderers) {
+      final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
       for (RendererHolder rendererHolder : renderers) {
         try {
           rendererHolder.reset();
@@ -2042,7 +2028,9 @@ import java.util.Objects;
             resetError ? null : playbackInfo.playbackError,
             /* isLoading= */ false,
             resetTrackInfo ? TrackGroupArray.EMPTY : playbackInfo.trackGroups,
-            resetTrackInfo ? emptyTrackSelectorResult : playbackInfo.trackSelectorResult,
+            resetTrackInfo
+                ? renderersCoordinator.emptyTrackSelectorResult
+                : playbackInfo.trackSelectorResult,
             resetTrackInfo ? ImmutableList.of() : playbackInfo.staticMetadata,
             mediaPeriodId,
             playbackInfo.playWhenReady,
@@ -2241,6 +2229,7 @@ import java.util.Objects;
   }
 
   private void disableRenderers() throws ExoPlaybackException {
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (int i = 0; i < renderers.length; i++) {
       disableRenderer(/* rendererIndex= */ i);
     }
@@ -2248,6 +2237,7 @@ import java.util.Objects;
   }
 
   private void disableRenderer(int rendererIndex) throws ExoPlaybackException {
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     int enabledRendererCountBeforeDisabling = renderers[rendererIndex].getEnabledRendererCount();
     renderers[rendererIndex].disable(mediaClock);
     maybeTriggerOnRendererReadyChanged(rendererIndex, /* allowsPlayback= */ false);
@@ -2255,9 +2245,10 @@ import java.util.Objects;
   }
 
   private void disableAndResetPrewarmingRenderers() {
-    if (!hasSecondaryRenderers || !areRenderersPrewarming()) {
+    if (!renderersCoordinator.hasSecondaryRenderers || !areRenderersPrewarming()) {
       return;
     }
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (RendererHolder renderer : renderers) {
       int enabledRendererCountBeforeDisabling = renderer.getEnabledRendererCount();
       renderer.disablePrewarming(mediaClock);
@@ -2272,6 +2263,7 @@ import java.util.Objects;
         || !queue.getPrewarmingPeriod().info.id.equals(mediaPeriodId)) {
       return false;
     }
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     return renderers[rendererIndex].isPrewarmingPeriod(queue.getPrewarmingPeriod());
   }
 
@@ -2294,6 +2286,7 @@ import java.util.Objects;
         // The reselection did not change any prepared periods.
         return;
       }
+      renderersCoordinator.reevaluate(periodHolder.getTrackGroups());
       newTrackSelectorResult =
           periodHolder.selectTracks(
               playbackSpeed, playbackInfo.timeline, playbackInfo.playWhenReady);
@@ -2319,6 +2312,7 @@ import java.util.Objects;
       boolean recreateStreams =
           (removeAfterResult & UPDATE_PERIOD_QUEUE_ALTERED_READING_PERIOD) != 0;
 
+      final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
       boolean[] streamResetFlags = new boolean[renderers.length];
       long periodPositionUs =
           playingPeriodHolder.applyTrackSelection(
@@ -2369,7 +2363,7 @@ import java.util.Objects;
       if (periodHolder.prepared) {
         long loadingPeriodPositionUs =
             max(periodHolder.info.startPositionUs, periodHolder.toPeriodTime(rendererPositionUs));
-        if (hasSecondaryRenderers
+        if (renderersCoordinator.hasSecondaryRenderers
             && areRenderersPrewarming()
             && queue.getPrewarmingPeriod() == periodHolder) {
           // If renderers are enabled early and track reselection is on the enabled-early period
@@ -2497,6 +2491,7 @@ import java.util.Objects;
             /* releaseMediaSourceList= */ false,
             /* resetError= */ true);
       }
+      final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
       for (RendererHolder rendererHolder : renderers) {
         rendererHolder.setTimeline(timeline);
       }
@@ -2631,6 +2626,7 @@ import java.util.Objects;
     if (!periodHolder.prepared) {
       return maxReadPositionUs;
     }
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (int i = 0; i < renderers.length; i++) {
       if (!renderers[i].isReadingFromPeriod(periodHolder)) {
         // Ignore disabled renderers and renderers with sample streams from previous periods.
@@ -2693,7 +2689,7 @@ import java.util.Objects;
   private void maybeUpdatePrewarmingPeriod() throws ExoPlaybackException {
     // TODO: Add limit as to not enable waiting renderer too early
     if (pendingPauseAtEndOfPeriod
-        || !hasSecondaryRenderers
+        || !renderersCoordinator.hasSecondaryRenderers
         || isPrewarmingDisabledUntilNextTransition
         || areRenderersPrewarming()) {
       return;
@@ -2722,6 +2718,7 @@ import java.util.Objects;
       return;
     }
     TrackSelectorResult trackSelectorResult = prewarmingPeriod.getTrackSelectorResult();
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (int i = 0; i < renderers.length; i++) {
       if (trackSelectorResult.isRendererEnabled(i)
           && renderers[i].hasSecondary()
@@ -2757,6 +2754,7 @@ import java.util.Objects;
       // We don't have a successor to advance the reading period to or we want to let them end
       // intentionally to pause at the end of the period.
       if (readingPeriodHolder.info.isFinal || pendingPauseAtEndOfPeriod) {
+        final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
         for (RendererHolder renderer : renderers) {
           if (!renderer.isReadingFromPeriod(readingPeriodHolder)) {
             continue;
@@ -2811,15 +2809,17 @@ import java.util.Objects;
         /* forceSetTargetOffsetOverride= */ false);
 
     if (readingPeriodHolder.prepared
-        && ((hasSecondaryRenderers && prewarmingMediaPeriodDiscontinuity != C.TIME_UNSET)
+        && ((renderersCoordinator.hasSecondaryRenderers
+                && prewarmingMediaPeriodDiscontinuity != C.TIME_UNSET)
             || readingPeriodHolder.mediaPeriod.readDiscontinuity() != C.TIME_UNSET)) {
       prewarmingMediaPeriodDiscontinuity = C.TIME_UNSET;
       // The new period starts with a discontinuity, so unless a pre-warming renderer is handling
       // the discontinuity, the renderers will play out all data, then
       // be disabled and re-enabled when they start playing the next period.
       boolean arePrewarmingRenderersHandlingDiscontinuity =
-          hasSecondaryRenderers && !isPrewarmingDisabledUntilNextTransition;
+          renderersCoordinator.hasSecondaryRenderers && !isPrewarmingDisabledUntilNextTransition;
       if (arePrewarmingRenderersHandlingDiscontinuity) {
+        final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
         for (int i = 0; i < renderers.length; i++) {
           if (!newTrackSelectorResult.isRendererEnabled(i)
               || renderers[i].getTrackType() == C.TRACK_TYPE_NONE) {
@@ -2850,6 +2850,7 @@ import java.util.Objects;
       }
     }
 
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (RendererHolder renderer : renderers) {
       renderer.maybeSetOldStreamToFinal(
           oldTrackSelectorResult,
@@ -2876,6 +2877,7 @@ import java.util.Objects;
     MediaPeriodHolder readingMediaPeriod = queue.getReadingPeriod();
     TrackSelectorResult newTrackSelectorResult = readingMediaPeriod.getTrackSelectorResult();
     boolean allUpdated = true;
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (int i = 0; i < renderers.length; i++) {
       int enabledRendererCountPreTransition = renderers[i].getEnabledRendererCount();
       int result =
@@ -2984,6 +2986,7 @@ import java.util.Objects;
   }
 
   private void maybeHandlePrewarmingTransition() throws ExoPlaybackException {
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (RendererHolder renderer : renderers) {
       renderer.maybeHandlePrewarmingTransition();
     }
@@ -3001,6 +3004,7 @@ import java.util.Objects;
       TrackSelectorResult trackSelectorResult = playingPeriodHolder.getTrackSelectorResult();
       boolean isAudioRendererEnabledAndOffloadPreferred = false;
       boolean isAudioOnly = true;
+      final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
       for (int i = 0; i < renderers.length; i++) {
         if (trackSelectorResult.isRendererEnabled(i)) {
           if (renderers[i].getTrackType() != C.TRACK_TYPE_AUDIO) {
@@ -3019,6 +3023,7 @@ import java.util.Objects;
 
   private void allowRenderersToRenderStartOfStreams() {
     TrackSelectorResult playingTracks = queue.getPlayingPeriod().getTrackSelectorResult();
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (int i = 0; i < renderers.length; i++) {
       if (!playingTracks.isRendererEnabled(i)) {
         continue;
@@ -3055,6 +3060,7 @@ import java.util.Objects;
     if (!readingPeriodHolder.prepared) {
       return false;
     }
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (int i = 0; i < renderers.length; i++) {
       if (!renderers[i].hasFinishedReadingFromPeriod(readingPeriodHolder)) {
         return false;
@@ -3064,6 +3070,7 @@ import java.util.Objects;
   }
 
   private void setAllNonPrewarmingRendererStreamsFinal(long streamEndPositionUs) {
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (RendererHolder renderer : renderers) {
       renderer.setAllNonPrewarmingRendererStreamsFinal(streamEndPositionUs);
     }
@@ -3071,7 +3078,7 @@ import java.util.Objects;
 
   private void handlePeriodPrepared(MediaPeriod mediaPeriod) throws ExoPlaybackException {
     if (queue.isLoading(mediaPeriod)) {
-      handleLoadingPeriodPrepared(checkNotNull(queue.getLoadingPeriod()));
+      handleLoadingPeriodPrepared(mediaPeriod, checkNotNull(queue.getLoadingPeriod()));
     } else {
       @Nullable MediaPeriodHolder preloadHolder = queue.getPreloadHolderByMediaPeriod(mediaPeriod);
       if (preloadHolder != null) {
@@ -3087,9 +3094,12 @@ import java.util.Objects;
     }
   }
 
-  private void handleLoadingPeriodPrepared(MediaPeriodHolder loadingPeriodHolder)
+  private void handleLoadingPeriodPrepared(
+      MediaPeriod mediaPeriod, MediaPeriodHolder loadingPeriodHolder)
       throws ExoPlaybackException {
     if (!loadingPeriodHolder.prepared) {
+      // Reevaluate the numbers of renderers needed onwards
+      renderersCoordinator.reevaluate(mediaPeriod.getTrackGroups());
       loadingPeriodHolder.handlePrepared(
           mediaClock.getPlaybackParameters().speed,
           playbackInfo.timeline,
@@ -3149,6 +3159,7 @@ import java.util.Objects;
       playbackInfo = playbackInfo.copyWithPlaybackParameters(playbackParameters);
     }
     updateTrackSelectionPlaybackSpeed(playbackParameters.speed);
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (RendererHolder rendererHolder : renderers) {
       rendererHolder.setPlaybackSpeed(
           currentPlaybackSpeed, /* targetPlaybackSpeed= */ playbackParameters.speed);
@@ -3251,7 +3262,7 @@ import java.util.Objects;
               : playingPeriodHolder.getTrackGroups();
       trackSelectorResult =
           playingPeriodHolder == null
-              ? emptyTrackSelectorResult
+              ? renderersCoordinator.emptyTrackSelectorResult
               : playingPeriodHolder.getTrackSelectorResult();
       staticMetadata = extractMetadataFromTrackSelectionArray(trackSelectorResult.selections);
       // Ensure the media period queue requested content position matches the new playback info.
@@ -3264,7 +3275,7 @@ import java.util.Objects;
     } else if (!mediaPeriodId.equals(playbackInfo.periodId)) {
       // Reset previously kept track info if unprepared and the period changes.
       trackGroupArray = TrackGroupArray.EMPTY;
-      trackSelectorResult = emptyTrackSelectorResult;
+      trackSelectorResult = renderersCoordinator.emptyTrackSelectorResult;
       staticMetadata = ImmutableList.of();
     }
     if (reportDiscontinuity) {
@@ -3300,6 +3311,7 @@ import java.util.Objects;
   }
 
   private void enableRenderers() throws ExoPlaybackException {
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     enableRenderers(
         /* rendererWasEnabledFlags= */ new boolean[renderers.length],
         queue.getReadingPeriod().getStartPositionRendererTime());
@@ -3311,6 +3323,7 @@ import java.util.Objects;
     TrackSelectorResult trackSelectorResult = readingMediaPeriod.getTrackSelectorResult();
     // Reset all disabled renderers before enabling any new ones. This makes sure resources released
     // by the disabled renderers will be available to renderers that are being enabled.
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (int i = 0; i < renderers.length; i++) {
       if (!trackSelectorResult.isRendererEnabled(i)) {
         renderers[i].reset();
@@ -3334,6 +3347,7 @@ import java.util.Objects;
       boolean wasRendererEnabled,
       long startPositionUs)
       throws ExoPlaybackException {
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     RendererHolder renderer = renderers[rendererIndex];
     if (renderer.isRendererEnabled()) {
       return;
@@ -3384,8 +3398,9 @@ import java.util.Objects;
   }
 
   private void releaseRenderers() {
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (int i = 0; i < renderers.length; i++) {
-      rendererCapabilities[i].clearListener();
+      renderersCoordinator.rendererCapabilities[i].clearListener();
       renderers[i].release();
     }
   }
@@ -3474,7 +3489,7 @@ import java.util.Objects;
 
   private void maybeThrowRendererStreamError(int rendererIndex)
       throws IOException, ExoPlaybackException {
-    RendererHolder renderer = renderers[rendererIndex];
+    RendererHolder renderer = renderersCoordinator.rendererHolders[rendererIndex];
     try {
       renderer.maybeThrowStreamError(checkNotNull(queue.getPlayingPeriod()));
     } catch (IOException | RuntimeException e) {
@@ -3513,9 +3528,10 @@ import java.util.Objects;
   }
 
   private boolean areRenderersPrewarming() {
-    if (!hasSecondaryRenderers) {
+    if (!renderersCoordinator.hasSecondaryRenderers) {
       return false;
     }
+    final RendererHolder[] renderers = renderersCoordinator.rendererHolders;
     for (RendererHolder renderer : renderers) {
       if (renderer.isPrewarming()) {
         return true;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/MediaPeriodHolder.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/MediaPeriodHolder.java
@@ -38,7 +38,7 @@ import androidx.media3.exoplayer.upstream.Allocator;
 import java.io.IOException;
 
 /** Holds a {@link MediaPeriod} with information required to play it as part of a timeline. */
-/* package */ final class MediaPeriodHolder {
+/* package */ final class MediaPeriodHolder implements RenderersCoordinator.OnRenderersReevaluated {
 
   private static final String TAG = "MediaPeriodHolder";
 
@@ -51,7 +51,7 @@ import java.io.IOException;
   /**
    * The sample streams for each renderer associated with this period. May contain null elements.
    */
-  public final @NullableType SampleStream[] sampleStreams;
+  public @NullableType SampleStream[] sampleStreams;
 
   /** The target buffer duration to preload. */
   public final long targetPreloadBufferDurationUs;
@@ -80,8 +80,8 @@ import java.io.IOException;
    */
   public boolean allRenderersInCorrectState;
 
-  private final boolean[] mayRetainStreamFlags;
-  private final RendererCapabilities[] rendererCapabilities;
+  private boolean[] mayRetainStreamFlags;
+  private final RenderersCoordinator renderersCoordinator;
   private final TrackSelector trackSelector;
   private final MediaSourceList mediaSourceList;
 
@@ -93,25 +93,22 @@ import java.io.IOException;
   /**
    * Creates a new holder with information required to play it as part of a timeline.
    *
-   * @param rendererCapabilities The renderer capabilities.
+   * @param renderersCoordinator A coordinator that allows dynamic allocation of renderers.
    * @param rendererPositionOffsetUs The renderer time of the start of the period, in microseconds.
    * @param trackSelector The track selector.
    * @param allocator The allocator.
    * @param mediaSourceList The playlist.
    * @param info Information used to identify this media period in its timeline period.
-   * @param emptyTrackSelectorResult A {@link TrackSelectorResult} with empty selections for each
-   *     renderer.
    */
   public MediaPeriodHolder(
-      RendererCapabilities[] rendererCapabilities,
+      RenderersCoordinator renderersCoordinator,
       long rendererPositionOffsetUs,
       TrackSelector trackSelector,
       Allocator allocator,
       MediaSourceList mediaSourceList,
       MediaPeriodInfo info,
-      TrackSelectorResult emptyTrackSelectorResult,
       long targetPreloadBufferDurationUs) {
-    this.rendererCapabilities = rendererCapabilities;
+    this.renderersCoordinator = renderersCoordinator;
     this.rendererPositionOffsetUs = rendererPositionOffsetUs;
     this.trackSelector = trackSelector;
     this.mediaSourceList = mediaSourceList;
@@ -119,7 +116,8 @@ import java.io.IOException;
     this.info = info;
     this.targetPreloadBufferDurationUs = targetPreloadBufferDurationUs;
     this.trackGroups = TrackGroupArray.EMPTY;
-    this.trackSelectorResult = emptyTrackSelectorResult;
+    this.trackSelectorResult = renderersCoordinator.emptyTrackSelectorResult;
+    final RendererCapabilities[] rendererCapabilities = renderersCoordinator.rendererCapabilities;
     sampleStreams = new SampleStream[rendererCapabilities.length];
     mayRetainStreamFlags = new boolean[rendererCapabilities.length];
     mediaPeriod =
@@ -130,6 +128,7 @@ import java.io.IOException;
             info.startPositionUs,
             info.endPositionUs,
             info.isPrecededByTransitionFromSameStream);
+    renderersCoordinator.addListener(this);
   }
 
   /**
@@ -267,6 +266,7 @@ import java.io.IOException;
    */
   public TrackSelectorResult selectTracks(
       float playbackSpeed, Timeline timeline, boolean playWhenReady) throws ExoPlaybackException {
+    final RendererCapabilities[] rendererCapabilities = renderersCoordinator.rendererCapabilities;
     TrackSelectorResult selectorResult =
         trackSelector.selectTracks(rendererCapabilities, getTrackGroups(), info.id, timeline);
     for (int i = 0; i < selectorResult.length; i++) {
@@ -303,7 +303,19 @@ import java.io.IOException;
         trackSelectorResult,
         positionUs,
         forceRecreateStreams,
-        new boolean[rendererCapabilities.length]);
+        new boolean[renderersCoordinator.rendererCapabilities.length]);
+  }
+
+  @Override
+  public void onRenderersReevaluated() {
+    int size = renderersCoordinator.renderers.length;
+    SampleStream[] newSampleStreams = new SampleStream[size];
+    boolean[] newMayRetainStreamFlags = new boolean[size];
+    System.arraycopy(sampleStreams, 0, newSampleStreams, 0, sampleStreams.length);
+    System.arraycopy(
+        mayRetainStreamFlags, 0, newMayRetainStreamFlags, 0, mayRetainStreamFlags.length);
+    sampleStreams = newSampleStreams;
+    mayRetainStreamFlags = newMayRetainStreamFlags;
   }
 
   /**
@@ -325,7 +337,9 @@ import java.io.IOException;
       boolean[] streamResetFlags) {
     for (int i = 0; i < newTrackSelectorResult.length; i++) {
       mayRetainStreamFlags[i] =
-          !forceRecreateStreams && newTrackSelectorResult.isEquivalent(trackSelectorResult, i);
+          !forceRecreateStreams
+              && i < trackSelectorResult.length
+              && newTrackSelectorResult.isEquivalent(trackSelectorResult, i);
     }
 
     // Undo the effect of previous call to associate no-sample renderers with empty tracks
@@ -350,10 +364,10 @@ import java.io.IOException;
       if (sampleStreams[i] != null) {
         checkState(newTrackSelectorResult.isRendererEnabled(i));
         // hasEnabledTracks should be true only when non-empty streams exists.
-        if (rendererCapabilities[i].getTrackType() != C.TRACK_TYPE_NONE) {
+        if (renderersCoordinator.rendererCapabilities[i].getTrackType() != C.TRACK_TYPE_NONE) {
           hasEnabledTracks = true;
         }
-      } else {
+      } else if (newTrackSelectorResult.selections.length > 0) {
         checkState(newTrackSelectorResult.selections[i] == null);
       }
     }
@@ -362,6 +376,7 @@ import java.io.IOException;
 
   /** Releases the media period. No other method should be called after the release. */
   public void release() {
+    renderersCoordinator.removeListener(this);
     disableTrackSelectionsInResult();
     releaseMediaPeriod(mediaSourceList, mediaPeriod);
   }
@@ -462,6 +477,7 @@ import java.io.IOException;
    */
   private void disassociateNoSampleRenderersWithEmptySampleStream(
       @NullableType SampleStream[] sampleStreams) {
+    final RendererCapabilities[] rendererCapabilities = renderersCoordinator.rendererCapabilities;
     for (int i = 0; i < rendererCapabilities.length; i++) {
       if (rendererCapabilities[i].getTrackType() == C.TRACK_TYPE_NONE) {
         sampleStreams[i] = null;
@@ -475,6 +491,7 @@ import java.io.IOException;
    */
   private void associateNoSampleRenderersWithEmptySampleStream(
       @NullableType SampleStream[] sampleStreams) {
+    final RendererCapabilities[] rendererCapabilities = renderersCoordinator.rendererCapabilities;
     for (int i = 0; i < rendererCapabilities.length; i++) {
       if (rendererCapabilities[i].getTrackType() == C.TRACK_TYPE_NONE
           && trackSelectorResult.isRendererEnabled(i)) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/RenderersCoordinator.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/RenderersCoordinator.java
@@ -1,0 +1,290 @@
+package androidx.media3.exoplayer;
+
+import static androidx.media3.common.util.Assertions.checkState;
+import static androidx.media3.common.util.Util.castNonNull;
+
+import android.os.Handler;
+import androidx.annotation.Nullable;
+import androidx.media3.common.C;
+import androidx.media3.common.Timeline;
+import androidx.media3.common.Tracks;
+import androidx.media3.common.util.Clock;
+import androidx.media3.common.util.NullableType;
+import androidx.media3.exoplayer.analytics.PlayerId;
+import androidx.media3.exoplayer.audio.AudioRendererEventListener;
+import androidx.media3.exoplayer.metadata.MetadataOutput;
+import androidx.media3.exoplayer.source.MediaSource.MediaPeriodId;
+import androidx.media3.exoplayer.source.TrackGroupArray;
+import androidx.media3.exoplayer.text.TextOutput;
+import androidx.media3.exoplayer.trackselection.ExoTrackSelection;
+import androidx.media3.exoplayer.trackselection.TrackSelector;
+import androidx.media3.exoplayer.trackselection.TrackSelectorResult;
+import androidx.media3.exoplayer.video.VideoRendererEventListener;
+import com.google.common.base.Supplier;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/* package */ class RenderersCoordinator {
+
+  @FunctionalInterface
+      /*package*/ interface WithLock {
+    void consume() throws ExoPlaybackException, IOException, RuntimeException;
+  }
+
+  /*package*/ interface OnRenderersReevaluated {
+    void onRenderersReevaluated();
+  }
+
+  private final PlayerId playerId;
+  private final Handler eventHandler;
+  private final TrackSelector trackSelector;
+  private final Clock clock;
+
+  private final Object lock = new Object();
+  /*package*/ RendererHolder[] rendererHolders;
+  /*package*/ RendererCapabilities[] rendererCapabilities;
+  /*package*/ boolean[] rendererReportedReady;
+  /*package*/  Renderer[] renderers;
+  /*package*/ @NullableType Renderer[] secondaryRenderers;
+  private final Supplier<RenderersFactory> renderersFactorySupplier;
+  private final VideoRendererEventListener videoRendererEventListener;
+  private final AudioRendererEventListener audioRendererEventListener;
+  private final TextOutput textRendererOutput;
+  private final MetadataOutput metadataRendererOutput;
+  boolean hasSecondaryRenderers;
+
+  private final List<OnRenderersReevaluated> listeners;
+
+  /**
+   * This empty track selector result can only be used for {@link PlaybackInfo#trackSelectorResult}
+   * when the player does not have any track selection made (such as when player is reset, or when
+   * player seeks to an unprepared period). It will not be used as result of any {@link
+   * TrackSelector#selectTracks(RendererCapabilities[], TrackGroupArray, MediaPeriodId, Timeline)}
+   * operation.
+   */
+  /* package */ TrackSelectorResult emptyTrackSelectorResult;
+
+  public RenderersCoordinator(
+      PlayerId playerId,
+      Handler eventHandler,
+      TrackSelector trackSelector,
+      Clock clock,
+      Supplier<RenderersFactory> renderersFactorySupplier,
+      VideoRendererEventListener videoRendererEventListener,
+      AudioRendererEventListener audioRendererEventListener,
+      TextOutput textRendererOutput,
+      MetadataOutput metadataRendererOutput) {
+    this.playerId = playerId;
+    this.eventHandler = eventHandler;
+    this.trackSelector = trackSelector;
+    this.clock = clock;
+
+    RenderersFactory renderersFactory = renderersFactorySupplier.get();
+
+    renderers =
+        renderersFactory
+            .createRenderers(
+                eventHandler,
+                videoRendererEventListener,
+                audioRendererEventListener,
+                textRendererOutput,
+                metadataRendererOutput);
+    checkState(renderers.length > 0);
+    secondaryRenderers = new Renderer[renderers.length];
+    for (int i = 0; i < secondaryRenderers.length; i++) {
+      // TODO(b/377671489): Fix DefaultAnalyticsCollector logic to still work with pre-warming.
+      secondaryRenderers[i] =
+          renderersFactory.createSecondaryRenderer(
+              renderers[i],
+              eventHandler,
+              videoRendererEventListener,
+              audioRendererEventListener,
+              textRendererOutput,
+              metadataRendererOutput);
+    }
+
+    rendererCapabilities = new RendererCapabilities[renderers.length];
+    rendererReportedReady = new boolean[renderers.length];
+    @Nullable
+    RendererCapabilities.Listener rendererCapabilitiesListener =
+        trackSelector.getRendererCapabilitiesListener();
+
+    boolean hasSecondaryRenderers = false;
+    this.rendererHolders = new RendererHolder[renderers.length];
+    for (int i = 0; i < renderers.length; i++) {
+      renderers[i].init(/* index= */ i, playerId, clock);
+      rendererCapabilities[i] = renderers[i].getCapabilities();
+      if (rendererCapabilitiesListener != null) {
+        rendererCapabilities[i].setListener(rendererCapabilitiesListener);
+      }
+      if (secondaryRenderers[i] != null) {
+        castNonNull(secondaryRenderers[i]).init(/* index= */ i, playerId, clock);
+        hasSecondaryRenderers = true;
+      }
+      this.rendererHolders[i] = new RendererHolder(
+          renderers[i], secondaryRenderers[i], /* index= */ i);
+    }
+    this.hasSecondaryRenderers = hasSecondaryRenderers;
+
+    this.renderersFactorySupplier = renderersFactorySupplier;
+    this.videoRendererEventListener = videoRendererEventListener;
+    this.audioRendererEventListener = audioRendererEventListener;
+    this.textRendererOutput = textRendererOutput;
+    this.metadataRendererOutput = metadataRendererOutput;
+    this.emptyTrackSelectorResult = newEmptyTrackSelectorResult();
+    this.listeners = new ArrayList<>();
+  }
+
+  public void addListener(OnRenderersReevaluated listener) {
+    this.listeners.add(listener);
+  }
+
+  public void removeListener(OnRenderersReevaluated listener) {
+    this.listeners.remove(listener);
+  }
+
+  public void reevaluate(TrackGroupArray trackGroups) {
+    // Obtain the new list of renderers
+    Renderer[] newRenderers = renderersFactorySupplier.get()
+        .reevaluateRenderers(
+            renderers,
+            trackGroups,
+            eventHandler,
+            videoRendererEventListener,
+            audioRendererEventListener,
+            textRendererOutput,
+            metadataRendererOutput
+        );
+    Renderer[] newSecondaryRenderers = new Renderer[newRenderers.length];
+    RendererHolder[] newRendererHolders = new RendererHolder[newRenderers.length];
+
+    // WARNING!! Previous renderers cannot be destroyed and must be kept in the same order.
+    // Otherwise the new allocation cannot be accepted.
+    int curlen = renderers.length;
+    if (curlen > newRenderers.length) return;
+    for (int i = 0; i < curlen; i++) {
+      if (renderers[i] != newRenderers[i]) return;
+    }
+
+    renderers = newRenderers;
+    rendererReportedReady = newRendererReportedReady();
+    rendererCapabilities = newRendererCapabilitiesList();
+
+    for (int i = 0; i < curlen; i++) {
+      newSecondaryRenderers[i] = secondaryRenderers[i];
+      newRendererHolders[i] = rendererHolders[i];
+    }
+
+    // Init new allocated renderers
+    for (int i = curlen; i < renderers.length; i++) {
+      renderers[i].init(/* index= */ i, playerId, clock);
+      rendererCapabilities[i] = renderers[i].getCapabilities();
+
+      @Nullable
+      RendererCapabilities.Listener listener = trackSelector.getRendererCapabilitiesListener();
+      if (listener != null) {
+        rendererCapabilities[i].setListener(listener);
+      }
+
+      initSecondaryRendererOnReevaluate(i);
+
+      newRendererHolders[i] = new RendererHolder(
+          renderers[i], newSecondaryRenderers[i], /* index= */ i);
+    }
+
+    secondaryRenderers = newSecondaryRenderers;
+    rendererHolders = newRendererHolders;
+
+    emptyTrackSelectorResult = newEmptyTrackSelectorResult();
+
+    // Update period holders
+    for (OnRenderersReevaluated listener : listeners) {
+      listener.onRenderersReevaluated();
+    }
+  }
+
+  public int getRendererCount() {
+    synchronized (lock) {
+      return renderers.length;
+    }
+  }
+
+  public @C.TrackType int getRendererType(int index) {
+    synchronized (lock) {
+      return renderers[index].getTrackType();
+    }
+  }
+
+  public Renderer getRenderer(int index) {
+    synchronized (lock) {
+      return renderers[index];
+    }
+  }
+
+  @Nullable
+  public Renderer getSecondaryRenderer(int index) {
+    synchronized (lock) {
+      return secondaryRenderers[index];
+    }
+  }
+
+  public TrackSelectorResult getEmptyTrackSelectorResult() {
+    synchronized (lock) {
+      return emptyTrackSelectorResult;
+    }
+  }
+
+  /*package*/ void withLock(WithLock action)
+      throws ExoPlaybackException, IOException, RuntimeException {
+    synchronized (lock) {
+      action.consume();
+    }
+  }
+
+  private RendererCapabilities[] newRendererCapabilitiesList() {
+    RendererCapabilities.Listener rendererCapabilitiesListener =
+        trackSelector.getRendererCapabilitiesListener();
+    RendererCapabilities[] rendererCapabilities = new RendererCapabilities[renderers.length];
+    for (int i = 0; i < renderers.length; i++) {
+      renderers[i].init(/* index= */ i, playerId, clock);
+      rendererCapabilities[i] = renderers[i].getCapabilities();
+      if (rendererCapabilitiesListener != null) {
+        rendererCapabilities[i].setListener(rendererCapabilitiesListener);
+      }
+    }
+    return rendererCapabilities;
+  }
+
+  private boolean[] newRendererReportedReady() {
+    boolean[] newRendererReportedReady = new boolean[renderers.length];
+    System.arraycopy(
+        rendererReportedReady, 0, newRendererReportedReady, 0, rendererReportedReady.length);
+    return newRendererReportedReady;
+  }
+
+  private TrackSelectorResult newEmptyTrackSelectorResult() {
+    return new TrackSelectorResult(
+        new RendererConfiguration[renderers.length],
+        new ExoTrackSelection[renderers.length],
+        Tracks.EMPTY,
+        /* info= */ null);
+  }
+
+  private void initSecondaryRendererOnReevaluate(int i) {
+    // TODO(b/377671489): Fix DefaultAnalyticsCollector logic to still work with pre-warming.
+    secondaryRenderers[i] =
+        renderersFactorySupplier.get().createSecondaryRenderer(
+            renderers[i],
+            eventHandler,
+            videoRendererEventListener,
+            audioRendererEventListener,
+            textRendererOutput,
+            metadataRendererOutput);
+
+    if (secondaryRenderers[i] != null) {
+      castNonNull(secondaryRenderers[i]).init(/* index= */ i + renderers.length, playerId, clock);
+      this.hasSecondaryRenderers = true;
+    }
+  }
+}

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/RenderersFactory.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/RenderersFactory.java
@@ -20,6 +20,7 @@ import androidx.annotation.Nullable;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.audio.AudioRendererEventListener;
 import androidx.media3.exoplayer.metadata.MetadataOutput;
+import androidx.media3.exoplayer.source.TrackGroupArray;
 import androidx.media3.exoplayer.text.TextOutput;
 import androidx.media3.exoplayer.video.VideoRendererEventListener;
 
@@ -67,5 +68,31 @@ public interface RenderersFactory {
       TextOutput textRendererOutput,
       MetadataOutput metadataRendererOutput) {
     return null;
+  }
+
+  /**
+   * Allows to reevaluate the number of {@link Renderer} instances to adapt to new track groups.
+   * <p>
+   * WARNING!! Previous renderers cannot be destroyed and must be kept in the same order.
+   * Otherwise the new allocation cannot be accepted.
+   *
+   * @param prevRenderers The previous available renderers.
+   * @param newTrackGroups The new track groups.
+   * @param eventHandler A handler to use when invoking event listeners and outputs.
+   * @param videoRendererEventListener An event listener for video renderers.
+   * @param audioRendererEventListener An event listener for audio renderers.
+   * @param textRendererOutput An output for text renderers.
+   * @param metadataRendererOutput An output for metadata renderers.
+   * @return The {@link Renderer instances}.
+   */
+  default Renderer[] reevaluateRenderers(
+      Renderer[] prevRenderers,
+      TrackGroupArray newTrackGroups,
+      Handler eventHandler,
+      VideoRendererEventListener videoRendererEventListener,
+      AudioRendererEventListener audioRendererEventListener,
+      TextOutput textRendererOutput,
+      MetadataOutput metadataRendererOutput) {
+    return prevRenderers;
   }
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/TrackSelectorResult.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/TrackSelectorResult.java
@@ -96,6 +96,9 @@ public final class TrackSelectorResult {
 
   /** Returns whether the renderer at the specified index is enabled. */
   public boolean isRendererEnabled(int index) {
+    if (index >= rendererConfigurations.length) {
+      return false;
+    }
     return rendererConfigurations[index] != null;
   }
 
@@ -131,6 +134,12 @@ public final class TrackSelectorResult {
    */
   public boolean isEquivalent(@Nullable TrackSelectorResult other, int index) {
     if (other == null) {
+      return false;
+    }
+    if (index >= rendererConfigurations.length || index >= other.rendererConfigurations.length) {
+      return false;
+    }
+    if (index >= selections.length || index >= other.selections.length) {
       return false;
     }
     return Objects.equals(rendererConfigurations[index], other.rendererConfigurations[index])


### PR DESCRIPTION
This PR tries to create an implementation for https://github.com/androidx/media/issues/2911, by allowing the reevaluate the number of renderers allocated at mid-stream through a new `RenderersFactory#reevaluateRenderers` method, that allow to provide new renderers based on the information from next tracks available in the stream.
The implementation only allows to increase the number of renderers, as old renderers could potentially be in use. A new shared `RenderersCoordinator` class has been added to centralize the use of all renderers-related instances, so they can be growth safely mid-stream.

For example, it can be used to increment the number of metadata renderers, if a new period during mid-string contains more metadata that need to be parsed, exceeding the 2 metadata renderers provided by the default implementation. Or other use cases where dynamic allocation of renderers is required by analyzing what is in the manifest, rather than assuming a fixed number of renderers required.

```kotlin
override fun reevaluateRenderers(
        prevRenderers: Array<out Renderer>,
        newTrackGroups: TrackGroupArray,
        eventHandler: Handler,
        videoRendererEventListener: VideoRendererEventListener,
        audioRendererEventListener: AudioRendererEventListener,
        textRendererOutput: TextOutput,
        metadataRendererOutput: MetadataOutput
    ): Array<Renderer> {
        val renderersList = prevRenderers.toMutableList()
       
        val newMetadataRenderers = newTrackGroups.trackTypes.count { it == C.TRACK_TYPE_METADATA }
        val prevMetadataRenderers = renderersList.count { it.trackType == C.TRACK_TYPE_METADATA }
        if (newMetadataRenderers > prevMetadataRenderers) {
            for (i in prevMetadataRenderers until newMetadataRenderers) {
                renderersList.add(MetadataRenderer(metadataRendererOutput, eventHandler.looper))
            }
        }

        return renderersList.toTypedArray()
    }
```