### PR TITLE
Set accurate seekMap duration in SubtitleExtractor after parsing

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/SubtitleExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/SubtitleExtractor.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /** Generic extractor for extracting subtitles from various subtitle formats. */
@@ -148,12 +149,11 @@ public class SubtitleExtractor implements Extractor {
     if (format != null) {
       trackOutput.format(format);
       output.endTracks();
-      IndexSeekMap seekMap =
+      seekMap =
           new IndexSeekMap(
               /* positions= */ new long[] {0},
               /* timesUs= */ new long[] {0},
               /* durationUs= */ C.TIME_UNSET);
-      this.seekMap = seekMap;
       output.seekMap(seekMap);
     }
     state = STATE_INITIALIZED;
@@ -253,7 +253,7 @@ public class SubtitleExtractor implements Extractor {
           seekTimeUs != C.TIME_UNSET
               ? SubtitleParser.OutputOptions.cuesAfterThenRemainingCuesBefore(seekTimeUs)
               : SubtitleParser.OutputOptions.allCues();
-      long[] maxEndTimeUs = {C.TIME_UNSET};
+      AtomicLong maxEndTimeUs = new AtomicLong(C.TIME_UNSET);
       subtitleParser.parse(
           subtitleData,
           /* offset= */ 0,
@@ -266,7 +266,10 @@ public class SubtitleExtractor implements Extractor {
                     cueEncoder.encode(cuesWithTiming.cues, cuesWithTiming.durationUs));
             samples.add(sample);
             if (cuesWithTiming.endTimeUs != C.TIME_UNSET) {
-              maxEndTimeUs[0] = Math.max(maxEndTimeUs[0], cuesWithTiming.endTimeUs);
+              maxEndTimeUs.set(
+                  maxEndTimeUs.get() == C.TIME_UNSET
+                      ? cuesWithTiming.endTimeUs
+                      : Math.max(maxEndTimeUs.get(), cuesWithTiming.endTimeUs));
             }
             if (seekTimeUs == C.TIME_UNSET || cuesWithTiming.endTimeUs >= seekTimeUs) {
               writeToOutput(sample);
@@ -278,9 +281,12 @@ public class SubtitleExtractor implements Extractor {
         timestamps[i] = samples.get(i).timeUs;
       }
       // Duration is exact after parsing all subtitle cues.
-      if (maxEndTimeUs[0] != C.TIME_UNSET && seekMap != null) {
-        seekMap.setDurationUs(maxEndTimeUs[0]);
-        checkNotNull(extractorOutput).seekMap(seekMap);
+      if (maxEndTimeUs.get() != C.TIME_UNSET) {
+        checkNotNull(trackOutput).durationUs(maxEndTimeUs.get());
+        if (seekMap != null) {
+          seekMap.setDurationUs(maxEndTimeUs.get());
+          checkNotNull(extractorOutput).seekMap(seekMap);
+        }
       }
       subtitleData = Util.EMPTY_BYTE_ARRAY;
     } catch (RuntimeException e) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/SubtitleExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/SubtitleExtractor.java
@@ -94,6 +94,8 @@ public class SubtitleExtractor implements Extractor {
 
   private byte[] subtitleData;
   private @MonotonicNonNull TrackOutput trackOutput;
+  private @MonotonicNonNull ExtractorOutput extractorOutput;
+  private @MonotonicNonNull IndexSeekMap seekMap;
   private int bytesRead;
   private @State int state;
   private long[] timestamps;
@@ -141,15 +143,18 @@ public class SubtitleExtractor implements Extractor {
   @Override
   public void init(ExtractorOutput output) {
     checkState(state == STATE_CREATED);
+    this.extractorOutput = output;
     trackOutput = output.track(TRACK_ID, C.TRACK_TYPE_TEXT);
     if (format != null) {
       trackOutput.format(format);
       output.endTracks();
-      output.seekMap(
+      IndexSeekMap seekMap =
           new IndexSeekMap(
               /* positions= */ new long[] {0},
               /* timesUs= */ new long[] {0},
-              /* durationUs= */ C.TIME_UNSET));
+              /* durationUs= */ C.TIME_UNSET);
+      this.seekMap = seekMap;
+      output.seekMap(seekMap);
     }
     state = STATE_INITIALIZED;
   }
@@ -248,6 +253,7 @@ public class SubtitleExtractor implements Extractor {
           seekTimeUs != C.TIME_UNSET
               ? SubtitleParser.OutputOptions.cuesAfterThenRemainingCuesBefore(seekTimeUs)
               : SubtitleParser.OutputOptions.allCues();
+      long[] maxEndTimeUs = {C.TIME_UNSET};
       subtitleParser.parse(
           subtitleData,
           /* offset= */ 0,
@@ -259,6 +265,9 @@ public class SubtitleExtractor implements Extractor {
                     cuesWithTiming.startTimeUs,
                     cueEncoder.encode(cuesWithTiming.cues, cuesWithTiming.durationUs));
             samples.add(sample);
+            if (cuesWithTiming.endTimeUs != C.TIME_UNSET) {
+              maxEndTimeUs[0] = Math.max(maxEndTimeUs[0], cuesWithTiming.endTimeUs);
+            }
             if (seekTimeUs == C.TIME_UNSET || cuesWithTiming.endTimeUs >= seekTimeUs) {
               writeToOutput(sample);
             }
@@ -267,6 +276,11 @@ public class SubtitleExtractor implements Extractor {
       timestamps = new long[samples.size()];
       for (int i = 0; i < samples.size(); i++) {
         timestamps[i] = samples.get(i).timeUs;
+      }
+      // Duration is exact after parsing all subtitle cues.
+      if (maxEndTimeUs[0] != C.TIME_UNSET && seekMap != null) {
+        seekMap.setDurationUs(maxEndTimeUs[0]);
+        checkNotNull(extractorOutput).seekMap(seekMap);
       }
       subtitleData = Util.EMPTY_BYTE_ARRAY;
     } catch (RuntimeException e) {

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/text/SubtitleExtractorTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/text/SubtitleExtractorTest.java
@@ -316,7 +316,7 @@ public class SubtitleExtractorTest {
   }
 
   @Test
-  public void extractor_longDurationCue_seekMapDurationReflectsEndTime() throws Exception {
+  public void extractor_longDurationCue_seekMapAndTrackDurationReflectsEndTime() throws Exception {
     FakeExtractorOutput output = new FakeExtractorOutput();
     FakeExtractorInput input =
         new FakeExtractorInput.Builder()
@@ -330,9 +330,12 @@ public class SubtitleExtractorTest {
 
     while (extractor.read(input, null) != Extractor.RESULT_END_OF_INPUT) {}
 
-    // The seekMap's durationUs should reflect the long-duration cue's endTimeUs (1 hour),
+    // The seekMap and track durationUs should reflect the long-duration cue's endTimeUs (1 hour),
     // not the largest sample startTimeUs (10 seconds).
-    assertThat(output.seekMap.getDurationUs()).isEqualTo(3_600_000_000L);
+    long expectedDurationUs = 3_600_000_000L;
+    assertThat(output.trackOutputs.size()).isEqualTo(1);
+    assertThat(output.trackOutputs.valueAt(0).getDurationUs()).isEqualTo(expectedDurationUs);
+    assertThat(output.seekMap.getDurationUs()).isEqualTo(expectedDurationUs);
   }
 
   private CuesWithTiming decodeSample(FakeTrackOutput trackOutput, int sampleIndex) {

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/text/SubtitleExtractorTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/text/SubtitleExtractorTest.java
@@ -294,7 +294,7 @@ public class SubtitleExtractorTest {
   }
 
   @Test
-  public void extractor_seekMapDuration_updatedToMaxEndTimeUs() throws Exception {
+  public void extractor_seekMapAndTrackDuration_updatedToMaxEndTimeUs() throws Exception {
     FakeExtractorOutput output = new FakeExtractorOutput();
     FakeExtractorInput input =
         new FakeExtractorInput.Builder()
@@ -310,8 +310,10 @@ public class SubtitleExtractorTest {
 
     while (extractor.read(input, null) != Extractor.RESULT_END_OF_INPUT) {}
 
-    // The seekMap's durationUs should be updated to the maximum endTimeUs (4_567_000) across all
-    // subtitle cues, not left as C.TIME_UNSET.
+    // The seekMap and track durationUs should be updated to the maximum endTimeUs (4_567_000)
+    // across all subtitle cues, not left as C.TIME_UNSET.
+    assertThat(output.trackOutputs.size()).isEqualTo(1);
+    assertThat(output.trackOutputs.valueAt(0).getDurationUs()).isEqualTo(4_567_000);
     assertThat(output.seekMap.getDurationUs()).isEqualTo(4_567_000);
   }
 
@@ -332,10 +334,9 @@ public class SubtitleExtractorTest {
 
     // The seekMap and track durationUs should reflect the long-duration cue's endTimeUs (1 hour),
     // not the largest sample startTimeUs (10 seconds).
-    long expectedDurationUs = 3_600_000_000L;
     assertThat(output.trackOutputs.size()).isEqualTo(1);
-    assertThat(output.trackOutputs.valueAt(0).getDurationUs()).isEqualTo(expectedDurationUs);
-    assertThat(output.seekMap.getDurationUs()).isEqualTo(expectedDurationUs);
+    assertThat(output.trackOutputs.valueAt(0).getDurationUs()).isEqualTo(3_600_000_000L);
+    assertThat(output.seekMap.getDurationUs()).isEqualTo(3_600_000_000L);
   }
 
   private CuesWithTiming decodeSample(FakeTrackOutput trackOutput, int sampleIndex) {

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/text/SubtitleExtractorTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/text/SubtitleExtractorTest.java
@@ -18,6 +18,7 @@ package androidx.media3.extractor.text;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Consumer;
@@ -48,6 +49,15 @@ public class SubtitleExtractorTest {
           + "\n"
           + "00:02.600 --> 00:04.567\n"
           + "This is the third subtitle.\n";
+
+  private static final String TEST_DATA_LONG_DURATION_CUE =
+      "WEBVTT\n"
+          + "\n"
+          + "00:00.000 --> 01:00:00.000\n"
+          + "This is a long-duration cue.\n"
+          + "\n"
+          + "00:05.000 --> 00:10.000\n"
+          + "This is a short cue.\n";
 
   private CueDecoder decoder;
 
@@ -281,6 +291,48 @@ public class SubtitleExtractorTest {
     extractor.release();
     extractor.release();
     // Calling realease() twice does not throw an exception.
+  }
+
+  @Test
+  public void extractor_seekMapDuration_updatedToMaxEndTimeUs() throws Exception {
+    FakeExtractorOutput output = new FakeExtractorOutput();
+    FakeExtractorInput input =
+        new FakeExtractorInput.Builder()
+            .setData(Util.getUtf8Bytes(TEST_DATA))
+            .setSimulatePartialReads(true)
+            .build();
+    SubtitleExtractor extractor =
+        new SubtitleExtractor(
+            new WebvttParser(), new Format.Builder().setSampleMimeType(MimeTypes.TEXT_VTT).build());
+    extractor.init(output);
+
+    assertThat(output.seekMap.getDurationUs()).isEqualTo(C.TIME_UNSET);
+
+    while (extractor.read(input, null) != Extractor.RESULT_END_OF_INPUT) {}
+
+    // The seekMap's durationUs should be updated to the maximum endTimeUs (4_567_000) across all
+    // subtitle cues, not left as C.TIME_UNSET.
+    assertThat(output.seekMap.getDurationUs()).isEqualTo(4_567_000);
+  }
+
+  @Test
+  public void extractor_longDurationCue_seekMapDurationReflectsEndTime() throws Exception {
+    FakeExtractorOutput output = new FakeExtractorOutput();
+    FakeExtractorInput input =
+        new FakeExtractorInput.Builder()
+            .setData(Util.getUtf8Bytes(TEST_DATA_LONG_DURATION_CUE))
+            .setSimulatePartialReads(true)
+            .build();
+    SubtitleExtractor extractor =
+        new SubtitleExtractor(
+            new WebvttParser(), new Format.Builder().setSampleMimeType(MimeTypes.TEXT_VTT).build());
+    extractor.init(output);
+
+    while (extractor.read(input, null) != Extractor.RESULT_END_OF_INPUT) {}
+
+    // The seekMap's durationUs should reflect the long-duration cue's endTimeUs (1 hour),
+    // not the largest sample startTimeUs (10 seconds).
+    assertThat(output.seekMap.getDurationUs()).isEqualTo(3_600_000_000L);
   }
 
   private CuesWithTiming decodeSample(FakeTrackOutput trackOutput, int sampleIndex) {

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/FakeTrackOutput.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/FakeTrackOutput.java
@@ -198,6 +198,10 @@ public final class FakeTrackOutput implements TrackOutput, Dumper.Dumpable {
     return sampleTimesUs.build();
   }
 
+  public long getDurationUs() {
+    return durationUs;
+  }
+
   @Override
   public void dump(Dumper dumper) {
     dumper.add("total output bytes", sampleData.length);


### PR DESCRIPTION
`SubtitleExtractor` creates its `IndexSeekMap` with `durationUs = C.TIME_UNSET` in `init()`, but never updates it after parsing, even though the exact duration is knowable from the parsed cues' `endTimeUs` values.

This causes problems for WebVTT files with long-duration cues (e.g. a cue spanning `00:00.000 --> 01:00:00.000`). 
Since the seekMap reports `TIME_UNSET` as its duration, consumers may fall back to estimating duration from sample timestamps (`startTimeUs`), which can be significantly shorter than the actual content end time. This can result in subtitle samples not being loaded after seeking to a position beyond the estimated duration.

This change updates the seekMap's `durationUs` to the maximum `endTimeUs` across all parsed cues, following the same pattern used by `Mp3Extractor` (which calls `IndexSeekMap.setDurationUs()` and re-emits the seekMap after reading all samples).

Also added tests to verify this behavior. Happy to adjust if anything needs to be changed :)