### PR TITLE
Fix: Support empty ILST entry

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -91,6 +91,9 @@
     *   Fix `ArrayIndexOutOfBoundsException` in `Mp4Extractor` when
         `FLAG_OMIT_TRACK_SAMPLE_TABLE` is set and the track lacks a sync sample
         (`stss`) box.
+    *   MP4: Prevent infinite loops and out-of-bounds reads when parsing empty
+        `ilst` metadata tag items
+        ([#3191](https://github.com/androidx/media/pull/3191)).
 *   Inspector:
 *   Audio:
     *   Update `MediaCodecAudioRenderer` to extract the spatial channelMask from

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/MetadataUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/MetadataUtil.java
@@ -152,6 +152,10 @@ import com.google.common.collect.ImmutableList;
     int type = ilst.readInt();
     int typeTopByte = (type >> 24) & 0xFF;
     try {
+      if (ilst.bytesLeft() == 0) {
+        Log.d(TAG, "Skipped empty metadata entry: " + Mp4Box.getBoxTypeString(type));
+        return null;
+      }
       if (typeTopByte == TYPE_TOP_BYTE_COPYRIGHT || typeTopByte == TYPE_TOP_BYTE_REPLACEMENT) {
         int shortType = type & 0x00FFFFFF;
         if (shortType == SHORT_TYPE_COMMENT) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/MetadataUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/MetadataUtil.java
@@ -148,12 +148,18 @@ import com.google.common.collect.ImmutableList;
   @Nullable
   public static Metadata.Entry parseIlstElement(ParsableByteArray ilst) {
     int position = ilst.getPosition();
-    int endPosition = position + ilst.readInt();
+    int size = ilst.readInt();
+    if (size < Mp4Box.HEADER_SIZE) {
+      Log.w(TAG, "Skipped empty metadata entry");
+      return null;
+    }
+    int endPosition = position + size;
     int type = ilst.readInt();
     int typeTopByte = (type >> 24) & 0xFF;
     try {
-      if (endPosition - ilst.getPosition() < Mp4Box.HEADER_SIZE) {
-        Log.d(TAG, "Skipped empty metadata entry: " + Mp4Box.getBoxTypeString(type));
+      int remainingPayloadSize = endPosition - ilst.getPosition();
+      if (remainingPayloadSize < Mp4Box.HEADER_SIZE) {
+        Log.w(TAG, "Skipped empty metadata entry: " + Mp4Box.getBoxTypeString(type));
         return null;
       }
       if (typeTopByte == TYPE_TOP_BYTE_COPYRIGHT || typeTopByte == TYPE_TOP_BYTE_REPLACEMENT) {
@@ -317,7 +323,7 @@ import com.google.common.collect.ImmutableList;
     if (value >= 0) {
       return isTextInformationFrame
           ? new TextInformationFrame(
-              id, /* description= */ null, ImmutableList.of(Integer.toString(value)))
+          id, /* description= */ null, ImmutableList.of(Integer.toString(value)))
           : new CommentFrame(C.LANGUAGE_UNDETERMINED, id, Integer.toString(value));
     }
     Log.w(TAG, "Failed to parse uint8 attribute: " + Mp4Box.getBoxTypeString(type));

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/MetadataUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/MetadataUtil.java
@@ -152,7 +152,7 @@ import com.google.common.collect.ImmutableList;
     int type = ilst.readInt();
     int typeTopByte = (type >> 24) & 0xFF;
     try {
-      if (ilst.bytesLeft() == 0) {
+      if (endPosition - ilst.getPosition() < Mp4Box.HEADER_SIZE) {
         Log.d(TAG, "Skipped empty metadata entry: " + Mp4Box.getBoxTypeString(type));
         return null;
       }

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/mp4/MetadataUtilTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/mp4/MetadataUtilTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.extractor.mp4;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import androidx.media3.common.Metadata;
+import androidx.media3.common.util.ParsableByteArray;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Unit tests for {@link MetadataUtil}. */
+@RunWith(AndroidJUnit4.class)
+public final class MetadataUtilTest {
+
+  @Test
+  public void parseIlstElement_withEmptyTagPayload_returnsNullWithoutCrashing() {
+    ParsableByteArray ilst =
+        new ParsableByteArray(
+            new byte[] {
+              0,
+              0,
+              0,
+              8, // Size = 8 bytes
+              (byte) 0xA9,
+              'n',
+              'a',
+              'm' // Type = ©nam
+            });
+
+    Metadata.Entry entry = MetadataUtil.parseIlstElement(ilst);
+
+    assertThat(entry).isNull();
+  }
+}

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/mp4/MetadataUtilTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/mp4/MetadataUtilTest.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 public final class MetadataUtilTest {
 
   @Test
-  public void parseIlstElement_withEmptyTagPayload_returnsNullWithoutCrashing() {
+  public void parseIlstElement_withEmptyTagPayload_returnsNullAndAdvancesPosition() {
     ParsableByteArray ilst =
         new ParsableByteArray(
             new byte[] {
@@ -45,5 +45,63 @@ public final class MetadataUtilTest {
     Metadata.Entry entry = MetadataUtil.parseIlstElement(ilst);
 
     assertThat(entry).isNull();
+    assertThat(ilst.getPosition()).isEqualTo(8);
+  }
+
+  @Test
+  public void parseIlstElement_withBoxSizeZero_returnsNullAndAdvancesPosition() {
+    ParsableByteArray ilst =
+        new ParsableByteArray(
+            new byte[] {
+                0, 0, 0, 0 // Size = 0 bytes
+            });
+
+    Metadata.Entry entry = MetadataUtil.parseIlstElement(ilst);
+
+    assertThat(entry).isNull();
+    assertThat(ilst.getPosition()).isEqualTo(4);
+  }
+
+  @Test
+  public void parseIlstElement_withBoxSizeSmallerThanHeaderSize_returnsNullAndAdvancesPosition() {
+    ParsableByteArray ilst =
+        new ParsableByteArray(
+            new byte[] {
+                0, 0, 0, 4 // Size = 4 bytes
+            });
+
+    Metadata.Entry entry = MetadataUtil.parseIlstElement(ilst);
+
+    assertThat(entry).isNull();
+    assertThat(ilst.getPosition()).isEqualTo(4);
+  }
+
+  @Test
+  public void
+  parseIlstElement_withRemainingPayloadSmallerThanAtomHeader_returnsNullAndAdvancesPosition() {
+    ParsableByteArray ilst =
+        new ParsableByteArray(
+            new byte[] {
+                0,
+                0,
+                0,
+                15, // Size = 15 bytes
+                (byte) 0xA9,
+                'n',
+                'a',
+                'm', // Type = ©nam
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0 // 7 trailing bytes
+            });
+
+    Metadata.Entry entry = MetadataUtil.parseIlstElement(ilst);
+
+    assertThat(entry).isNull();
+    assertThat(ilst.getPosition()).isEqualTo(15);
   }
 }


### PR DESCRIPTION
Some files can have empty ILST that will prevent playback due to unbounded attempt to read them.