### PR TITLE
Fix HEVC fallback for Dolby Vision Profile 7 to preserve HDR10+ metadata

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
@@ -382,16 +382,17 @@ public final class MediaCodecUtil {
     }
     if (MimeTypes.VIDEO_DOLBY_VISION.equals(format.sampleMimeType)) {
       // H.264/AVC, H.265/HEVC or AV1 decoders can decode the base layer of some DV profiles.
-      // This can't be done for profile CodecProfileLevel.DolbyVisionProfileDvheStn and profile
-      // CodecProfileLevel.DolbyVisionProfileDvheDtb because the first one is not backward
-      // compatible and the second one is deprecated and is not always backward compatible.
+      // This can't be done for profile CodecProfileLevel.DolbyVisionProfileDvheStn because it is
+      // not backward compatible. Profile DolbyVisionProfileDvheDtb (profile 7) is deprecated but
+      // its base layer is always backward-compatible HEVC Main 10, so HEVC fallback is safe.
       @Nullable
       MediaCodecProfileAndLevel codecProfileAndLevel =
           CodecSpecificDataUtil.getMediaCodecProfileAndLevel(format);
       if (codecProfileAndLevel != null && codecProfileAndLevel.isSupportableByMediaCodec()) {
         int profile = codecProfileAndLevel.getProfile();
         if (profile == CodecProfileLevel.DolbyVisionProfileDvheDtr
-            || profile == CodecProfileLevel.DolbyVisionProfileDvheSt) {
+            || profile == CodecProfileLevel.DolbyVisionProfileDvheSt
+            || profile == CodecProfileLevel.DolbyVisionProfileDvheDtb) {
           return MimeTypes.VIDEO_H265;
         } else if (profile == CodecProfileLevel.DolbyVisionProfileDvavSe) {
           return MimeTypes.VIDEO_H264;

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/video/MediaCodecVideoRendererTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/video/MediaCodecVideoRendererTest.java
@@ -4445,6 +4445,11 @@ public class MediaCodecVideoRendererTest {
             .setSampleMimeType(MimeTypes.VIDEO_DOLBY_VISION)
             .setCodecs("dvhe.04.01")
             .build();
+    Format formatDvheDtbFallbackToH265 =
+        new Format.Builder()
+            .setSampleMimeType(MimeTypes.VIDEO_DOLBY_VISION)
+            .setCodecs("dvhe.07.01")
+            .build();
     Format formatDvheStFallbackToH265 =
         new Format.Builder()
             .setSampleMimeType(MimeTypes.VIDEO_DOLBY_VISION)
@@ -4556,6 +4561,8 @@ public class MediaCodecVideoRendererTest {
     @Capabilities
     int capabilitiesDvheDtrFallbackToH265 = renderer.supportsFormat(formatDvheDtrFallbackToH265);
     @Capabilities
+    int capabilitiesDvheDtbFallbackToH265 = renderer.supportsFormat(formatDvheDtbFallbackToH265);
+    @Capabilities
     int capabilitiesDvheStFallbackToH265 = renderer.supportsFormat(formatDvheStFallbackToH265);
     @Capabilities
     int capabilitiesDvavSeFallbackToH264 = renderer.supportsFormat(formatDvavSeFallbackToH264);
@@ -4567,6 +4574,8 @@ public class MediaCodecVideoRendererTest {
     int capabilitiesNoFallbackPossible = renderer.supportsFormat(formatNoFallbackPossible);
 
     assertThat(RendererCapabilities.getFormatSupport(capabilitiesDvheDtrFallbackToH265))
+        .isEqualTo(C.FORMAT_HANDLED);
+    assertThat(RendererCapabilities.getFormatSupport(capabilitiesDvheDtbFallbackToH265))
         .isEqualTo(C.FORMAT_HANDLED);
     assertThat(RendererCapabilities.getFormatSupport(capabilitiesDvheStFallbackToH265))
         .isEqualTo(C.FORMAT_HANDLED);


### PR DESCRIPTION
On devices/displays that do not support Dolby Vision, playback of DV Profile 7 (dvhe.07) hybrid remux files containing HDR10+ metadata in the base layer falls back to plain HDR10 instead of utilizing the HDR10+ dynamic metadata present in the HEVC base layer.

The issue is that getAlternativeCodecMimeType explicitly excludes DolbyVisionProfileDvheDtb (Profile 7) from the HEVC fallback path, so getAlternativeDecoderInfos returns empty on non-DV displays and no HEVC decoder is selected.

This change does not add Dolby Vision Profile 7 support.  
It only enables HEVC fallback for cases where the platform decoder is already capable of decoding the base layer.

In practice, hybrid remux files (dvhe.07) contain a backward-compatible HEVC Main 10 base layer with HDR10+ metadata. Currently, excluding Profile 7 prevents selecting a usable HEVC decoder on non-DV displays, resulting in playback issues or loss of HDR10+ metadata.

This change aligns Profile 7 behavior with existing fallback handling for Profile 8, without affecting Dolby Vision-capable devices.

Fixes #3119
