### PR TITLE
Bugfix: Dolby Vision Profile 10.0 playback artifacts issue

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -1813,7 +1813,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
             || Objects.equals(newFormat.sampleMimeType, MimeTypes.VIDEO_VP9)
             || (Objects.equals(newFormat.sampleMimeType, MimeTypes.VIDEO_DOLBY_VISION)
                 && Objects.equals(
-                    MediaCodecUtil.getAlternativeCodecMimeType(newFormat), MimeTypes.VIDEO_AV1)))
+                    MediaCodecUtil.getDolbyVisionBlMimeType(newFormat), MimeTypes.VIDEO_AV1)))
         && !newFormat.initializationData.isEmpty()) {
       newFormat = newFormat.buildUpon().setInitializationData(null).build();
     }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
@@ -366,6 +366,34 @@ public final class MediaCodecUtil {
   }
 
   /**
+   * Returns a Dolby Vision base layer codec MIME type of the provided {@link Format}.
+   *
+   * @param format The media format.
+   * @return A Dolby Vision base layer MIME type, or null if a Dolby Vision profile is not
+   *     identified.
+   */
+  @Nullable
+  public static String getDolbyVisionBlMimeType(Format format) {
+
+    if (MimeTypes.VIDEO_DOLBY_VISION.equals(format.sampleMimeType)) {
+      @Nullable Pair<Integer, Integer> codecProfileAndLevel = getCodecProfileAndLevel(format);
+      if (codecProfileAndLevel != null) {
+        int profile = codecProfileAndLevel.first;
+        if (profile == CodecProfileLevel.DolbyVisionProfileDvheDtr            // profile 4
+            || profile == CodecProfileLevel.DolbyVisionProfileDvheStn         // profile 5
+            || profile == CodecProfileLevel.DolbyVisionProfileDvheSt) {       // profile 8
+          return MimeTypes.VIDEO_H265;
+        } else if (profile == CodecProfileLevel.DolbyVisionProfileDvavSe) {   // profile 9
+          return MimeTypes.VIDEO_H264;
+        } else if (profile == CodecProfileLevel.DolbyVisionProfileDvav110) {  // profile 10
+          return MimeTypes.VIDEO_AV1;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
    * Returns an alternative codec MIME type (besides the default {@link Format#sampleMimeType}) that
    * can be used to decode samples of the provided {@link Format}.
    *


### PR DESCRIPTION
This issue was triggered because [this PR](https://github.com/androidx/media/pull/2830) was not merged correctly.

The issue arises when all four of the following conditions are met simultaneously:

1. The content is Dolby Vision Profile 10.0
2. A resolution switch occurs during playback due to network bandwidth changes (e.g., 1080p → 720p)
3. Device integrates Dolby Vision decoder which supports Dolby Vision profile 10.x 
4. The device’s AV1 decoder fails to properly handle AV1 Codec-Specific Data (CSD)

getAlternativeCodecMimeType() returns backward compatible codec mime type. For example, For Dolby Vision profile 10.0, it returns null since DV P10.0 is not backward compatible with AV1. Both DV P10.1 and P10.4 will return AV1.

getDolbyVisionBlMimeType() returns base layer of Dolby Vision stream. For example, for all Dolby Vision profile 10.x (10.0, 10.1, 10.4), it will return AV1 since all of them are AV1 based. This method doesn't consider backward compatibility.

Without this patch, during resolution switch of DV P10.0 playback, MediaCodecRenderer::onInputFormatChanged() is called, MediaCodecUtil.getAlternativeCodecMimeType(newFormat) returns null so that CSD is still sent to DV decoder. DV decoder forwards this CSD to AV1 decoder then results in decoding failure.

With this patch, MediaCodecUtil.getDolbyVisionBlMimeType(newFormat) returns video/av1, which results in CSD is set to null. Then everything is OK since AV1 decoder will not receive CSD.

The good news is there is no DV P10.0 content in market by now. But we had better fix it ASAP.