### PR TITLE
Add custom format comparator support to AdaptiveTrackSelection

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -55,6 +55,10 @@
 *   Transformer:
     *   Fix an issue where `ExportResult.fileSizeBytes` may be over-reported.
 *   Track selection:
+    *   Expose `BaseTrackSelection.DEFAULT_FORMAT_COMPARATOR` and add
+        `AdaptiveTrackSelection.Factory.setTrackFormatComparator` to allow
+        custom format ordering and ABR selection priority beyond bitrate-only
+        ordering.
 *   Extractors:
     *   MP4: Add support for extracting ITU-T T.35 (`it35`) timed metadata
         tracks.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelection.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelection.java
@@ -245,6 +245,11 @@ public class AdaptiveTrackSelection extends BaseTrackSelection {
       return this;
     }
 
+    /** Returns the comparator used to order formats in adaptive track selections. */
+    protected final Comparator<Format> getTrackFormatComparator() {
+      return trackFormatComparator;
+    }
+
     @Override
     public final @NullableType ExoTrackSelection[] createTrackSelections(
         @NullableType Definition[] definitions,
@@ -306,7 +311,7 @@ public class AdaptiveTrackSelection extends BaseTrackSelection {
           bufferedFractionToLiveEdgeForQualityIncrease,
           adaptationCheckpoints,
           clock,
-          trackFormatComparator);
+          getTrackFormatComparator());
     }
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelection.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelection.java
@@ -234,8 +234,8 @@ public class AdaptiveTrackSelection extends BaseTrackSelection {
     }
 
     /**
-     * Sets the comparator used to order formats in adaptive track selections.
-     * The comparator order controls which formats are considered first during adaptation.
+     * Sets the comparator used to order formats in adaptive track selections. The comparator order
+     * controls which formats are considered first during adaptation.
      *
      * @param trackFormatComparator Comparator used to order selected formats.
      * @return This factory, for convenience.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelection.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelection.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -237,17 +238,16 @@ public class AdaptiveTrackSelection extends BaseTrackSelection {
      * Sets the comparator used to order formats in adaptive track selections. The comparator order
      * controls which formats are considered first during adaptation.
      *
+     * <p>The default is {@link BaseTrackSelection#DEFAULT_FORMAT_COMPARATOR}, which decides the
+     * priority based on the bitrate.
+     *
      * @param trackFormatComparator Comparator used to order selected formats.
      * @return This factory, for convenience.
      */
+    @CanIgnoreReturnValue
     public Factory setTrackFormatComparator(Comparator<Format> trackFormatComparator) {
       this.trackFormatComparator = checkNotNull(trackFormatComparator);
       return this;
-    }
-
-    /** Returns the comparator used to order formats in adaptive track selections. */
-    protected final Comparator<Format> getTrackFormatComparator() {
-      return trackFormatComparator;
     }
 
     @Override
