### PR TITLE
Rename AUDIO_DTS_X to AUDIO_DTS_UHD_P2

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
@@ -100,9 +100,7 @@ public final class MimeTypes {
   /**
    * @deprecated Use {@link #AUDIO_DTS_UHD_P2} instead.
    */
-  @Deprecated
-  @UnstableApi
-  public static final String AUDIO_DTS_X = AUDIO_DTS_UHD_P2;
+  @Deprecated @UnstableApi public static final String AUDIO_DTS_X = AUDIO_DTS_UHD_P2;
 
   public static final String AUDIO_VORBIS = BASE_TYPE_AUDIO + "/vorbis";
   public static final String AUDIO_OPUS = BASE_TYPE_AUDIO + "/opus";

--- a/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
@@ -97,6 +97,13 @@ public final class MimeTypes {
   @UnstableApi
   public static final String AUDIO_DTS_UHD_P2 = BASE_TYPE_AUDIO + "/vnd.dts.uhd;profile=p2";
 
+  /**
+   * @deprecated Use {@link #AUDIO_DTS_UHD_P2} instead.
+   */
+  @Deprecated
+  @UnstableApi
+  public static final String AUDIO_DTS_X = AUDIO_DTS_UHD_P2;
+
   public static final String AUDIO_VORBIS = BASE_TYPE_AUDIO + "/vorbis";
   public static final String AUDIO_OPUS = BASE_TYPE_AUDIO + "/opus";
   public static final String AUDIO_AMR = BASE_TYPE_AUDIO + "/amr";

--- a/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
@@ -93,7 +93,10 @@ public final class MimeTypes {
   public static final String AUDIO_DTS = BASE_TYPE_AUDIO + "/vnd.dts";
   public static final String AUDIO_DTS_HD = BASE_TYPE_AUDIO + "/vnd.dts.hd";
   public static final String AUDIO_DTS_EXPRESS = BASE_TYPE_AUDIO + "/vnd.dts.hd;profile=lbr";
-  @UnstableApi public static final String AUDIO_DTS_X = BASE_TYPE_AUDIO + "/vnd.dts.uhd;profile=p2";
+
+  @UnstableApi
+  public static final String AUDIO_DTS_UHD_P2 = BASE_TYPE_AUDIO + "/vnd.dts.uhd;profile=p2";
+
   public static final String AUDIO_VORBIS = BASE_TYPE_AUDIO + "/vorbis";
   public static final String AUDIO_OPUS = BASE_TYPE_AUDIO + "/opus";
   public static final String AUDIO_AMR = BASE_TYPE_AUDIO + "/amr";
@@ -504,7 +507,7 @@ public final class MimeTypes {
     } else if (codec.startsWith("dtsh") || codec.startsWith("dtsl")) {
       return MimeTypes.AUDIO_DTS_HD;
     } else if (codec.startsWith("dtsx")) {
-      return MimeTypes.AUDIO_DTS_X;
+      return MimeTypes.AUDIO_DTS_UHD_P2;
     } else if (codec.startsWith("opus")) {
       return MimeTypes.AUDIO_OPUS;
     } else if (codec.startsWith("vorbis")) {
@@ -710,7 +713,7 @@ public final class MimeTypes {
         return C.ENCODING_DTS_HD;
       case MimeTypes.AUDIO_DTS_EXPRESS:
         return C.ENCODING_DTS_HD;
-      case MimeTypes.AUDIO_DTS_X:
+      case MimeTypes.AUDIO_DTS_UHD_P2:
         return C.ENCODING_DTS_UHD_P2;
       case MimeTypes.AUDIO_TRUEHD:
         return C.ENCODING_DOLBY_TRUEHD;

--- a/libraries/common/src/test/java/androidx/media3/common/MimeTypesTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/MimeTypesTest.java
@@ -180,7 +180,7 @@ public final class MimeTypesTest {
     assertThat(MimeTypes.getMediaMimeType("dtse")).isEqualTo(MimeTypes.AUDIO_DTS_EXPRESS);
     assertThat(MimeTypes.getMediaMimeType("dtsh")).isEqualTo(MimeTypes.AUDIO_DTS_HD);
     assertThat(MimeTypes.getMediaMimeType("dtsl")).isEqualTo(MimeTypes.AUDIO_DTS_HD);
-    assertThat(MimeTypes.getMediaMimeType("dtsx")).isEqualTo(MimeTypes.AUDIO_DTS_X);
+    assertThat(MimeTypes.getMediaMimeType("dtsx")).isEqualTo(MimeTypes.AUDIO_DTS_UHD_P2);
     assertThat(MimeTypes.getMediaMimeType("opus")).isEqualTo(MimeTypes.AUDIO_OPUS);
     assertThat(MimeTypes.getMediaMimeType("vorbis")).isEqualTo(MimeTypes.AUDIO_VORBIS);
     assertThat(MimeTypes.getMediaMimeType("mp4a")).isEqualTo(MimeTypes.AUDIO_AAC);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -415,7 +415,7 @@ public final class AudioCapabilities {
           audioProfile.getMaxSupportedChannelCountForPassthrough(sampleRate, audioAttributes);
     } else {
       channelCount = format.channelCount;
-      if (format.sampleMimeType.equals(MimeTypes.AUDIO_DTS_X) && SDK_INT < 33) {
+      if (format.sampleMimeType.equals(MimeTypes.AUDIO_DTS_UHD_P2) && SDK_INT < 33) {
         // Some DTS:X TVs reports ACTION_HDMI_AUDIO_PLUG.EXTRA_MAX_CHANNEL_COUNT as 8
         // instead of 10. See https://github.com/androidx/media/issues/396
         if (channelCount > 10) {

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/DefaultAudioOffloadSupportProviderTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/DefaultAudioOffloadSupportProviderTest.java
@@ -68,7 +68,10 @@ public final class DefaultAudioOffloadSupportProviderTest {
   public void
       getAudioOffloadSupport_withDtsXAndSdkUnder34_returnsAudioOffloadSupportDefaultUnsupported() {
     Format formatDtsX =
-        new Format.Builder().setSampleMimeType(MimeTypes.AUDIO_DTS_X).setSampleRate(48_000).build();
+        new Format.Builder()
+            .setSampleMimeType(MimeTypes.AUDIO_DTS_UHD_P2)
+            .setSampleRate(48_000)
+            .build();
     DefaultAudioOffloadSupportProvider audioOffloadSupportProvider =
         new DefaultAudioOffloadSupportProvider();
 

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/DefaultAudioOffloadSupportProviderTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/DefaultAudioOffloadSupportProviderTest.java
@@ -66,8 +66,8 @@ public final class DefaultAudioOffloadSupportProviderTest {
   @Test
   @Config(maxSdk = 33)
   public void
-      getAudioOffloadSupport_withDtsXAndSdkUnder34_returnsAudioOffloadSupportDefaultUnsupported() {
-    Format formatDtsX =
+      getAudioOffloadSupport_withDtsUhdP2AndSdkUnder34_returnsAudioOffloadSupportDefaultUnsupported() {
+    Format formatDtsUhdP2 =
         new Format.Builder()
             .setSampleMimeType(MimeTypes.AUDIO_DTS_UHD_P2)
             .setSampleRate(48_000)
@@ -76,7 +76,7 @@ public final class DefaultAudioOffloadSupportProviderTest {
         new DefaultAudioOffloadSupportProvider();
 
     AudioOffloadSupport audioOffloadSupport =
-        audioOffloadSupportProvider.getAudioOffloadSupport(formatDtsX, AudioAttributes.DEFAULT);
+        audioOffloadSupportProvider.getAudioOffloadSupport(formatDtsUhdP2, AudioAttributes.DEFAULT);
 
     assertThat(audioOffloadSupport.isFormatSupported).isFalse();
   }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
@@ -86,13 +86,19 @@ public final class DtsUtil {
    * <ul>
    *   <li>{@link MimeTypes#AUDIO_DTS}
    *   <li>{@link MimeTypes#AUDIO_DTS_EXPRESS}
-   *   <li>{@link MimeTypes#AUDIO_DTS_X}
+   *   <li>{@link MimeTypes#AUDIO_DTS_HD}
+   *   <li>{@link MimeTypes#AUDIO_DTS_UHD_P2}
    * </ul>
    */
   @Documented
   @Retention(SOURCE)
   @Target(TYPE_USE)
-  @StringDef({MimeTypes.AUDIO_DTS, MimeTypes.AUDIO_DTS_EXPRESS, MimeTypes.AUDIO_DTS_X})
+  @StringDef({
+    MimeTypes.AUDIO_DTS,
+    MimeTypes.AUDIO_DTS_EXPRESS,
+    MimeTypes.AUDIO_DTS_HD,
+    MimeTypes.AUDIO_DTS_UHD_P2
+  })
   public @interface DtsAudioMimeType {}
 
   /**
@@ -656,7 +662,7 @@ public final class DtsUtil {
 
     int frameSize = ftocPayloadInBytes + chunkPayloadBytes;
     return new DtsHeader(
-        MimeTypes.AUDIO_DTS_X,
+        MimeTypes.AUDIO_DTS_UHD_P2,
         // To determine the actual number of channels from a bit stream, we need to read the
         // metadata chunk bytes. If defining a constant channel count causes problems, we can
         // consider adding additional parsing logic for UHD frames.

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
@@ -2116,7 +2116,7 @@ public final class BoxParser {
     } else if (atomType == Mp4Box.TYPE_dtse) {
       mimeType = MimeTypes.AUDIO_DTS_EXPRESS;
     } else if (atomType == Mp4Box.TYPE_dtsx) {
-      mimeType = MimeTypes.AUDIO_DTS_X;
+      mimeType = MimeTypes.AUDIO_DTS_UHD_P2;
     } else if (atomType == Mp4Box.TYPE_samr) {
       mimeType = MimeTypes.AUDIO_AMR_NB;
     } else if (atomType == Mp4Box.TYPE_sawb) {


### PR DESCRIPTION
* The AudioFormat constant is named ENCODING_DTS_UHD_P2, and the internal platform mime type constant too is named MEDIA_MIMETYPE_AUDIO_DTS_UHD_P2. It's a correct and clear way to refer to this format.
* DTS:X is a marketing name that can be misleading because DTS:X is a proprietary extension to other DTS formats, however DTS:X supports both DTS-HD based and DTS-UHD based formats. Equating DTS-UHD with DTS:X is bound to cause confusion when DTS-HD based DTS:X is encountered.

Issue: #2487