### PR TITLE
Allow to use float output in any case if output provider doesn't support 16-bit int

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -686,7 +686,7 @@ public final class DefaultAudioSink implements AudioSink {
     // For PCM formats, convert the format to what our audio processors will produce.
     boolean transcodingViaAudioProcessors = false;
     if (Util.isEncodingLinearPcm(format.pcmEncoding)) {
-      boolean usesFloatPcm = shouldUseFloatOutput(format.pcmEncoding);
+      boolean usesFloatPcm = shouldUseFloatOutput(format);
       if (usesFloatPcm && format.pcmEncoding != C.ENCODING_PCM_FLOAT) {
         format = format.buildUpon().setPcmEncoding(C.ENCODING_PCM_FLOAT).build();
         transcodingViaAudioProcessors = true;
@@ -750,7 +750,7 @@ public final class DefaultAudioSink implements AudioSink {
 
       ImmutableList.Builder<AudioProcessor> pipelineProcessors = new ImmutableList.Builder<>();
       pipelineProcessors.addAll(availableAudioProcessors);
-      if (shouldUseFloatOutput(inputFormat.pcmEncoding)) {
+      if (shouldUseFloatOutput(inputFormat)) {
         pipelineProcessors.add(toFloatPcmAudioProcessor);
       } else {
         pipelineProcessors.add(toInt16PcmAudioProcessor);
@@ -1667,9 +1667,7 @@ public final class DefaultAudioSink implements AudioSink {
     // - when playing encoded audio via passthrough/offload, because modifying the audio stream
     //   would require decoding/re-encoding; and
     // - when outputting float PCM audio, because SonicAudioProcessor outputs 16-bit integer PCM.
-    return !tunneling
-        && configuration.isPcm()
-        && !shouldUseFloatOutput(configuration.inputFormat.pcmEncoding);
+    return !tunneling && configuration.isPcm() && !shouldUseFloatOutput(configuration.inputFormat);
   }
 
   private boolean useAudioOutputPlaybackParams() {
@@ -1677,11 +1675,25 @@ public final class DefaultAudioSink implements AudioSink {
   }
 
   /**
-   * Returns whether audio in the specified PCM encoding should be written to the audio output as
+   * Returns whether audio in the specified PCM format should be written to the audio output as
    * float PCM.
    */
-  private boolean shouldUseFloatOutput(@C.PcmEncoding int pcmEncoding) {
-    return enableFloatOutput && Util.isEncodingHighResolutionPcm(pcmEncoding);
+  private boolean shouldUseFloatOutput(Format format) {
+    boolean supportsFloat =
+        audioOutputProvider.getFormatSupport(
+                    getFormatConfig(
+                        format.buildUpon().setPcmEncoding(C.ENCODING_PCM_FLOAT).build()))
+                .supportLevel
+            != AudioOutputProvider.FORMAT_UNSUPPORTED;
+    boolean preferFloat = Util.isEncodingHighResolutionPcm(format.pcmEncoding);
+    // If the AudioOutputProvider cannot output 16-bit PCM, we should use float output.
+    boolean supportsInt16 =
+        audioOutputProvider.getFormatSupport(
+                    getFormatConfig(
+                        format.buildUpon().setPcmEncoding(C.ENCODING_PCM_16BIT).build()))
+                .supportLevel
+            != AudioOutputProvider.FORMAT_UNSUPPORTED;
+    return supportsFloat && enableFloatOutput && (preferFloat || !supportsInt16);
   }
 
   /**


### PR DESCRIPTION
This commit is a continuation of 4f4ad5f82d156767f89b9a6dec44c37bb8d153f4 and fe4f235c103167c5ee8be4f713ebf264b72f6bec by Toni, decoupling DefaultAudioSink logic from assumptions that AudioTrack is used.

* If audio output provider doesn't support 16-bit int PCM, we should use float PCM in any case, even if input isn't high-resolution PCM
* Unlike when this check was written, ToFloatPcmAudioProcessor now supports every linear PCM format, similar to ToIntPcmAudioProcessor, it is no longer limited to high-resolution only
* While AudioTrack (and by extension AudioTrackAudioOutputProvider) always supports 16-bit int (hence, this change is a no-op for them), it may not apply to other ways of outputting PCM
* Additionally, the same applies to the provider possibly not supporting float PCM output. Currently, we have the enableFloatOutput option, but this is scheduled to be replaced by a more generic one. While we're here, we can address it as well by adding a check.