@@ -311,7 +311,7 @@ public class AdaptiveTrackSelection extends BaseTrackSelection {
           bufferedFractionToLiveEdgeForQualityIncrease,
           adaptationCheckpoints,
           clock,
-          getTrackFormatComparator());
+          trackFormatComparator);
     }
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/BaseTrackSelection.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/BaseTrackSelection.java
@@ -29,11 +29,15 @@ import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
 import androidx.media3.exoplayer.source.chunk.MediaChunk;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 /** An abstract base class suitable for most {@link ExoTrackSelection} implementations. */
 @UnstableApi
 public abstract class BaseTrackSelection implements ExoTrackSelection {
+
+  static final Comparator<Format> DEFAULT_FORMAT_COMPARATOR =
+      (firstFormat, secondFormat) -> Integer.compare(secondFormat.bitrate, firstFormat.bitrate);
 
   /** The selected {@link TrackGroup}. */
   protected final TrackGroup group;
@@ -41,17 +45,20 @@ public abstract class BaseTrackSelection implements ExoTrackSelection {
   /** The number of selected tracks within the {@link TrackGroup}. Always greater than zero. */
   protected final int length;
 
-  /** The indices of the selected tracks in {@link #group}, in order of decreasing bandwidth. */
+  /** The indices of the selected tracks in {@link #group}, in selection order. */
   protected final int[] tracks;
 
   /** The type of the selection. */
   private final @Type int type;
 
-  /** The {@link Format}s of the selected tracks, in order of decreasing bandwidth. */
+  /** The {@link Format}s of the selected tracks, in selection order. */
   private final Format[] formats;
 
-  /** Selected track exclusion timestamps, in order of decreasing bandwidth. */
+  /** Selected track exclusion timestamps, in selection order. */
   private final long[] excludeUntilTimes;
+
+  /** Whether selected formats are ordered with the default bitrate comparator. */
+  private final boolean isUsingDefaultFormatComparator;
 
   // Lazily initialized hashcode.
   private int hashCode;
@@ -75,23 +82,42 @@ public abstract class BaseTrackSelection implements ExoTrackSelection {
    * @param type The type that will be returned from {@link TrackSelection#getType()}.
    */
   public BaseTrackSelection(TrackGroup group, int[] tracks, @Type int type) {
+    this(group, tracks, type, DEFAULT_FORMAT_COMPARATOR);
+  }
+
+  /**
+   * @param group The {@link TrackGroup}. Must not be null.
+   * @param tracks The indices of the selected tracks within the {@link TrackGroup}. Must not be
+   *     null or empty. May be in any order.
+   * @param type The type that will be returned from {@link TrackSelection#getType()}.
+   * @param formatComparator Comparator that determines the order of selected {@link Format}s.
+   */
+  protected BaseTrackSelection(
+      TrackGroup group, int[] tracks, @Type int type, Comparator<Format> formatComparator) {
     checkState(tracks.length > 0);
     this.type = type;
     this.group = checkNotNull(group);
     this.length = tracks.length;
-    // Set the formats, sorted in order of decreasing bandwidth.
+    // Set the formats in selection order.
     formats = new Format[length];
     for (int i = 0; i < tracks.length; i++) {
       formats[i] = group.getFormat(tracks[i]);
     }
-    // Sort in order of decreasing bandwidth.
-    Arrays.sort(formats, (a, b) -> b.bitrate - a.bitrate);
+    Comparator<Format> safeFormatComparator = checkNotNull(formatComparator);
+    boolean isUsingDefaultFormatComparator = safeFormatComparator == DEFAULT_FORMAT_COMPARATOR;
+    try {
+      Arrays.sort(formats, safeFormatComparator);
+    } catch (Throwable throwable) {
+      Arrays.sort(formats, DEFAULT_FORMAT_COMPARATOR);
+      isUsingDefaultFormatComparator = true;
+    }
     // Set the format indices in the same order.
     this.tracks = new int[length];
     for (int i = 0; i < length; i++) {
       this.tracks[i] = group.indexOf(formats[i]);
     }
     excludeUntilTimes = new long[length];
+    this.isUsingDefaultFormatComparator = isUsingDefaultFormatComparator;
     playWhenReady = false;
   }
 
@@ -211,6 +237,11 @@ public abstract class BaseTrackSelection implements ExoTrackSelection {
   /** Returns whether the playback using this track selection will proceed when ready. */
   protected final boolean getPlayWhenReady() {
     return playWhenReady;
+  }
+
+  /** Returns whether formats are ordered with the default bitrate comparator. */
+  protected final boolean isUsingDefaultFormatComparator() {
+    return isUsingDefaultFormatComparator;
   }
 
   // Object overrides.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/BaseTrackSelection.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/BaseTrackSelection.java
@@ -57,9 +57,6 @@ public abstract class BaseTrackSelection implements ExoTrackSelection {
   /** Selected track exclusion timestamps, in selection order. */
   private final long[] excludeUntilTimes;
 
-  /** Whether selected formats are ordered with the default bitrate comparator. */
-  private final boolean isUsingDefaultFormatComparator;
-
   // Lazily initialized hashcode.
   private int hashCode;
 
@@ -103,21 +100,13 @@ public abstract class BaseTrackSelection implements ExoTrackSelection {
     for (int i = 0; i < tracks.length; i++) {
       formats[i] = group.getFormat(tracks[i]);
     }
-    Comparator<Format> safeFormatComparator = checkNotNull(formatComparator);
-    boolean isUsingDefaultFormatComparator = safeFormatComparator == DEFAULT_FORMAT_COMPARATOR;
-    try {
-      Arrays.sort(formats, safeFormatComparator);
-    } catch (Throwable throwable) {
-      Arrays.sort(formats, DEFAULT_FORMAT_COMPARATOR);
-      isUsingDefaultFormatComparator = true;
-    }
+    Arrays.sort(formats, checkNotNull(formatComparator));
     // Set the format indices in the same order.
     this.tracks = new int[length];
     for (int i = 0; i < length; i++) {
       this.tracks[i] = group.indexOf(formats[i]);
     }
     excludeUntilTimes = new long[length];
-    this.isUsingDefaultFormatComparator = isUsingDefaultFormatComparator;
     playWhenReady = false;
   }
 
@@ -237,11 +226,6 @@ public abstract class BaseTrackSelection implements ExoTrackSelection {
   /** Returns whether the playback using this track selection will proceed when ready. */
   protected final boolean getPlayWhenReady() {
     return playWhenReady;
-  }
-
-  /** Returns whether formats are ordered with the default bitrate comparator. */
-  protected final boolean isUsingDefaultFormatComparator() {
-    return isUsingDefaultFormatComparator;
   }
 
   // Object overrides.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/BaseTrackSelection.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/BaseTrackSelection.java
@@ -36,7 +36,8 @@ import java.util.List;
 @UnstableApi
 public abstract class BaseTrackSelection implements ExoTrackSelection {
 
-  static final Comparator<Format> DEFAULT_FORMAT_COMPARATOR =
+  /** The default {@link Format} comparator, which sorts formats by bitrate in descending order. */
+  public static final Comparator<Format> DEFAULT_FORMAT_COMPARATOR =
       (firstFormat, secondFormat) -> Integer.compare(secondFormat.bitrate, firstFormat.bitrate);
 
   /** The selected {@link TrackGroup}. */
@@ -87,7 +88,8 @@ public abstract class BaseTrackSelection implements ExoTrackSelection {
    * @param tracks The indices of the selected tracks within the {@link TrackGroup}. Must not be
    *     null or empty. May be in any order.
    * @param type The type that will be returned from {@link TrackSelection#getType()}.
-   * @param formatComparator Comparator that determines the order of selected {@link Format}s.
+   * @param formatComparator Comparator that determines the order of selected {@linkplain Format
+   *     formats}.
    */
   protected BaseTrackSelection(
       TrackGroup group, int[] tracks, @Type int type, Comparator<Format> formatComparator) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/TrackSelection.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/TrackSelection.java
@@ -31,7 +31,8 @@ import java.lang.annotation.Target;
  * A track selection consisting of a static subset of selected tracks belonging to a {@link
  * TrackGroup}.
  *
- * <p>Tracks belonging to the subset are exposed in decreasing bandwidth order.
+ * <p>Tracks belonging to the subset are exposed in selection order, which by default is decreasing
+ * bandwidth order.
  */
 @UnstableApi
 public interface TrackSelection {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/TrackSelection.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/TrackSelection.java
@@ -31,8 +31,8 @@ import java.lang.annotation.Target;
  * A track selection consisting of a static subset of selected tracks belonging to a {@link
  * TrackGroup}.
  *
- * <p>Tracks belonging to the subset are exposed in selection order, which by default is decreasing
- * bandwidth order.
+ * <p>Tracks belonging to the subset are exposed in selection order with the highest priority track
+ * first, for example in decreasing bandwidth order.
  */
 @UnstableApi
 public interface TrackSelection {

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelectionTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelectionTest.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.exoplayer.trackselection;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -588,7 +589,7 @@ public final class AdaptiveTrackSelectionTest {
         /* playbackPositionUs= */ 0,
         /* bufferedDurationUs= */ 25_000_000,
         /* availableDurationUs= */ C.TIME_UNSET,
-        /* queue= */ Collections.emptyList(),
+        /* queue= */ ImmutableList.of(),
         createMediaChunkIterators(trackGroup, TEST_CHUNK_DURATION_US));
 
     // With sufficient buffer (bufferedDurationUs >= maxDurationForQualityDecreaseUs), the
@@ -1029,6 +1030,7 @@ public final class AdaptiveTrackSelectionTest {
 
   private static int getFormatOrderIndex(List<Format> orderedFormats, Format format) {
     int index = orderedFormats.indexOf(format);
-    return index == C.INDEX_UNSET ? Integer.MAX_VALUE : index;
+    checkState(index != C.INDEX_UNSET);
+    return index;
   }
 }

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelectionTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelectionTest.java
@@ -37,6 +37,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
@@ -215,6 +216,104 @@ public final class AdaptiveTrackSelectionTest {
         createMediaChunkIterators(trackGroup, /* chunkDurationUs= */ 2_000_000));
 
     assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format3);
+  }
+
+  @Test
+  public void initial_updateSelectedTrack_usesFactoryProvidedTrackFormatComparatorOrder() {
+    Format format1 = videoFormat(/* bitrate= */ 500, /* width= */ 320, /* height= */ 240);
+    Format format2 = videoFormat(/* bitrate= */ 1000, /* width= */ 640, /* height= */ 480);
+    Format format3 = videoFormat(/* bitrate= */ 2000, /* width= */ 960, /* height= */ 720);
+    TrackGroup trackGroup = new TrackGroup(format1, format2, format3);
+    AdaptiveTrackSelection.Factory factory =
+        new AdaptiveTrackSelection.Factory(
+                /* minDurationForQualityIncreaseMs= */ 10_000,
+                /* maxDurationForQualityDecreaseMs= */ 25_000,
+                /* minDurationToRetainAfterDiscardMs= */ 25_000,
+                /* bandwidthFraction= */ 1f)
+            .setTrackFormatComparator(
+                formatComparatorInOrder(ImmutableList.of(format2, format3, format1)));
+
+    when(mockBandwidthMeter.getBitrateEstimate()).thenReturn(2000L);
+    AdaptiveTrackSelection adaptiveTrackSelection =
+        factory.createAdaptiveTrackSelection(
+            trackGroup,
+            /* tracks= */ new int[] {0, 1, 2},
+            /* type= */ TrackSelection.TYPE_UNSET,
+            mockBandwidthMeter,
+            /* adaptationCheckpoints= */ ImmutableList.of());
+    adaptiveTrackSelection = prepareTrackSelection(adaptiveTrackSelection);
+
+    assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format2);
+    assertThat(adaptiveTrackSelection.getSelectionReason()).isEqualTo(C.SELECTION_REASON_INITIAL);
+  }
+
+  @Test
+  public void initial_updateSelectedTrack_withNoSelectableFormat_fallsBackToLowestBitrate() {
+    Format format1 = videoFormat(/* bitrate= */ 500, /* width= */ 320, /* height= */ 240);
+    Format format2 = videoFormat(/* bitrate= */ 1000, /* width= */ 640, /* height= */ 480);
+    Format format3 = videoFormat(/* bitrate= */ 2000, /* width= */ 960, /* height= */ 720);
+    TrackGroup trackGroup = new TrackGroup(format1, format2, format3);
+
+    when(mockBandwidthMeter.getBitrateEstimate()).thenReturn(499L);
+    AdaptiveTrackSelection adaptiveTrackSelection =
+        prepareAdaptiveTrackSelectionWithFormatComparator(
+            trackGroup, formatComparatorInOrder(ImmutableList.of(format2, format1, format3)));
+
+    assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format1);
+    assertThat(adaptiveTrackSelection.getSelectionReason()).isEqualTo(C.SELECTION_REASON_INITIAL);
+  }
+
+  @Test
+  public void initial_updateSelectedTrack_withInvalidComparator_fallsBackToDefaultOrdering() {
+    Format format1 = videoFormat(/* bitrate= */ 500, /* width= */ 320, /* height= */ 240);
+    Format format2 = videoFormat(/* bitrate= */ 1000, /* width= */ 640, /* height= */ 480);
+    Format format3 = videoFormat(/* bitrate= */ 2000, /* width= */ 960, /* height= */ 720);
+    TrackGroup trackGroup = new TrackGroup(format1, format2, format3);
+    Comparator<Format> throwingComparator =
+        (firstFormat, secondFormat) -> {
+          throw new RuntimeException("Comparator failure");
+        };
+
+    when(mockBandwidthMeter.getBitrateEstimate()).thenReturn(1000L);
+    AdaptiveTrackSelection adaptiveTrackSelection =
+        prepareAdaptiveTrackSelectionWithFormatComparator(trackGroup, throwingComparator);
+
+    assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format2);
+    assertThat(adaptiveTrackSelection.getSelectionReason()).isEqualTo(C.SELECTION_REASON_INITIAL);
+  }
+
+  @Test
+  public void
+      updateSelectedTrack_withInvalidComparator_preservesDefaultDownSwitchDeferralWhenBufferedEnough() {
+    Format format1 = videoFormat(/* bitrate= */ 500, /* width= */ 320, /* height= */ 240);
+    Format format2 = videoFormat(/* bitrate= */ 1000, /* width= */ 640, /* height= */ 480);
+    Format format3 = videoFormat(/* bitrate= */ 2000, /* width= */ 960, /* height= */ 720);
+    TrackGroup trackGroup = new TrackGroup(format1, format2, format3);
+    Comparator<Format> throwingComparator =
+        (firstFormat, secondFormat) -> {
+          throw new RuntimeException("Comparator failure");
+        };
+
+    // The second measurement onward returns 500L, which prompts the track selection to switch down
+    // if necessary.
+    when(mockBandwidthMeter.getBitrateEstimate()).thenReturn(1000L, 500L);
+    AdaptiveTrackSelection adaptiveTrackSelection =
+        prepareAdaptiveTrackSelectionWithFormatComparatorAndDurations(
+            trackGroup,
+            AdaptiveTrackSelection.DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS,
+            /* maxDurationForQualityDecreaseMs= */ 25_000,
+            throwingComparator);
+
+    adaptiveTrackSelection.updateSelectedTrack(
+        /* playbackPositionUs= */ 0,
+        /* bufferedDurationUs= */ 25_000_000,
+        /* availableDurationUs= */ C.TIME_UNSET,
+        /* queue= */ Collections.emptyList(),
+        createMediaChunkIterators(trackGroup, TEST_CHUNK_DURATION_US));
+
+    // Invalid comparators fall back to the default ordering and preserve the default behavior.
+    assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format2);
+    assertThat(adaptiveTrackSelection.getSelectionReason()).isEqualTo(C.SELECTION_REASON_INITIAL);
   }
 
   @Test
@@ -487,6 +586,67 @@ public final class AdaptiveTrackSelectionTest {
         createMediaChunkIterators(trackGroup, TEST_CHUNK_DURATION_US));
 
     assertThat(adaptiveTrackSelection.getSelectedFormat()).isAnyOf(format1, format2);
+  }
+
+  @Test
+  public void updateSelectedTrack_withCustomFormatOrder_usesCustomOrderForSwitchDirection() {
+    Format format1 = videoFormat(/* bitrate= */ 500, /* width= */ 320, /* height= */ 240);
+    Format format2 = videoFormat(/* bitrate= */ 1000, /* width= */ 640, /* height= */ 480);
+    Format format3 = videoFormat(/* bitrate= */ 2000, /* width= */ 960, /* height= */ 720);
+    TrackGroup trackGroup = new TrackGroup(format1, format2, format3);
+    Comparator<Format> formatComparator =
+        formatComparatorInOrder(ImmutableList.of(format1, format2, format3));
+    when(mockBandwidthMeter.getBitrateEstimate()).thenReturn(2000L);
+    AdaptiveTrackSelection adaptiveTrackSelection =
+        prepareAdaptiveTrackSelectionWithFormatComparatorAndDurations(
+            trackGroup,
+            /* minDurationForQualityIncreaseMs= */ 10_000,
+            /* maxDurationForQualityDecreaseMs= */ 25_000,
+            formatComparator);
+
+    FakeMediaChunk chunk =
+        new FakeMediaChunk(
+            format2, /* startTimeUs= */ 0, /* endTimeUs= */ 2_000_000, C.SELECTION_REASON_INITIAL);
+    adaptiveTrackSelection.updateSelectedTrack(
+        /* playbackPositionUs= */ 0,
+        /* bufferedDurationUs= */ 4_000_000,
+        /* availableDurationUs= */ C.TIME_UNSET,
+        /* queue= */ ImmutableList.of(chunk),
+        createMediaChunkIterators(trackGroup, TEST_CHUNK_DURATION_US));
+
+    // format1 is higher priority than format2 according to the custom order, so switching from
+    // format2 to format1 is treated as a switch-up and deferred when not buffered enough.
+    assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format2);
+    assertThat(adaptiveTrackSelection.getSelectionReason()).isEqualTo(C.SELECTION_REASON_INITIAL);
+  }
+
+  @Test
+  public void
+      updateSelectedTrack_withCustomFormatOrder_switchesDownIfCurrentTrackExceedsBandwidth() {
+    Format format1 = videoFormat(/* bitrate= */ 500, /* width= */ 320, /* height= */ 240);
+    Format format2 = videoFormat(/* bitrate= */ 1000, /* width= */ 640, /* height= */ 480);
+    Format format3 = videoFormat(/* bitrate= */ 2000, /* width= */ 960, /* height= */ 720);
+    TrackGroup trackGroup = new TrackGroup(format1, format2, format3);
+    Comparator<Format> formatComparator =
+        formatComparatorInOrder(ImmutableList.of(format2, format1, format3));
+
+    when(mockBandwidthMeter.getBitrateEstimate()).thenReturn(1000L, 500L);
+    AdaptiveTrackSelection adaptiveTrackSelection =
+        prepareAdaptiveTrackSelectionWithFormatComparatorAndDurations(
+            trackGroup,
+            AdaptiveTrackSelection.DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS,
+            /* maxDurationForQualityDecreaseMs= */ 25_000,
+            formatComparator);
+
+    adaptiveTrackSelection.updateSelectedTrack(
+        /* playbackPositionUs= */ 0,
+        /* bufferedDurationUs= */ 25_000_000,
+        /* availableDurationUs= */ C.TIME_UNSET,
+        /* queue= */ Collections.emptyList(),
+        createMediaChunkIterators(trackGroup, TEST_CHUNK_DURATION_US));
+
+    assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format1);
+    assertThat(adaptiveTrackSelection.getSelectionReason()).isEqualTo(C.SELECTION_REASON_ADAPTIVE);
   }
 
   @Test
@@ -826,6 +986,38 @@ public final class AdaptiveTrackSelectionTest {
             fakeClock));
   }
 
+  private AdaptiveTrackSelection prepareAdaptiveTrackSelectionWithFormatComparator(
+      TrackGroup trackGroup, Comparator<Format> trackFormatComparator) {
+    return prepareAdaptiveTrackSelectionWithFormatComparatorAndDurations(
+        trackGroup,
+        AdaptiveTrackSelection.DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS,
+        AdaptiveTrackSelection.DEFAULT_MAX_DURATION_FOR_QUALITY_DECREASE_MS,
+        trackFormatComparator);
+  }
+
+  private AdaptiveTrackSelection prepareAdaptiveTrackSelectionWithFormatComparatorAndDurations(
+      TrackGroup trackGroup,
+      long minDurationForQualityIncreaseMs,
+      long maxDurationForQualityDecreaseMs,
+      Comparator<Format> trackFormatComparator) {
+    return prepareTrackSelection(
+        new AdaptiveTrackSelection(
+            trackGroup,
+            selectedAllTracksInGroup(trackGroup),
+            TrackSelection.TYPE_UNSET,
+            mockBandwidthMeter,
+            minDurationForQualityIncreaseMs,
+            maxDurationForQualityDecreaseMs,
+            AdaptiveTrackSelection.DEFAULT_MIN_DURATION_TO_RETAIN_AFTER_DISCARD_MS,
+            AdaptiveTrackSelection.DEFAULT_MAX_WIDTH_TO_DISCARD,
+            AdaptiveTrackSelection.DEFAULT_MAX_HEIGHT_TO_DISCARD,
+            /* bandwidthFraction= */ 1.0f,
+            AdaptiveTrackSelection.DEFAULT_BUFFERED_FRACTION_TO_LIVE_EDGE_FOR_QUALITY_INCREASE,
+            /* adaptationCheckpoints= */ ImmutableList.of(),
+            fakeClock,
+            trackFormatComparator));
+  }
+
   private AdaptiveTrackSelection prepareTrackSelection(
       AdaptiveTrackSelection adaptiveTrackSelection) {
     adaptiveTrackSelection.enable();
@@ -878,5 +1070,17 @@ public final class AdaptiveTrackSelectionTest {
         .setWidth(width)
         .setHeight(height)
         .build();
+  }
+
+  private static Comparator<Format> formatComparatorInOrder(List<Format> orderedFormats) {
+    return (firstFormat, secondFormat) ->
+        Integer.compare(
+            getFormatOrderIndex(orderedFormats, firstFormat),
+            getFormatOrderIndex(orderedFormats, secondFormat));
+  }
+
+  private static int getFormatOrderIndex(List<Format> orderedFormats, Format format) {
+    int index = orderedFormats.indexOf(format);
+    return index == C.INDEX_UNSET ? Integer.MAX_VALUE : index;
   }
 }

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelectionTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelectionTest.java
@@ -568,8 +568,7 @@ public final class AdaptiveTrackSelectionTest {
   }
 
   @Test
-  public void
-      updateSelectedTrack_withCustomFormatOrder_defersSwitchDownWhenBufferedEnough() {
+  public void updateSelectedTrack_withCustomFormatOrder_defersSwitchDownWhenBufferedEnough() {
     Format format1 = videoFormat(/* bitrate= */ 500, /* width= */ 320, /* height= */ 240);
     Format format2 = videoFormat(/* bitrate= */ 1000, /* width= */ 640, /* height= */ 480);
     Format format3 = videoFormat(/* bitrate= */ 2000, /* width= */ 960, /* height= */ 720);

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelectionTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/trackselection/AdaptiveTrackSelectionTest.java
@@ -248,7 +248,7 @@ public final class AdaptiveTrackSelectionTest {
   }
 
   @Test
-  public void initial_updateSelectedTrack_withNoSelectableFormat_fallsBackToLowestBitrate() {
+  public void initial_updateSelectedTrack_withNoSelectableFormat_fallsBackToLowestPriorityFormat() {
     Format format1 = videoFormat(/* bitrate= */ 500, /* width= */ 320, /* height= */ 240);
     Format format2 = videoFormat(/* bitrate= */ 1000, /* width= */ 640, /* height= */ 480);
     Format format3 = videoFormat(/* bitrate= */ 2000, /* width= */ 960, /* height= */ 720);
@@ -259,60 +259,7 @@ public final class AdaptiveTrackSelectionTest {
         prepareAdaptiveTrackSelectionWithFormatComparator(
             trackGroup, formatComparatorInOrder(ImmutableList.of(format2, format1, format3)));
 
-    assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format1);
-    assertThat(adaptiveTrackSelection.getSelectionReason()).isEqualTo(C.SELECTION_REASON_INITIAL);
-  }
-
-  @Test
-  public void initial_updateSelectedTrack_withInvalidComparator_fallsBackToDefaultOrdering() {
-    Format format1 = videoFormat(/* bitrate= */ 500, /* width= */ 320, /* height= */ 240);
-    Format format2 = videoFormat(/* bitrate= */ 1000, /* width= */ 640, /* height= */ 480);
-    Format format3 = videoFormat(/* bitrate= */ 2000, /* width= */ 960, /* height= */ 720);
-    TrackGroup trackGroup = new TrackGroup(format1, format2, format3);
-    Comparator<Format> throwingComparator =
-        (firstFormat, secondFormat) -> {
-          throw new RuntimeException("Comparator failure");
-        };
-
-    when(mockBandwidthMeter.getBitrateEstimate()).thenReturn(1000L);
-    AdaptiveTrackSelection adaptiveTrackSelection =
-        prepareAdaptiveTrackSelectionWithFormatComparator(trackGroup, throwingComparator);
-
-    assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format2);
-    assertThat(adaptiveTrackSelection.getSelectionReason()).isEqualTo(C.SELECTION_REASON_INITIAL);
-  }
-
-  @Test
-  public void
-      updateSelectedTrack_withInvalidComparator_preservesDefaultDownSwitchDeferralWhenBufferedEnough() {
-    Format format1 = videoFormat(/* bitrate= */ 500, /* width= */ 320, /* height= */ 240);
-    Format format2 = videoFormat(/* bitrate= */ 1000, /* width= */ 640, /* height= */ 480);
-    Format format3 = videoFormat(/* bitrate= */ 2000, /* width= */ 960, /* height= */ 720);
-    TrackGroup trackGroup = new TrackGroup(format1, format2, format3);
-    Comparator<Format> throwingComparator =
-        (firstFormat, secondFormat) -> {
-          throw new RuntimeException("Comparator failure");
-        };
-
-    // The second measurement onward returns 500L, which prompts the track selection to switch down
-    // if necessary.
-    when(mockBandwidthMeter.getBitrateEstimate()).thenReturn(1000L, 500L);
-    AdaptiveTrackSelection adaptiveTrackSelection =
-        prepareAdaptiveTrackSelectionWithFormatComparatorAndDurations(
-            trackGroup,
-            AdaptiveTrackSelection.DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS,
-            /* maxDurationForQualityDecreaseMs= */ 25_000,
-            throwingComparator);
-
-    adaptiveTrackSelection.updateSelectedTrack(
-        /* playbackPositionUs= */ 0,
-        /* bufferedDurationUs= */ 25_000_000,
-        /* availableDurationUs= */ C.TIME_UNSET,
-        /* queue= */ Collections.emptyList(),
-        createMediaChunkIterators(trackGroup, TEST_CHUNK_DURATION_US));
-
-    // Invalid comparators fall back to the default ordering and preserve the default behavior.
-    assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format2);
+    assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format3);
     assertThat(adaptiveTrackSelection.getSelectionReason()).isEqualTo(C.SELECTION_REASON_INITIAL);
   }
 
@@ -622,7 +569,7 @@ public final class AdaptiveTrackSelectionTest {
 
   @Test
   public void
-      updateSelectedTrack_withCustomFormatOrder_switchesDownIfCurrentTrackExceedsBandwidth() {
+      updateSelectedTrack_withCustomFormatOrder_defersSwitchDownWhenBufferedEnough() {
     Format format1 = videoFormat(/* bitrate= */ 500, /* width= */ 320, /* height= */ 240);
     Format format2 = videoFormat(/* bitrate= */ 1000, /* width= */ 640, /* height= */ 480);
     Format format3 = videoFormat(/* bitrate= */ 2000, /* width= */ 960, /* height= */ 720);
@@ -645,8 +592,10 @@ public final class AdaptiveTrackSelectionTest {
         /* queue= */ Collections.emptyList(),
         createMediaChunkIterators(trackGroup, TEST_CHUNK_DURATION_US));
 
-    assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format1);
-    assertThat(adaptiveTrackSelection.getSelectionReason()).isEqualTo(C.SELECTION_REASON_ADAPTIVE);
+    // With sufficient buffer (bufferedDurationUs >= maxDurationForQualityDecreaseUs), the
+    // down-switch is deferred regardless of which comparator is in use.
+    assertThat(adaptiveTrackSelection.getSelectedFormat()).isEqualTo(format2);
+    assertThat(adaptiveTrackSelection.getSelectionReason()).isEqualTo(C.SELECTION_REASON_INITIAL);
   }
 
   @Test


### PR DESCRIPTION
### Summary
 Adds optional custom format ordering for `AdaptiveTrackSelection` so apps can influence
  ABR selection priority beyond bitrate-only ordering. **While default behavior remain unchanged**

**This PR is refined version of the PR: https://github.com/androidx/media/pull/3064** in which I received comments about track format sorting. Intend to close above PR if this one is deemed good eventually.

### What changed
- Added `AdaptiveTrackSelection.Factory#setTrackFormatComparator(Comparator<Format>)`
    to allow custom format ordering via the factory.
  - Added `protected final getTrackFormatComparator()` on `Factory` so subclasses that
    override `createAdaptiveTrackSelection()` can access the configured comparator.
  - Added a new `protected` constructor on `AdaptiveTrackSelection` accepting a
    `Comparator<Format>`, enabling subclasses to pass a comparator directly.
  - Updated switch-up/switch-down direction logic in `updateSelectedTrack` to use index
    comparison instead of bitrate comparison, so it works correctly with any comparator
    (lower index = higher priority).
  - Extracted `DEFAULT_FORMAT_COMPARATOR` as a named constant in `BaseTrackSelection`.
  - Updated `TrackSelection` and field Javadoc to say "selection order" instead of
    "decreasing bandwidth order".


### Why
The current implementation always prioritizes higher bitrate. This makes it difficult to
  express developer-defined rules (e.g. a quality score ranking) without subclassing and
  duplicating ABR logic. These hooks allow custom ordering without touching core ABR
  switching behavior.


### Testing Done
- Unit test for comparator and default behavior