### PR TITLE
Handle the tunnelingAudioSessionId set after enabled renderers.

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -619,6 +619,7 @@ public final class DefaultAudioSink implements AudioSink {
   @Nullable private AudioDeviceInfo preferredDevice;
   private int virtualDeviceId;
   private boolean tunneling;
+  private boolean pendingTunnelingRequest;
   private long lastFeedElapsedRealtimeMs;
   private boolean offloadDisabledUntilNextConfiguration;
   private boolean isWaitingForOffloadEndOfStreamHandled;
@@ -1382,6 +1383,11 @@ public final class DefaultAudioSink implements AudioSink {
     if (this.audioSessionId != audioSessionId) {
       this.audioSessionId = audioSessionId;
       externalAudioSessionIdProvided = audioSessionId != C.AUDIO_SESSION_ID_UNSET;
+      // If audio session ID is now available and tunneling was pending, enable it now
+      if (externalAudioSessionIdProvided && pendingTunnelingRequest && !tunneling) {
+        tunneling = true;
+        pendingTunnelingRequest = false;
+      }
       reconfigureAndFlush();
     }
   }
@@ -1438,10 +1444,16 @@ public final class DefaultAudioSink implements AudioSink {
 
   @Override
   public void enableTunnelingV21() {
-    checkState(externalAudioSessionIdProvided);
-    if (!tunneling) {
-      tunneling = true;
-      reconfigureAndFlush();
+    if (externalAudioSessionIdProvided) {
+      // Audio session ID is available, enable tunneling immediately
+      if (!tunneling) {
+        tunneling = true;
+        reconfigureAndFlush();
+      }
+      pendingTunnelingRequest = false;
+    } else {
+      // Audio session ID is not yet available, defer tunneling request
+      pendingTunnelingRequest = true;
     }
   }
 
@@ -1451,6 +1463,7 @@ public final class DefaultAudioSink implements AudioSink {
       tunneling = false;
       reconfigureAndFlush();
     }
+    pendingTunnelingRequest = false;
   }
 
   @RequiresApi(29)

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -914,7 +914,9 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       throws ExoPlaybackException {
     super.onEnabled(joining, mayRenderStartOfStream);
     boolean tunneling = getConfiguration().tunneling;
-    checkState(!tunneling || tunnelingAudioSessionId != C.AUDIO_SESSION_ID_UNSET);
+    if (tunneling && tunnelingAudioSessionId == C.AUDIO_SESSION_ID_UNSET) {
+      Log.w(TAG, "MediaCodecVideoRenderer onEnabled in tunneling mode, but the tunnelingAudioSessionId has not yet been set.");
+    }
     if (this.tunneling != tunneling) {
       this.tunneling = tunneling;
       releaseCodec();


### PR DESCRIPTION
As now the audio session is not immediately available when create player, which may cause that the tunnelingAudioSessionId set after renderer onEnabled, that will cause checkState failure as tunnelingAudioSessionId has not been set yet. 