### PR TITLE
Add descriptive error message for looper mismatch in BaseMediaSource

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -53,6 +53,9 @@
         `DefaultBandwidthMeter.Builder.setInitialBitrateSupplier()`.
     *   Enable dynamic scheduling by default. `ExoPlayer` playback work loop
         will run dynamically as opposed to on a static interval.
+    *   Add a descriptive error message when `MediaSource` is prepared on a
+        different looper than it was originally bound to, making this previously
+        silent 1004 failure easier to diagnose.
 *   CompositionPlayer:
 *   Transformer:
     *   Fix an issue where `ExportResult.fileSizeBytes` may be over-reported.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/BaseMediaSource.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/BaseMediaSource.java
@@ -265,7 +265,13 @@ public abstract class BaseMediaSource implements MediaSource {
   public final void prepareSource(
       MediaSourceCaller caller, PlayerId playerId, BandwidthMeter bandwidthMeter) {
     Looper looper = Looper.myLooper();
-    checkArgument(this.looper == null || this.looper == looper);
+    checkArgument(
+        this.looper == null || this.looper == looper,
+        "MediaSource already bound to looper %s, cannot prepare on looper %s. "
+            + "Use ExoPlayer.Builder.setPlaybackLooper() to share a looper across players, "
+            + "or create a separate MediaSource per player.",
+        this.looper,
+        looper);
     this.playerId = playerId;
     this.bandwidthMeter = bandwidthMeter;
     @Nullable Timeline timeline = this.timeline;


### PR DESCRIPTION
Reusing a cached `MediaSource` across players with different playback threads throws a message-less `IllegalArgumentException`, silently swallowed into error code 1004. 

**Impact at Reddit Android App**
We experienced ~2M errors/day. It only showed up in one specific edge case, so we had nothing to go on but telemetry with 1004 error code — and the empty exception made it much harder to pin down. (We spent a week debugging this).

We're currently experimenting with a single shared looper and seeing the problem addressed.

See [#2263](https://github.com/androidx/media/issues/2263)

Thank you!
