### PR TITLE
Add hybrid MP4 muxer for crash-safe recording with non-fragmented fin…

### DIFF
--- a/demos/composition/src/main/java/androidx/media3/demo/composition/CompositionPreviewViewModel.kt
+++ b/demos/composition/src/main/java/androidx/media3/demo/composition/CompositionPreviewViewModel.kt
@@ -73,6 +73,7 @@ import androidx.media3.transformer.Effects
 import androidx.media3.transformer.ExportException
 import androidx.media3.transformer.ExportResult
 import androidx.media3.transformer.InAppFragmentedMp4Muxer
+import androidx.media3.transformer.InAppHybridMp4Muxer
 import androidx.media3.transformer.InAppMp4Muxer
 import androidx.media3.transformer.JsonUtil
 import androidx.media3.transformer.Transformer
@@ -494,6 +495,10 @@ class CompositionPreviewViewModel(application: Application) : AndroidViewModel(a
       MUXER_OPTIONS[2] -> {
         transformerBuilder.setMuxerFactory(InAppFragmentedMp4Muxer.Factory())
       }
+
+      MUXER_OPTIONS[3] -> {
+        transformerBuilder.setMuxerFactory(InAppHybridMp4Muxer.Factory())
+      }
     }
 
     transformer =
@@ -819,7 +824,7 @@ class CompositionPreviewViewModel(application: Application) : AndroidViewModel(a
     val RESOLUTION_HEIGHTS =
       listOf(SAME_AS_INPUT_OPTION, "144", "240", "360", "480", "720", "1080", "1440", "2160")
     val MUXER_OPTIONS =
-      listOf("Use Platform MediaMuxer", "Use Media3 Mp4Muxer", "Use Media3 FragmentedMp4Muxer")
+      listOf("Use Platform MediaMuxer", "Use Media3 Mp4Muxer", "Use Media3 FragmentedMp4Muxer", "Use Media3 HybridMp4Muxer")
     val COMPOSITION_LAYOUT = listOf("Sequential", "2x2 grid", "PiP overlay")
 
     fun getAudioBackgroundSequence(): EditedMediaItemSequence {

--- a/demos/transformer/src/main/java/androidx/media3/demo/transformer/ConfigurationActivity.java
+++ b/demos/transformer/src/main/java/androidx/media3/demo/transformer/ConfigurationActivity.java
@@ -79,6 +79,7 @@ public final class ConfigurationActivity extends AppCompatActivity {
   public static final String ENABLE_DEBUG_PREVIEW = "enable_debug_preview";
   public static final String ABORT_SLOW_EXPORT = "abort_slow_export";
   public static final String PRODUCE_FRAGMENTED_MP4 = "produce_fragmented_mp4";
+  public static final String PRODUCE_HYBRID_MP4 = "produce_hybrid_mp4";
   public static final String ENABLE_TRIM_OPTIMIZATION = "enable_trim_optimization";
   public static final String ENABLE_MP4_EDIT_LIST_TRIMMING = "enable_mp4_edit_list_trimming";
   public static final String ENABLE_CODECDB_LITE = "enable_codecdb_lite";
@@ -181,6 +182,7 @@ public final class ConfigurationActivity extends AppCompatActivity {
   private CheckBox enableDebugTracingCheckBox;
   private CheckBox abortSlowExportCheckBox;
   private CheckBox produceFragmentedMp4;
+  private CheckBox produceHybridMp4;
   private Spinner hdrModeSpinner;
   private CheckBox enableTrimOptimization;
   private CheckBox enableMp4EditListTrimming;
@@ -308,6 +310,7 @@ public final class ConfigurationActivity extends AppCompatActivity {
 
     abortSlowExportCheckBox = findViewById(R.id.abort_slow_export_checkbox);
     produceFragmentedMp4 = findViewById(R.id.produce_fragmented_mp4_checkbox);
+    produceHybridMp4 = findViewById(R.id.produce_hybrid_mp4_checkbox);
     enableTrimOptimization = findViewById(R.id.enable_trim_optimization);
     enableMp4EditListTrimming = findViewById(R.id.enable_mp4_edit_list_trimming);
     enableCodecDbLite = findViewById(R.id.enable_codecdb_lite);
@@ -413,6 +416,7 @@ public final class ConfigurationActivity extends AppCompatActivity {
     bundle.putBoolean(ENABLE_DEBUG_PREVIEW, enableDebugPreviewCheckBox.isChecked());
     bundle.putBoolean(ABORT_SLOW_EXPORT, abortSlowExportCheckBox.isChecked());
     bundle.putBoolean(PRODUCE_FRAGMENTED_MP4, produceFragmentedMp4.isChecked());
+    bundle.putBoolean(PRODUCE_HYBRID_MP4, produceHybridMp4.isChecked());
     bundle.putBoolean(ENABLE_TRIM_OPTIMIZATION, enableTrimOptimization.isChecked());
     bundle.putBoolean(ENABLE_MP4_EDIT_LIST_TRIMMING, enableMp4EditListTrimming.isChecked());
     bundle.putBoolean(ENABLE_CODECDB_LITE, enableCodecDbLite.isChecked());

--- a/demos/transformer/src/main/java/androidx/media3/demo/transformer/TransformerActivity.java
+++ b/demos/transformer/src/main/java/androidx/media3/demo/transformer/TransformerActivity.java
@@ -104,6 +104,7 @@ import androidx.media3.transformer.ExperimentalAnalyzerModeFactory;
 import androidx.media3.transformer.ExportException;
 import androidx.media3.transformer.ExportResult;
 import androidx.media3.transformer.InAppFragmentedMp4Muxer;
+import androidx.media3.transformer.InAppHybridMp4Muxer;
 import androidx.media3.transformer.JsonUtil;
 import androidx.media3.transformer.MediaProjectionAssetLoader;
 import androidx.media3.transformer.ProgressHolder;
@@ -395,6 +396,8 @@ public final class TransformerActivity extends AppCompatActivity {
 
       if (bundle.getBoolean(ConfigurationActivity.PRODUCE_FRAGMENTED_MP4)) {
         transformerBuilder.setMuxerFactory(new InAppFragmentedMp4Muxer.Factory());
+      } else if (bundle.getBoolean(ConfigurationActivity.PRODUCE_HYBRID_MP4)) {
+        transformerBuilder.setMuxerFactory(new InAppHybridMp4Muxer.Factory());
       }
 
       if (bundle.getBoolean(ConfigurationActivity.ENABLE_DEBUG_PREVIEW)) {

--- a/demos/transformer/src/main/res/layout/configuration_activity.xml
+++ b/demos/transformer/src/main/res/layout/configuration_activity.xml
@@ -237,6 +237,15 @@
           android:layout_gravity="end"/>
       </TableRow>
       <TableRow
+        android:layout_weight="1">
+        <TextView
+          android:layout_gravity="center_vertical"
+          android:text="@string/produce_hybrid_mp4" />
+        <CheckBox
+          android:id="@+id/produce_hybrid_mp4_checkbox"
+          android:layout_gravity="end"/>
+      </TableRow>
+      <TableRow
         android:layout_weight="1"
         android:gravity="center_vertical" >
         <TextView

--- a/demos/transformer/src/main/res/values/strings.xml
+++ b/demos/transformer/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
   <string name="enable_debug_tracing" translatable="false">Enable debug tracing</string>
   <string name="abort_slow_export" translatable="false">Abort slow export</string>
   <string name="produce_fragmented_mp4" translatable="false">Produce Fragmented Mp4</string>
+  <string name="produce_hybrid_mp4" translatable="false">Produce Hybrid Mp4</string>
   <string name="trim" translatable="false">Trim</string>
   <string name="hdr_mode" translatable="false">HDR mode</string>
   <string name="enable_trim_optimization" translatable="false">Enable trim optimization</string>

--- a/libraries/muxer/src/main/java/androidx/media3/muxer/HybridMp4Muxer.java
+++ b/libraries/muxer/src/main/java/androidx/media3/muxer/HybridMp4Muxer.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.muxer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import android.util.SparseArray;
+import androidx.media3.common.Format;
+import androidx.media3.common.Metadata;
+import androidx.media3.common.MimeTypes;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.container.MdtaMetadataEntry;
+import androidx.media3.container.Mp4LocationData;
+import androidx.media3.container.Mp4OrientationData;
+import androidx.media3.container.Mp4TimestampData;
+import androidx.media3.container.XmpData;
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * A muxer for creating a hybrid MP4 file.
+ *
+ * <p>Hybrid MP4 writes fragmented MP4 during recording for crash safety (each fragment is
+ * independently playable), then converts to a standard non-fragmented MP4 on finalization for broad
+ * compatibility.
+ *
+ * <p>Requires a {@link SeekableMuxerOutput} because finalization needs to seek back and overwrite
+ * the placeholder at the start of the file.
+ *
+ * <p>All the operations are performed on the caller thread.
+ *
+ * <p>To create a hybrid MP4 file, the caller must:
+ *
+ * <ul>
+ *   <li>Add tracks using {@link #addTrack(Format)} which will return a track id.
+ *   <li>Use the associated track id when {@linkplain #writeSampleData(int, ByteBuffer, BufferInfo)
+ *       writing samples} for that track.
+ *   <li>{@link #close} the muxer when all data has been written.
+ * </ul>
+ */
+@UnstableApi
+public final class HybridMp4Muxer implements Muxer {
+  /** The default fragment duration. */
+  public static final long DEFAULT_FRAGMENT_DURATION_MS = 2_000;
+
+  /** A builder for {@link HybridMp4Muxer} instances. */
+  public static final class Builder {
+    private final SeekableMuxerOutput seekableMuxerOutput;
+
+    private long fragmentDurationMs;
+    private boolean sampleCopyEnabled;
+
+    /**
+     * Creates a {@link Builder} instance with default values.
+     *
+     * @param seekableMuxerOutput The {@link SeekableMuxerOutput} to write the media data to. This
+     *     output will be automatically closed by the muxer when {@link HybridMp4Muxer#close()} is
+     *     called.
+     */
+    public Builder(SeekableMuxerOutput seekableMuxerOutput) {
+      this.seekableMuxerOutput = seekableMuxerOutput;
+      fragmentDurationMs = DEFAULT_FRAGMENT_DURATION_MS;
+      sampleCopyEnabled = true;
+    }
+
+    /**
+     * Sets the fragment duration (in milliseconds).
+     *
+     * <p>The muxer will attempt to create fragments of the given duration but the actual duration
+     * might be greater depending upon the frequency of sync samples.
+     *
+     * <p>The default value is {@link #DEFAULT_FRAGMENT_DURATION_MS}.
+     */
+    @CanIgnoreReturnValue
+    public Builder setFragmentDurationMs(long fragmentDurationMs) {
+      this.fragmentDurationMs = fragmentDurationMs;
+      return this;
+    }
+
+    /**
+     * Sets whether to enable the sample copy.
+     *
+     * <p>If the sample copy is enabled, {@link #writeSampleData(int, ByteBuffer, BufferInfo)}
+     * copies the input {@link ByteBuffer} and {@link BufferInfo} before it returns, so it is safe
+     * to reuse them immediately. Otherwise, the muxer takes ownership of the {@link ByteBuffer} and
+     * the {@link BufferInfo} and the caller must not modify them.
+     *
+     * <p>The default value is {@code true}.
+     */
+    @CanIgnoreReturnValue
+    public Builder setSampleCopyingEnabled(boolean enabled) {
+      this.sampleCopyEnabled = enabled;
+      return this;
+    }
+
+    /** Builds a {@link HybridMp4Muxer} instance. */
+    public HybridMp4Muxer build() {
+      return new HybridMp4Muxer(seekableMuxerOutput, fragmentDurationMs, sampleCopyEnabled);
+    }
+  }
+
+  /** A list of supported video {@linkplain MimeTypes sample MIME types}. */
+  public static final ImmutableList<String> SUPPORTED_VIDEO_SAMPLE_MIME_TYPES =
+      ImmutableList.of(
+          MimeTypes.VIDEO_AV1,
+          MimeTypes.VIDEO_H263,
+          MimeTypes.VIDEO_H264,
+          MimeTypes.VIDEO_H265,
+          MimeTypes.VIDEO_MP4V,
+          MimeTypes.VIDEO_VP9,
+          MimeTypes.VIDEO_APV,
+          MimeTypes.VIDEO_DOLBY_VISION);
+
+  /** A list of supported audio {@linkplain MimeTypes sample MIME types}. */
+  public static final ImmutableList<String> SUPPORTED_AUDIO_SAMPLE_MIME_TYPES =
+      ImmutableList.of(
+          MimeTypes.AUDIO_AAC,
+          MimeTypes.AUDIO_AMR_NB,
+          MimeTypes.AUDIO_AMR_WB,
+          MimeTypes.AUDIO_OPUS,
+          MimeTypes.AUDIO_VORBIS,
+          MimeTypes.AUDIO_RAW);
+
+  private final HybridMp4Writer hybridMp4Writer;
+  private final MetadataCollector metadataCollector;
+  private final SparseArray<Track> trackIdToTrack;
+
+  private HybridMp4Muxer(
+      SeekableMuxerOutput seekableMuxerOutput,
+      long fragmentDurationMs,
+      boolean sampleCopyEnabled) {
+    metadataCollector = new MetadataCollector();
+    hybridMp4Writer =
+        new HybridMp4Writer(
+            seekableMuxerOutput,
+            metadataCollector,
+            AnnexBToAvccConverter.DEFAULT,
+            fragmentDurationMs,
+            sampleCopyEnabled);
+    trackIdToTrack = new SparseArray<>();
+  }
+
+  @Override
+  public int addTrack(Format format) {
+    Track track = hybridMp4Writer.addTrack(/* sortKey= */ 1, format);
+    trackIdToTrack.append(track.id, track);
+    return track.id;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Samples are written to the disk in batches as fragments. If {@link
+   * Builder#setSampleCopyingEnabled(boolean) sample copying} is disabled, the {@code byteBuffer}
+   * and the {@code bufferInfo} must not be modified after calling this method. Otherwise, they are
+   * copied and it is safe to modify them after this method returns.
+   *
+   * @param trackId The track id for which this sample is being written.
+   * @param byteBuffer The encoded sample.
+   * @param bufferInfo The {@link BufferInfo} related to this sample.
+   * @throws MuxerException If there is any error while writing data to the disk.
+   */
+  @Override
+  public void writeSampleData(int trackId, ByteBuffer byteBuffer, BufferInfo bufferInfo)
+      throws MuxerException {
+    try {
+      hybridMp4Writer.writeSampleData(trackIdToTrack.get(trackId), byteBuffer, bufferInfo);
+    } catch (IOException e) {
+      throw new MuxerException(
+          "Failed to write sample for presentationTimeUs="
+              + bufferInfo.presentationTimeUs
+              + ", size="
+              + bufferInfo.size,
+          e);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>List of supported {@linkplain Metadata.Entry metadata entries}:
+   *
+   * <ul>
+   *   <li>{@link Mp4OrientationData}
+   *   <li>{@link Mp4LocationData}
+   *   <li>{@link Mp4TimestampData}
+   *   <li>{@link MdtaMetadataEntry}: Only {@linkplain MdtaMetadataEntry#TYPE_INDICATOR_STRING
+   *       string type} or {@linkplain MdtaMetadataEntry#TYPE_INDICATOR_FLOAT32 float type} value is
+   *       supported.
+   *   <li>{@link XmpData}
+   * </ul>
+   *
+   * @param metadataEntry The {@linkplain Metadata.Entry metadata}. An {@link
+   *     IllegalArgumentException} is thrown if the {@linkplain Metadata.Entry metadata} is not
+   *     supported.
+   */
+  @Override
+  public void addMetadataEntry(Metadata.Entry metadataEntry) {
+    checkArgument(MuxerUtil.isMetadataSupported(metadataEntry), "Unsupported metadata");
+    metadataCollector.addMetadata(metadataEntry);
+  }
+
+  @Override
+  public void close() throws MuxerException {
+    try {
+      hybridMp4Writer.close();
+    } catch (IOException e) {
+      throw new MuxerException("Failed to close the muxer", e);
+    }
+  }
+}

--- a/libraries/muxer/src/main/java/androidx/media3/muxer/HybridMp4Writer.java
+++ b/libraries/muxer/src/main/java/androidx/media3/muxer/HybridMp4Writer.java
@@ -1,0 +1,461 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.muxer;
+
+import static androidx.media3.muxer.AnnexBUtils.doesSampleContainAnnexBNalUnits;
+import static androidx.media3.muxer.Av1ConfigUtil.createAv1CodecConfigurationRecord;
+import static androidx.media3.muxer.Boxes.BOX_HEADER_SIZE;
+import static androidx.media3.muxer.Boxes.LARGE_SIZE_BOX_HEADER_SIZE;
+import static androidx.media3.muxer.Boxes.MFHD_BOX_CONTENT_SIZE;
+import static androidx.media3.muxer.Boxes.TFHD_BOX_CONTENT_SIZE;
+import static androidx.media3.muxer.Boxes.getTrunBoxContentSize;
+import static androidx.media3.muxer.Mp4Muxer.LAST_SAMPLE_DURATION_BEHAVIOR_SET_FROM_END_OF_STREAM_BUFFER_OR_DUPLICATE_PREVIOUS;
+import static androidx.media3.muxer.MuxerUtil.UNSIGNED_INT_MAX_VALUE;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+import androidx.media3.common.C;
+import androidx.media3.common.Format;
+import androidx.media3.common.MimeTypes;
+import androidx.media3.common.util.Util;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+
+/**
+ * Writes media samples as fragmented MP4 during recording, then converts to a standard
+ * non-fragmented MP4 on finalization.
+ *
+ * <p>This approach provides crash safety (each fragment is independently playable) while producing a
+ * broadly compatible non-fragmented MP4 as the final output.
+ *
+ * <p>The file layout during recording:
+ *
+ * <pre>
+ * [ftyp] [free (placeholder)] [moov (empty, with mvex)] [moof+mdat]* fragments
+ * </pre>
+ *
+ * <p>After finalization:
+ *
+ * <pre>
+ * [ftyp] [mdat (giant, absorbs placeholder + old moov + all fragments)] [moov (full sample tables)]
+ * </pre>
+ */
+/* package */ final class HybridMp4Writer {
+  private final SeekableMuxerOutput muxerOutput;
+  private final MetadataCollector metadataCollector;
+  private final AnnexBToAvccConverter annexBToAvccConverter;
+  private final long fragmentDurationUs;
+  private final boolean sampleCopyEnabled;
+  private final @Mp4Muxer.LastSampleDurationBehavior int lastSampleDurationBehavior;
+  private final List<Track> tracks;
+  private final List<TrackAccumulator> trackAccumulators;
+  private final LinearByteBufferAllocator linearByteBufferAllocator;
+
+  private @MonotonicNonNull Track videoTrack;
+  private int currentFragmentSequenceNumber;
+  private boolean headerCreated;
+  private long minInputPresentationTimeUs;
+  private long maxTrackDurationUs;
+  private int nextTrackId;
+
+  // Position tracking for the hybrid conversion.
+  private long mdatPlaceholderPosition;
+  private long ftypSize;
+
+  /**
+   * Creates an instance.
+   *
+   * @param muxerOutput The {@link SeekableMuxerOutput} to write the data to.
+   * @param metadataCollector A {@link MetadataCollector}.
+   * @param annexBToAvccConverter The {@link AnnexBToAvccConverter}.
+   * @param fragmentDurationMs The fragment duration (in milliseconds).
+   * @param sampleCopyEnabled Whether sample copying is enabled.
+   */
+  public HybridMp4Writer(
+      SeekableMuxerOutput muxerOutput,
+      MetadataCollector metadataCollector,
+      AnnexBToAvccConverter annexBToAvccConverter,
+      long fragmentDurationMs,
+      boolean sampleCopyEnabled) {
+    this.muxerOutput = muxerOutput;
+    this.metadataCollector = metadataCollector;
+    this.annexBToAvccConverter = annexBToAvccConverter;
+    this.fragmentDurationUs = fragmentDurationMs * 1_000;
+    this.sampleCopyEnabled = sampleCopyEnabled;
+    lastSampleDurationBehavior =
+        LAST_SAMPLE_DURATION_BEHAVIOR_SET_FROM_END_OF_STREAM_BUFFER_OR_DUPLICATE_PREVIOUS;
+    tracks = new ArrayList<>();
+    trackAccumulators = new ArrayList<>();
+    minInputPresentationTimeUs = Long.MAX_VALUE;
+    currentFragmentSequenceNumber = 1;
+    linearByteBufferAllocator = new LinearByteBufferAllocator(/* initialCapacity= */ 0);
+  }
+
+  public Track addTrack(int sortKey, Format format) {
+    Track track = new Track(nextTrackId++, format, sampleCopyEnabled);
+    tracks.add(track);
+    trackAccumulators.add(new TrackAccumulator());
+    if (MimeTypes.isVideo(format.sampleMimeType)) {
+      videoTrack = track;
+    }
+    return track;
+  }
+
+  public void writeSampleData(Track track, ByteBuffer byteBuffer, BufferInfo bufferInfo)
+      throws IOException {
+    if (Objects.equals(track.format.sampleMimeType, MimeTypes.VIDEO_AV1)
+        && track.format.initializationData.isEmpty()
+        && track.parsedCsd == null) {
+      track.parsedCsd = createAv1CodecConfigurationRecord(byteBuffer.duplicate());
+    }
+    if (!headerCreated) {
+      createHeader();
+      headerCreated = true;
+    }
+    if (shouldFlushPendingSamples(track, bufferInfo)) {
+      createFragment();
+    }
+    track.writeSampleData(byteBuffer, bufferInfo);
+    BufferInfo firstPendingSample = checkNotNull(track.pendingSamplesBufferInfo.peekFirst());
+    BufferInfo lastPendingSample = checkNotNull(track.pendingSamplesBufferInfo.peekLast());
+    minInputPresentationTimeUs =
+        min(minInputPresentationTimeUs, firstPendingSample.presentationTimeUs);
+    maxTrackDurationUs =
+        max(
+            maxTrackDurationUs,
+            lastPendingSample.presentationTimeUs - firstPendingSample.presentationTimeUs);
+  }
+
+  public void close() throws IOException {
+    try {
+      // Flush any remaining samples as a final fragment.
+      createFragment();
+      // Convert from fragmented to non-fragmented.
+      finalizeAsNonFragmented();
+    } finally {
+      muxerOutput.close();
+    }
+  }
+
+  private void createHeader() throws IOException {
+    // Write ftyp.
+    ByteBuffer ftypBox = Boxes.ftyp();
+    ftypSize = ftypBox.remaining();
+    muxerOutput.setPosition(0L);
+    muxerOutput.write(ftypBox);
+
+    // Write a free box placeholder. After finalization this region (plus the old moov and all
+    // fragments) will be rewritten as a single mdat box.
+    mdatPlaceholderPosition = muxerOutput.getPosition();
+    // Write an 8-byte placeholder (will become the 64-bit mdat header).
+    ByteBuffer placeholder = ByteBuffer.allocate(LARGE_SIZE_BOX_HEADER_SIZE);
+    placeholder.putInt(1); // indicates 64-bit length follows
+    placeholder.put(Util.getUtf8Bytes("free"));
+    placeholder.putLong(LARGE_SIZE_BOX_HEADER_SIZE); // self-referencing size for now
+    placeholder.flip();
+    muxerOutput.write(placeholder);
+
+    // Write the fragmented moov (with mvex) for crash-safe playback.
+    muxerOutput.write(
+        Boxes.moov(
+            tracks, metadataCollector, /* isFragmentedMp4= */ true, lastSampleDurationBehavior));
+  }
+
+  private boolean shouldFlushPendingSamples(Track track, BufferInfo nextSampleBufferInfo) {
+    if (videoTrack != null) {
+      if (track.equals(videoTrack)
+          && track.hadKeyframe
+          && ((nextSampleBufferInfo.flags & C.BUFFER_FLAG_KEY_FRAME) > 0)) {
+        BufferInfo firstPendingSample = checkNotNull(track.pendingSamplesBufferInfo.peekFirst());
+        BufferInfo lastPendingSample = checkNotNull(track.pendingSamplesBufferInfo.peekLast());
+        return lastPendingSample.presentationTimeUs - firstPendingSample.presentationTimeUs
+            >= fragmentDurationUs;
+      }
+      return false;
+    } else {
+      return maxTrackDurationUs >= fragmentDurationUs;
+    }
+  }
+
+  private void createFragment() throws IOException {
+    ImmutableList<ProcessedTrackInfo> trackInfos = processAllTracks();
+    long moofBoxStartPosition = muxerOutput.getSize();
+    ImmutableList<ByteBuffer> trafBoxes = createTrafBoxes(trackInfos, moofBoxStartPosition);
+    if (trafBoxes.isEmpty()) {
+      return;
+    }
+    muxerOutput.setPosition(moofBoxStartPosition);
+    muxerOutput.write(Boxes.moof(Boxes.mfhd(currentFragmentSequenceNumber), trafBoxes));
+
+    // Track the data offset for each track's samples in this fragment.
+    long mdatDataStart = muxerOutput.getPosition() + 8; // after mdat header
+    writeMdatBox(trackInfos);
+
+    // Accumulate sample metadata for the final non-fragmented moov.
+    accumulateFragmentSamples(trackInfos, mdatDataStart);
+
+    currentFragmentSequenceNumber++;
+    maxTrackDurationUs = 0;
+  }
+
+  private void accumulateFragmentSamples(
+      List<ProcessedTrackInfo> trackInfos, long mdatDataStart) {
+    long currentOffset = mdatDataStart;
+    for (int i = 0; i < trackInfos.size(); i++) {
+      ProcessedTrackInfo info = trackInfos.get(i);
+      int trackIndex = info.trackId - 1;
+      TrackAccumulator accumulator = trackAccumulators.get(trackIndex);
+
+      // Record a chunk for this track in this fragment.
+      accumulator.chunkOffsets.add(currentOffset);
+      accumulator.chunkSampleCounts.add(info.pendingSamplesMetadata.size());
+
+      for (int j = 0; j < info.pendingSamplesMetadata.size(); j++) {
+        BufferInfo bufferInfo = info.pendingSamplesBufferInfo.get(j);
+        accumulator.writtenSamples.add(bufferInfo);
+      }
+      currentOffset += info.totalSamplesSize;
+    }
+  }
+
+  private void finalizeAsNonFragmented() throws IOException {
+    if (!headerCreated) {
+      return;
+    }
+
+    // Transfer accumulated sample metadata into the Track objects so that Boxes.moov() can
+    // build complete sample tables (stco, stsz, stts, stss, ctts).
+    for (int i = 0; i < tracks.size(); i++) {
+      Track track = tracks.get(i);
+      TrackAccumulator accumulator = trackAccumulators.get(i);
+      track.writtenSamples.addAll(accumulator.writtenSamples);
+      track.writtenChunkOffsets.addAll(accumulator.chunkOffsets);
+      track.writtenChunkSampleCounts.addAll(accumulator.chunkSampleCounts);
+    }
+
+    // Write the full non-fragmented moov at the end of the file.
+    long moovPosition = muxerOutput.getSize();
+    muxerOutput.setPosition(moovPosition);
+    ByteBuffer moovBox =
+        Boxes.moov(
+            tracks, metadataCollector, /* isFragmentedMp4= */ false, lastSampleDurationBehavior);
+    muxerOutput.write(moovBox);
+
+    // Now overwrite the placeholder to turn the region [placeholder .. end-of-fragments] into a
+    // single mdat box. The mdat absorbs the old fragmented moov and all moof+mdat fragments.
+    long mdatSize = moovPosition - mdatPlaceholderPosition;
+    muxerOutput.setPosition(mdatPlaceholderPosition);
+    ByteBuffer mdatHeader = ByteBuffer.allocate(LARGE_SIZE_BOX_HEADER_SIZE);
+    mdatHeader.putInt(1); // indicates 64-bit length
+    mdatHeader.put(Util.getUtf8Bytes("mdat"));
+    mdatHeader.putLong(mdatSize);
+    mdatHeader.flip();
+    muxerOutput.write(mdatHeader);
+  }
+
+  // Fragment writing helpers — mirrored from FragmentedMp4Writer.
+
+  private static ImmutableList<ByteBuffer> createTrafBoxes(
+      List<ProcessedTrackInfo> trackInfos, long moofBoxStartPosition) {
+    ImmutableList.Builder<ByteBuffer> trafBoxes = new ImmutableList.Builder<>();
+    int moofBoxSize = calculateMoofBoxSize(trackInfos);
+    int mdatBoxHeaderSize = BOX_HEADER_SIZE;
+    int dataOffset = moofBoxSize + mdatBoxHeaderSize;
+    for (int i = 0; i < trackInfos.size(); i++) {
+      ProcessedTrackInfo currentTrackInfo = trackInfos.get(i);
+      trafBoxes.add(
+          Boxes.traf(
+              Boxes.tfhd(currentTrackInfo.trackId, /* baseDataOffset= */ moofBoxStartPosition),
+              Boxes.trun(
+                  currentTrackInfo.trackFormat,
+                  currentTrackInfo.pendingSamplesMetadata,
+                  dataOffset,
+                  currentTrackInfo.hasBFrame)));
+      dataOffset += currentTrackInfo.totalSamplesSize;
+    }
+    return trafBoxes.build();
+  }
+
+  private static int calculateMoofBoxSize(List<ProcessedTrackInfo> trackInfos) {
+    int moofBoxHeaderSize = BOX_HEADER_SIZE;
+    int mfhdBoxSize = BOX_HEADER_SIZE + MFHD_BOX_CONTENT_SIZE;
+    int trafBoxHeaderSize = BOX_HEADER_SIZE;
+    int tfhdBoxSize = BOX_HEADER_SIZE + TFHD_BOX_CONTENT_SIZE;
+    int trunBoxHeaderFixedSize = BOX_HEADER_SIZE;
+    int trafBoxesSize = 0;
+    for (int i = 0; i < trackInfos.size(); i++) {
+      ProcessedTrackInfo trackInfo = trackInfos.get(i);
+      int trunBoxSize =
+          trunBoxHeaderFixedSize
+              + getTrunBoxContentSize(trackInfo.pendingSamplesMetadata.size(), trackInfo.hasBFrame);
+      trafBoxesSize += trafBoxHeaderSize + tfhdBoxSize + trunBoxSize;
+    }
+    return moofBoxHeaderSize + mfhdBoxSize + trafBoxesSize;
+  }
+
+  private void writeMdatBox(List<ProcessedTrackInfo> trackInfos) throws IOException {
+    long totalNumBytesSamples = 0;
+    for (int trackInfoIndex = 0; trackInfoIndex < trackInfos.size(); trackInfoIndex++) {
+      ProcessedTrackInfo currentTrackInfo = trackInfos.get(trackInfoIndex);
+      for (int sampleIndex = 0;
+          sampleIndex < currentTrackInfo.pendingSamplesByteBuffer.size();
+          sampleIndex++) {
+        totalNumBytesSamples +=
+            currentTrackInfo.pendingSamplesByteBuffer.get(sampleIndex).remaining();
+      }
+    }
+
+    int mdatHeaderSize = 8;
+    ByteBuffer header = ByteBuffer.allocate(mdatHeaderSize);
+    long totalMdatSize = mdatHeaderSize + totalNumBytesSamples;
+
+    checkArgument(
+        totalMdatSize <= UNSIGNED_INT_MAX_VALUE,
+        "Only 32-bit long mdat size supported in the fragmented MP4");
+    header.putInt((int) totalMdatSize);
+    header.put(Util.getUtf8Bytes("mdat"));
+    header.flip();
+    muxerOutput.write(header);
+
+    for (int trackInfoIndex = 0; trackInfoIndex < trackInfos.size(); trackInfoIndex++) {
+      ProcessedTrackInfo currentTrackInfo = trackInfos.get(trackInfoIndex);
+      for (int sampleIndex = 0;
+          sampleIndex < currentTrackInfo.pendingSamplesByteBuffer.size();
+          sampleIndex++) {
+        muxerOutput.write(currentTrackInfo.pendingSamplesByteBuffer.get(sampleIndex));
+      }
+    }
+    linearByteBufferAllocator.reset();
+  }
+
+  private ImmutableList<ProcessedTrackInfo> processAllTracks() {
+    ImmutableList.Builder<ProcessedTrackInfo> trackInfos = new ImmutableList.Builder<>();
+    for (int i = 0; i < tracks.size(); i++) {
+      if (!tracks.get(i).pendingSamplesBufferInfo.isEmpty()) {
+        trackInfos.add(processTrack(/* trackId= */ i + 1, tracks.get(i)));
+      }
+    }
+    return trackInfos.build();
+  }
+
+  private ProcessedTrackInfo processTrack(int trackId, Track track) {
+    checkState(track.pendingSamplesByteBuffer.size() == track.pendingSamplesBufferInfo.size());
+
+    ImmutableList.Builder<ByteBuffer> pendingSamplesByteBuffer = new ImmutableList.Builder<>();
+    ImmutableList.Builder<BufferInfo> pendingSamplesBufferInfoBuilder =
+        new ImmutableList.Builder<>();
+    if (doesSampleContainAnnexBNalUnits(track.format)) {
+      while (!track.pendingSamplesByteBuffer.isEmpty()) {
+        ByteBuffer currentSampleByteBuffer = track.pendingSamplesByteBuffer.removeFirst();
+        currentSampleByteBuffer =
+            annexBToAvccConverter.process(currentSampleByteBuffer, linearByteBufferAllocator);
+        pendingSamplesByteBuffer.add(currentSampleByteBuffer);
+        BufferInfo currentSampleBufferInfo = track.pendingSamplesBufferInfo.removeFirst();
+        currentSampleBufferInfo =
+            new BufferInfo(
+                currentSampleBufferInfo.presentationTimeUs,
+                currentSampleByteBuffer.remaining(),
+                currentSampleBufferInfo.flags);
+        pendingSamplesBufferInfoBuilder.add(currentSampleBufferInfo);
+      }
+    } else {
+      pendingSamplesByteBuffer.addAll(track.pendingSamplesByteBuffer);
+      track.pendingSamplesByteBuffer.clear();
+      pendingSamplesBufferInfoBuilder.addAll(track.pendingSamplesBufferInfo);
+      track.pendingSamplesBufferInfo.clear();
+    }
+
+    boolean hasBFrame = false;
+    ImmutableList<BufferInfo> pendingSamplesBufferInfo = pendingSamplesBufferInfoBuilder.build();
+    List<Integer> sampleDurations =
+        Boxes.convertPresentationTimestampsToDurationsVu(
+            pendingSamplesBufferInfo,
+            track.videoUnitTimebase(),
+            LAST_SAMPLE_DURATION_BEHAVIOR_SET_FROM_END_OF_STREAM_BUFFER_OR_DUPLICATE_PREVIOUS,
+            track.endOfStreamTimestampUs);
+
+    List<Integer> sampleCompositionTimeOffsets =
+        Boxes.calculateSampleCompositionTimeOffsets(
+            pendingSamplesBufferInfo, sampleDurations, track.videoUnitTimebase());
+    if (!sampleCompositionTimeOffsets.isEmpty()) {
+      hasBFrame = true;
+    }
+
+    ImmutableList.Builder<FragmentedMp4Writer.SampleMetadata> pendingSamplesMetadata =
+        new ImmutableList.Builder<>();
+    int totalSamplesSize = 0;
+    for (int i = 0; i < pendingSamplesBufferInfo.size(); i++) {
+      totalSamplesSize += pendingSamplesBufferInfo.get(i).size;
+      pendingSamplesMetadata.add(
+          new FragmentedMp4Writer.SampleMetadata(
+              sampleDurations.get(i),
+              pendingSamplesBufferInfo.get(i).size,
+              pendingSamplesBufferInfo.get(i).flags,
+              hasBFrame ? sampleCompositionTimeOffsets.get(i) : 0));
+    }
+
+    return new ProcessedTrackInfo(
+        trackId,
+        track.format,
+        totalSamplesSize,
+        hasBFrame,
+        pendingSamplesByteBuffer.build(),
+        pendingSamplesBufferInfo,
+        pendingSamplesMetadata.build());
+  }
+
+  /** Accumulates sample metadata across fragments for the final non-fragmented moov. */
+  private static final class TrackAccumulator {
+    final List<BufferInfo> writtenSamples = new ArrayList<>();
+    final List<Long> chunkOffsets = new ArrayList<>();
+    final List<Integer> chunkSampleCounts = new ArrayList<>();
+  }
+
+  private static class ProcessedTrackInfo {
+    public final int trackId;
+    public final Format trackFormat;
+    public final int totalSamplesSize;
+    public final boolean hasBFrame;
+    public final ImmutableList<ByteBuffer> pendingSamplesByteBuffer;
+    public final ImmutableList<BufferInfo> pendingSamplesBufferInfo;
+    public final ImmutableList<FragmentedMp4Writer.SampleMetadata> pendingSamplesMetadata;
+
+    public ProcessedTrackInfo(
+        int trackId,
+        Format trackFormat,
+        int totalSamplesSize,
+        boolean hasBFrame,
+        ImmutableList<ByteBuffer> pendingSamplesByteBuffer,
+        ImmutableList<BufferInfo> pendingSamplesBufferInfo,
+        ImmutableList<FragmentedMp4Writer.SampleMetadata> pendingSamplesMetadata) {
+      this.trackId = trackId;
+      this.trackFormat = trackFormat;
+      this.totalSamplesSize = totalSamplesSize;
+      this.hasBFrame = hasBFrame;
+      this.pendingSamplesByteBuffer = pendingSamplesByteBuffer;
+      this.pendingSamplesBufferInfo = pendingSamplesBufferInfo;
+      this.pendingSamplesMetadata = pendingSamplesMetadata;
+    }
+  }
+}

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/HybridMp4MuxerEndToEndTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/HybridMp4MuxerEndToEndTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.muxer;
+
+import static androidx.media3.muxer.MuxerTestUtil.feedInputDataToMuxer;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.truth.Truth.assertThat;
+
+import android.content.Context;
+import androidx.media3.container.Mp4TimestampData;
+import androidx.media3.extractor.mp4.FragmentedMp4Extractor;
+import androidx.media3.extractor.mp4.Mp4Extractor;
+import androidx.media3.test.utils.DumpFileAsserts;
+import androidx.media3.test.utils.FakeExtractorOutput;
+import androidx.media3.test.utils.TestUtil;
+import androidx.test.core.app.ApplicationProvider;
+import com.google.common.collect.ImmutableList;
+import java.io.FileOutputStream;
+import java.nio.ByteBuffer;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameter;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
+
+/**
+ * End to end tests for {@link HybridMp4Muxer}.
+ *
+ * <p>Hybrid MP4 writes fragmented MP4 during recording (crash-safe) and converts to a standard
+ * non-fragmented MP4 on finalization. The final output should be readable by {@link Mp4Extractor}
+ * and produce the same sample data as the regular {@link Mp4Muxer}.
+ */
+@RunWith(ParameterizedRobolectricTestRunner.class)
+public class HybridMp4MuxerEndToEndTest {
+  // Video Codecs
+  private static final String H264_MP4 = "mp4/sample_no_bframes.mp4";
+  private static final String H264_WITH_NON_REFERENCE_B_FRAMES_MP4 =
+      "mp4/bbb_800x640_768kbps_30fps_avc_non_reference_3b.mp4";
+  private static final String H264_WITH_PYRAMID_B_FRAMES_MP4 =
+      "mp4/bbb_800x640_768kbps_30fps_avc_pyramid_3b.mp4";
+  private static final String H265_HDR10_MP4 = "mp4/hdr10-720p.mp4";
+  private static final String AV1_MP4 = "mp4/sample_av1.mp4";
+  // Audio Codecs
+  private static final String AUDIO_ONLY_MP4 = "mp4/sample_audio_only_15s.mp4";
+
+  public static final String MEDIA_ASSET_DIRECTORY = "asset:///media/";
+
+  @Parameters(name = "{0}")
+  public static ImmutableList<String> mediaSamples() {
+    return ImmutableList.of(
+        H264_MP4,
+        H264_WITH_NON_REFERENCE_B_FRAMES_MP4,
+        H264_WITH_PYRAMID_B_FRAMES_MP4,
+        H265_HDR10_MP4,
+        AV1_MP4,
+        AUDIO_ONLY_MP4);
+  }
+
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Parameter public @MonotonicNonNull String inputFile;
+
+  private final Context context = ApplicationProvider.getApplicationContext();
+
+  @Test
+  public void createHybridMp4File_finalized_isReadableByMp4Extractor() throws Exception {
+    String outputPath = temporaryFolder.newFile("hybrid_output.mp4").getPath();
+
+    try (HybridMp4Muxer hybridMuxer =
+        new HybridMp4Muxer.Builder(SeekableMuxerOutput.of(new FileOutputStream(outputPath)))
+            .build()) {
+      hybridMuxer.addMetadataEntry(
+          new Mp4TimestampData(
+              /* creationTimestampSeconds= */ 100_000_000L,
+              /* modificationTimestampSeconds= */ 500_000_000L));
+      feedInputDataToMuxer(
+          context, hybridMuxer, checkNotNull(MEDIA_ASSET_DIRECTORY + inputFile));
+    }
+
+    // The finalized hybrid output should be readable as a non-fragmented MP4.
+    FakeExtractorOutput extractorOutput =
+        TestUtil.extractAllSamplesFromFilePath(
+            new Mp4Extractor(), checkNotNull(outputPath));
+    // Verify tracks were extracted.
+    assertThat(extractorOutput.numberOfTracks).isGreaterThan(0);
+  }
+
+  @Test
+  public void createHybridMp4File_finalized_boxStructureIsNonFragmented() throws Exception {
+    String outputPath = temporaryFolder.newFile("hybrid_output.mp4").getPath();
+
+    try (HybridMp4Muxer hybridMuxer =
+        new HybridMp4Muxer.Builder(SeekableMuxerOutput.of(new FileOutputStream(outputPath)))
+            .build()) {
+      hybridMuxer.addMetadataEntry(
+          new Mp4TimestampData(
+              /* creationTimestampSeconds= */ 100_000_000L,
+              /* modificationTimestampSeconds= */ 500_000_000L));
+      feedInputDataToMuxer(
+          context, hybridMuxer, checkNotNull(MEDIA_ASSET_DIRECTORY + inputFile));
+    }
+
+    byte[] outputBytes = TestUtil.getByteArrayFromFilePath(checkNotNull(outputPath));
+    ByteBuffer buffer = ByteBuffer.wrap(outputBytes);
+
+    // After finalization, the file should contain a top-level moov box (non-fragmented)
+    // and should NOT contain any moof boxes at the top level.
+    boolean foundMoov = false;
+    boolean foundMoof = false;
+    while (buffer.remaining() >= 8) {
+      long boxSize = buffer.getInt() & 0xFFFFFFFFL;
+      int boxType = buffer.getInt();
+      if (boxSize == 1 && buffer.remaining() >= 8) {
+        // 64-bit extended size.
+        boxSize = buffer.getLong();
+        if (boxType == 0x6D6F6F76) { // "moov"
+          foundMoov = true;
+        }
+        if (boxType == 0x6D6F6F66) { // "moof"
+          foundMoof = true;
+        }
+        if (boxSize < 16 || boxSize - 16 > buffer.remaining()) {
+          break;
+        }
+        buffer.position(buffer.position() + (int) (boxSize - 16));
+      } else {
+        if (boxType == 0x6D6F6F76) { // "moov"
+          foundMoov = true;
+        }
+        if (boxType == 0x6D6F6F66) { // "moof"
+          foundMoof = true;
+        }
+        if (boxSize < 8 || boxSize - 8 > buffer.remaining()) {
+          break;
+        }
+        buffer.position(buffer.position() + (int) (boxSize - 8));
+      }
+    }
+
+    assertThat(foundMoov).isTrue();
+    // In a properly finalized hybrid MP4, moof boxes should be absorbed into the mdat.
+    assertThat(foundMoof).isFalse();
+  }
+
+  @Test
+  public void createHybridMp4File_notClosed_isPlayableAsFragmentedMp4() throws Exception {
+    String outputPath = temporaryFolder.newFile("hybrid_output.mp4").getPath();
+
+    // Write data but do NOT close — simulating a crash mid-recording.
+    SeekableMuxerOutput muxerOutput = SeekableMuxerOutput.of(new FileOutputStream(outputPath));
+    HybridMp4Muxer hybridMuxer = new HybridMp4Muxer.Builder(muxerOutput).build();
+    hybridMuxer.addMetadataEntry(
+        new Mp4TimestampData(
+            /* creationTimestampSeconds= */ 100_000_000L,
+            /* modificationTimestampSeconds= */ 500_000_000L));
+    feedInputDataToMuxer(
+        context, hybridMuxer, checkNotNull(MEDIA_ASSET_DIRECTORY + inputFile));
+    // Intentionally not calling hybridMuxer.close().
+    // Flush to disk without finalizing.
+    muxerOutput.close();
+
+    // The file should still be playable as fragmented MP4 because the ftyp, fragmented moov
+    // (with mvex), and moof+mdat fragments were written during recording.
+    FakeExtractorOutput extractorOutput =
+        TestUtil.extractAllSamplesFromFilePath(
+            new FragmentedMp4Extractor(), checkNotNull(outputPath));
+    assertThat(extractorOutput.numberOfTracks).isGreaterThan(0);
+  }
+}

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/InAppHybridMp4Muxer.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/InAppHybridMp4Muxer.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.transformer;
+
+import androidx.media3.common.C;
+import androidx.media3.common.Format;
+import androidx.media3.common.MediaLibraryInfo;
+import androidx.media3.common.Metadata;
+import androidx.media3.common.MimeTypes;
+import androidx.media3.common.util.Log;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.container.Mp4OrientationData;
+import androidx.media3.muxer.BufferInfo;
+import androidx.media3.muxer.HybridMp4Muxer;
+import androidx.media3.muxer.Muxer;
+import androidx.media3.muxer.MuxerException;
+import androidx.media3.muxer.MuxerUtil;
+import androidx.media3.muxer.SeekableMuxerOutput;
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.nio.ByteBuffer;
+import java.util.Locale;
+
+/** {@link Muxer} implementation that uses a {@link HybridMp4Muxer}. */
+@UnstableApi
+public final class InAppHybridMp4Muxer implements Muxer {
+  /** {@link Muxer.Factory} for {@link InAppHybridMp4Muxer}. */
+  public static final class Factory implements Muxer.Factory {
+    private final long fragmentDurationMs;
+
+    private long videoDurationUs;
+
+    /** Creates an instance with default values. */
+    public Factory() {
+      this(C.TIME_UNSET);
+    }
+
+    /**
+     * Creates an instance.
+     *
+     * @param fragmentDurationMs The fragment duration (in milliseconds).
+     */
+    public Factory(long fragmentDurationMs) {
+      this.fragmentDurationMs = fragmentDurationMs;
+      videoDurationUs = C.TIME_UNSET;
+    }
+
+    /**
+     * Sets the duration of the video track (in microseconds) in the output.
+     *
+     * <p>Only the duration of the last sample is adjusted to achieve the given duration. Duration
+     * of the other samples remains unchanged.
+     *
+     * <p>The default is {@link C#TIME_UNSET} to not set any duration in the output. In this case
+     * the video track duration is determined by the samples written to it and the duration of the
+     * last sample will be same as that of the sample before that.
+     *
+     * @param videoDurationUs The duration of the video track (in microseconds) in the output, or
+     *     {@link C#TIME_UNSET} to not set any duration. Only applicable when a video track is
+     *     {@linkplain #addTrack(Format) added}.
+     * @return This factory.
+     */
+    @CanIgnoreReturnValue
+    public Factory setVideoDurationUs(long videoDurationUs) {
+      this.videoDurationUs = videoDurationUs;
+      return this;
+    }
+
+    @Override
+    public InAppHybridMp4Muxer create(String path) throws MuxerException {
+      FileOutputStream outputStream;
+      try {
+        outputStream = new FileOutputStream(path);
+      } catch (FileNotFoundException e) {
+        throw new MuxerException("Error creating file output stream", e);
+      }
+
+      HybridMp4Muxer.Builder builder =
+          new HybridMp4Muxer.Builder(SeekableMuxerOutput.of(outputStream));
+      if (fragmentDurationMs != C.TIME_UNSET) {
+        builder.setFragmentDurationMs(fragmentDurationMs);
+      }
+      HybridMp4Muxer muxer = builder.build();
+
+      return new InAppHybridMp4Muxer(muxer, videoDurationUs);
+    }
+
+    @Override
+    public ImmutableList<String> getSupportedSampleMimeTypes(@C.TrackType int trackType) {
+      if (trackType == C.TRACK_TYPE_VIDEO) {
+        return HybridMp4Muxer.SUPPORTED_VIDEO_SAMPLE_MIME_TYPES;
+      } else if (trackType == C.TRACK_TYPE_AUDIO) {
+        return HybridMp4Muxer.SUPPORTED_AUDIO_SAMPLE_MIME_TYPES;
+      }
+      return ImmutableList.of();
+    }
+  }
+
+  public static final String MUXER_NAME =
+      "androidx.media3:media3-muxer:" + MediaLibraryInfo.VERSION;
+
+  private static final String TAG = "InAppHybridMp4Muxer";
+  private static final int TRACK_ID_UNSET = -1;
+
+  private final HybridMp4Muxer muxer;
+  private final long videoDurationUs;
+
+  private int videoTrackId;
+
+  private InAppHybridMp4Muxer(HybridMp4Muxer muxer, long videoDurationUs) {
+    this.muxer = muxer;
+    this.videoDurationUs = videoDurationUs;
+    videoTrackId = TRACK_ID_UNSET;
+  }
+
+  @Override
+  public int addTrack(Format format) {
+    int trackId = muxer.addTrack(format);
+    if (MimeTypes.isVideo(format.sampleMimeType)) {
+      muxer.addMetadataEntry(new Mp4OrientationData(format.rotationDegrees));
+      videoTrackId = trackId;
+    }
+    return trackId;
+  }
+
+  @Override
+  public void writeSampleData(int trackId, ByteBuffer byteBuffer, BufferInfo bufferInfo)
+      throws MuxerException {
+    if (videoDurationUs != C.TIME_UNSET
+        && trackId == videoTrackId
+        && bufferInfo.presentationTimeUs > videoDurationUs) {
+      Log.w(
+          TAG,
+          String.format(
+              Locale.US,
+              "Skipped sample with presentation time (%d) > video duration (%d)",
+              bufferInfo.presentationTimeUs,
+              videoDurationUs));
+      return;
+    }
+    muxer.writeSampleData(trackId, byteBuffer, bufferInfo);
+  }
+
+  @Override
+  public void addMetadataEntry(Metadata.Entry metadataEntry) {
+    if (MuxerUtil.isMetadataSupported(metadataEntry)) {
+      muxer.addMetadataEntry(metadataEntry);
+    }
+  }
+
+  @Override
+  public void close() throws MuxerException {
+    if (videoDurationUs != C.TIME_UNSET && videoTrackId != TRACK_ID_UNSET) {
+      BufferInfo bufferInfo =
+          new BufferInfo(
+              /* presentationTimeUs= */ videoDurationUs,
+              /* size= */ 0,
+              C.BUFFER_FLAG_END_OF_STREAM);
+      writeSampleData(videoTrackId, ByteBuffer.allocateDirect(0), bufferInfo);
+    }
+    muxer.close();
+  }
+}


### PR DESCRIPTION
# Summary:
Hybrid MP4 support involves ending up with a normal, non-fragmented file on happy path cases, while still keeping the file readable via its interim state as fragmented mp4 allowing for crash/fault tolerance.

See [Writing an MP4 Muxer for fun and profit](https://obsproject.com/blog/obs-studio-hybrid-mp4) for more details.

# Components:
* `HybridMp4Muxer / HybridMp4Writer` are implementations of hybrid MP4 melding the current `FragmentedMp4Muxer` with some bookkeeping to convert it at the end.
* `HybridMp4MuxerEndToEndTest` which adds tests to the fault tolerance, as well as assertions of having no output. 
* TransformerDemo: Integrates this logic into the TransformerDemo. To test one can transform a large file and in realtime do 

```
adb pull /sdcard/Android/data/androidx.media3.demo.transformer/cache/

❯ mp4dump /Users/anthonybajoua/cache/transformer-output-3879342.mp4 | grep sidx

❯ mp4dump /Users/anthonybajoua/cache/transformer-output-3879342.mp4 | grep moov
[moov] size=8+810206
```


## Credit
Inspired by [FFmpeg-devel](https://ffmpeg.org/pipermail/ffmpeg-devel/2024-June/329979.html) ingesting all of the optimizations from FFmpeg 8.1