### PR TITLE
Fallback to `displayAlign` from `style` for TTML regions

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -26,6 +26,8 @@
     *   Add support for skipping frames that are late during join rather than
         dropping in DecoderVideoRenderer.
 *   Text:
+    *   TTML: Fallback to `displayAlign` from `style` for regions
+        ([#2559](https://github.com/androidx/media/issues/2559)).
 *   Metadata:
 *   Image:
 *   DataSource:

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/ttml/TtmlParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/ttml/TtmlParser.java
@@ -462,6 +462,15 @@ public final class TtmlParser implements SubtitleParser {
     @Nullable
     String displayAlign =
         XmlPullParserUtil.getAttributeValue(xmlParser, TtmlNode.ATTR_TTS_DISPLAY_ALIGN);
+    if (displayAlign == null) {
+      String styleId = XmlPullParserUtil.getAttributeValue(xmlParser, TtmlNode.ATTR_STYLE);
+      if (styleId != null) {
+        TtmlStyle style = globalStyles.get(styleId);
+        if (style != null) {
+          displayAlign = style.getDisplayAlign();
+        }
+      }
+    }
     if (displayAlign != null) {
       switch (Ascii.toLowerCase(displayAlign)) {
         case "center":
@@ -641,6 +650,9 @@ public final class TtmlParser implements SubtitleParser {
           break;
         case TtmlNode.ATTR_TTS_EXTENT:
           style = createIfNull(style).setExtent(attributeValue);
+          break;
+        case TtmlNode.ATTR_TTS_DISPLAY_ALIGN:
+          style = createIfNull(style).setDisplayAlign(attributeValue);
           break;
         default:
           // ignore

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/ttml/TtmlStyle.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/ttml/TtmlStyle.java
@@ -98,6 +98,7 @@ import java.lang.annotation.Target;
   private float shearPercentage;
   @Nullable private String origin;
   @Nullable private String extent;
+  @Nullable private String displayAlign;
 
   public TtmlStyle() {
     linethrough = UNSPECIFIED;
@@ -285,6 +286,9 @@ import java.lang.annotation.Target;
       if (extent == null) {
         extent = ancestor.extent;
       }
+      if (displayAlign == null) {
+        displayAlign = ancestor.displayAlign;
+      }
       // attributes not inherited as of http://www.w3.org/TR/ttml1/
       if (chaining && !hasBackgroundColor && ancestor.hasBackgroundColor) {
         setBackgroundColor(ancestor.backgroundColor);
@@ -411,5 +415,16 @@ import java.lang.annotation.Target;
   @Nullable
   public String getExtent() {
     return extent;
+  }
+
+  @CanIgnoreReturnValue
+  public TtmlStyle setDisplayAlign(String displayAlign) {
+    this.displayAlign = displayAlign;
+    return this;
+  }
+
+  @Nullable
+  public String getDisplayAlign() {
+    return displayAlign;
   }
 }

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/text/ttml/TtmlParserTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/text/ttml/TtmlParserTest.java
@@ -1129,8 +1129,8 @@ public final class TtmlParserTest {
     Cue fourthCue = Iterables.getOnlyElement(allCues.get(3).cues);
     assertThat(fourthCue.lineAnchor).isEqualTo(Cue.ANCHOR_TYPE_END);
 
-    Cue fithCue = Iterables.getOnlyElement(allCues.get(4).cues);
-    assertThat(fithCue.lineAnchor).isEqualTo(Cue.ANCHOR_TYPE_END);
+    Cue fifthCue = Iterables.getOnlyElement(allCues.get(4).cues);
+    assertThat(fifthCue.lineAnchor).isEqualTo(Cue.ANCHOR_TYPE_END);
   }
 
   private static Spanned getOnlyCueTextAtIndex(List<CuesWithTiming> allCues, int index) {

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/text/ttml/TtmlParserTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/text/ttml/TtmlParserTest.java
@@ -76,6 +76,8 @@ public final class TtmlParserTest {
   private static final String SHEAR_FILE = "media/ttml/shear.xml";
   private static final String REGION_ATTRS_FROM_STYLE_FILE =
       "media/ttml/inherit_region_attributes_from_style.xml";
+  private static final String DISPLAY_ALIGN_ATTR_FROM_STYLE_FILE =
+      "media/ttml/fallback_display_align_from_style.xml";
 
   @Test
   public void simple_allCues() throws Exception {
@@ -1109,6 +1111,26 @@ public final class TtmlParserTest {
     assertThat(thirdCue.position).isEqualTo(30f / 100f);
     assertThat(thirdCue.line).isEqualTo(30f / 100f);
     assertThat(thirdCue.size).isEqualTo(20f / 100f);
+  }
+
+  @Test
+  public void regionDisplayAlignFromStyle() throws Exception {
+    ImmutableList<CuesWithTiming> allCues = getAllCues(DISPLAY_ALIGN_ATTR_FROM_STYLE_FILE);
+
+    Cue firstCue = Iterables.getOnlyElement(allCues.get(0).cues);
+    assertThat(firstCue.lineAnchor).isEqualTo(Cue.ANCHOR_TYPE_START);
+
+    Cue secondCue = Iterables.getOnlyElement(allCues.get(1).cues);
+    assertThat(secondCue.lineAnchor).isEqualTo(Cue.ANCHOR_TYPE_START);
+
+    Cue thirdCue = Iterables.getOnlyElement(allCues.get(2).cues);
+    assertThat(thirdCue.lineAnchor).isEqualTo(Cue.ANCHOR_TYPE_MIDDLE);
+
+    Cue fourthCue = Iterables.getOnlyElement(allCues.get(3).cues);
+    assertThat(fourthCue.lineAnchor).isEqualTo(Cue.ANCHOR_TYPE_END);
+
+    Cue fithCue = Iterables.getOnlyElement(allCues.get(4).cues);
+    assertThat(fithCue.lineAnchor).isEqualTo(Cue.ANCHOR_TYPE_END);
   }
 
   private static Spanned getOnlyCueTextAtIndex(List<CuesWithTiming> allCues, int index) {

--- a/libraries/test_data/src/test/assets/media/ttml/fallback_display_align_from_style.xml
+++ b/libraries/test_data/src/test/assets/media/ttml/fallback_display_align_from_style.xml
@@ -1,0 +1,28 @@
+<tt xmlns="http://www.w3.org/ns/ttml"
+  xmlns:tts="http://www.w3.org/2006/10/ttaf1#style">
+  <head>
+    <styling>
+      <style xml:id="style1" />
+      <style xml:id="style2" tts:displayAlign="before"/>
+      <style xml:id="style3" tts:displayAlign="center"/>
+      <style xml:id="style4" tts:displayAlign="after"/>
+      <style xml:id="style5" style="style4"/>
+    </styling>
+    <layout>
+      <region xml:id="region1" style="style1" />
+      <region xml:id="region2" style="style2" />
+      <region xml:id="region3" style="style3" />
+      <region xml:id="region4" style="style4" />
+      <region xml:id="region5" style="style5" />
+    </layout>
+  </head>
+  <body>
+      <div>
+        <p begin="2s" end="4s" region="region1">text 1</p>
+        <p begin="4s" end="6s" region="region2">text 2</p>
+        <p begin="8s" end="10s" region="region3">text 3</p>
+        <p begin="10s" end="12s" region="region4">text 4</p>
+        <p begin="12s" end="14s" region="region5">text 5</p>
+      </div>
+  </body>
+</tt>


### PR DESCRIPTION
Adds support for using the `displayAlign` from the `style` of a region, if it has no explicit `displayAlign` set.

Closes: https://github.com/androidx/media/issues/2559