### PR TITLE
Update DefaultAudioSink.java

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -757,8 +757,8 @@ public final class DefaultAudioSink implements AudioSink {
         pipelineProcessors.add(toFloatPcmAudioProcessor);
       } else {
         pipelineProcessors.add(toInt16PcmAudioProcessor);
-        pipelineProcessors.add(audioProcessorChain.getAudioProcessors());
       }
+      pipelineProcessors.add(audioProcessorChain.getAudioProcessors());
       audioProcessingPipeline = new AudioProcessingPipeline(pipelineProcessors.build());
 
       // If the underlying processors of the new pipeline are the same as the existing pipeline,


### PR DESCRIPTION
Hello:
In my application, I implemented AudioProcessors that allow processing audio encoded in all encoding types supported by Android, including Float. Why can't they be implemented if the audio encoding type is Float? With this change, AudioProcessors can be used even if the audio is of type Float.