### PR TITLE
Add DTS fallback to MediaCodec

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
@@ -380,6 +380,11 @@ public final class MediaCodecUtil {
       // E-AC3 decoders can decode JOC streams, but in 2-D rather than 3-D.
       return MimeTypes.AUDIO_E_AC3;
     }
+    if (MimeTypes.AUDIO_DTS_HD.equals(format.sampleMimeType)
+        || MimeTypes.AUDIO_DTS_UHD_P2.equals(format.sampleMimeType)) {
+      // DTS decoders support DTS-HD streams (but decode only the core layer).
+      return MimeTypes.AUDIO_DTS;
+    }
     if (MimeTypes.VIDEO_DOLBY_VISION.equals(format.sampleMimeType)) {
       // H.264/AVC, H.265/HEVC or AV1 decoders can decode the base layer of some DV profiles.
       // This can't be done for profile CodecProfileLevel.DolbyVisionProfileDvheStn and profile


### PR DESCRIPTION
Currently, ExoPlayer only has a fallback for passthrough case:

https://github.com/androidx/media/blob/7ce3aa2619b19009e4799319b4dd694a4a7577df/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java#L397-L400

Mirror the logic for MediaCodec.

Issue: #2487