### PR TITLE
Add a disc subtitle field to MediaMetadata 

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -132,6 +132,8 @@
         framework issue existing prior to API 31.
 *   Text:
 *   Metadata:
+    *   Add `MediaMetadata.discSubtitle` field and parse it from ID3v2.4 `TSST`
+        and Vorbis `DISCSUBTITLE` data.
 *   Image:
     *   Fix issue in scrubbing mode where image updates would only take effect
         when the user "stops scrubbing"

--- a/libraries/common/src/main/java/androidx/media3/common/MediaMetadata.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MediaMetadata.java
@@ -85,6 +85,7 @@ public final class MediaMetadata {
     @Nullable private CharSequence composer;
     @Nullable private CharSequence conductor;
     @Nullable private Integer discNumber;
+    @Nullable private CharSequence discSubtitle;
     @Nullable private Integer totalDiscCount;
     @Nullable private CharSequence genre;
     @Nullable private CharSequence compilation;
@@ -129,6 +130,7 @@ public final class MediaMetadata {
       this.composer = mediaMetadata.composer;
       this.conductor = mediaMetadata.conductor;
       this.discNumber = mediaMetadata.discNumber;
+      this.discSubtitle = mediaMetadata.discSubtitle;
       this.totalDiscCount = mediaMetadata.totalDiscCount;
       this.genre = mediaMetadata.genre;
       this.compilation = mediaMetadata.compilation;
@@ -419,6 +421,13 @@ public final class MediaMetadata {
       return this;
     }
 
+    /** Sets the disc subtitle. */
+    @CanIgnoreReturnValue
+    public Builder setDiscSubtitle(@Nullable CharSequence discSubtitle) {
+      this.discSubtitle = discSubtitle;
+      return this;
+    }
+
     /** Sets the total number of discs. */
     @CanIgnoreReturnValue
     public Builder setTotalDiscCount(@Nullable Integer totalDiscCount) {
@@ -609,6 +618,9 @@ public final class MediaMetadata {
       }
       if (mediaMetadata.discNumber != null) {
         setDiscNumber(mediaMetadata.discNumber);
+      }
+      if (mediaMetadata.discSubtitle != null) {
+        setDiscSubtitle(mediaMetadata.discSubtitle);
       }
       if (mediaMetadata.totalDiscCount != null) {
         setTotalDiscCount(mediaMetadata.totalDiscCount);
@@ -1142,6 +1154,9 @@ public final class MediaMetadata {
   /** Optional disc number. */
   @Nullable public final Integer discNumber;
 
+  /** Optional disc subtitle. */
+  @Nullable public final CharSequence discSubtitle;
+
   /** Optional total number of discs. */
   @Nullable public final Integer totalDiscCount;
 
@@ -1221,6 +1236,7 @@ public final class MediaMetadata {
     this.composer = builder.composer;
     this.conductor = builder.conductor;
     this.discNumber = builder.discNumber;
+    this.discSubtitle = builder.discSubtitle;
     this.totalDiscCount = builder.totalDiscCount;
     this.genre = builder.genre;
     this.compilation = builder.compilation;
@@ -1274,6 +1290,7 @@ public final class MediaMetadata {
         && TextUtils.equals(composer, that.composer)
         && TextUtils.equals(conductor, that.conductor)
         && Objects.equals(discNumber, that.discNumber)
+        && TextUtils.equals(discSubtitle, that.discSubtitle)
         && Objects.equals(totalDiscCount, that.totalDiscCount)
         && TextUtils.equals(genre, that.genre)
         && TextUtils.equals(compilation, that.compilation)
@@ -1315,6 +1332,7 @@ public final class MediaMetadata {
         composer,
         conductor,
         discNumber,
+        discSubtitle,
         totalDiscCount,
         genre,
         compilation,
@@ -1359,6 +1377,7 @@ public final class MediaMetadata {
   private static final String FIELD_IS_BROWSABLE = Util.intToStringMaxRadix(32);
   private static final String FIELD_DURATION_MS = Util.intToStringMaxRadix(33);
   private static final String FIELD_SUPPORTED_COMMANDS = Util.intToStringMaxRadix(34);
+  private static final String FIELD_DISC_SUBTITLE = Util.intToStringMaxRadix(35);
   private static final String FIELD_EXTRAS = Util.intToStringMaxRadix(1000);
 
   // Use a fairly lenient threshold for sending byte array to legacy processes that don't support
@@ -1483,6 +1502,9 @@ public final class MediaMetadata {
     }
     if (discNumber != null) {
       bundle.putInt(FIELD_DISC_NUMBER, discNumber);
+    }
+    if (discSubtitle != null) {
+      bundle.putCharSequence(FIELD_DISC_SUBTITLE, discSubtitle);
     }
     if (totalDiscCount != null) {
       bundle.putInt(FIELD_TOTAL_DISC_COUNT, totalDiscCount);

--- a/libraries/common/src/main/java/androidx/media3/common/MediaMetadata.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MediaMetadata.java
@@ -415,6 +415,7 @@ public final class MediaMetadata {
     }
 
     /** Sets the disc subtitle. */
+    @UnstableApi
     @CanIgnoreReturnValue
     public Builder setDiscSubtitle(@Nullable CharSequence discSubtitle) {
       this.discSubtitle = discSubtitle;
@@ -1152,7 +1153,7 @@ public final class MediaMetadata {
   @Nullable public final CharSequence conductor;
 
   /** Optional disc subtitle. */
-  @Nullable public final CharSequence discSubtitle;
+  @UnstableApi @Nullable public final CharSequence discSubtitle;
 
   /** Optional disc number. */
   @Nullable public final Integer discNumber;
@@ -1556,6 +1557,7 @@ public final class MediaMetadata {
         .setWriter(bundle.getCharSequence(FIELD_WRITER))
         .setComposer(bundle.getCharSequence(FIELD_COMPOSER))
         .setConductor(bundle.getCharSequence(FIELD_CONDUCTOR))
+        .setDiscSubtitle(bundle.getCharSequence(FIELD_DISC_SUBTITLE))
         .setGenre(bundle.getCharSequence(FIELD_GENRE))
         .setCompilation(bundle.getCharSequence(FIELD_COMPILATION))
         .setStation(bundle.getCharSequence(FIELD_STATION))

--- a/libraries/common/src/main/java/androidx/media3/common/MediaMetadata.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MediaMetadata.java
@@ -84,8 +84,8 @@ public final class MediaMetadata {
     @Nullable private CharSequence author;
     @Nullable private CharSequence composer;
     @Nullable private CharSequence conductor;
-    @Nullable private Integer discNumber;
     @Nullable private CharSequence discSubtitle;
+    @Nullable private Integer discNumber;
     @Nullable private Integer totalDiscCount;
     @Nullable private CharSequence genre;
     @Nullable private CharSequence compilation;
@@ -414,17 +414,17 @@ public final class MediaMetadata {
       return this;
     }
 
-    /** Sets the disc number. */
-    @CanIgnoreReturnValue
-    public Builder setDiscNumber(@Nullable Integer discNumber) {
-      this.discNumber = discNumber;
-      return this;
-    }
-
     /** Sets the disc subtitle. */
     @CanIgnoreReturnValue
     public Builder setDiscSubtitle(@Nullable CharSequence discSubtitle) {
       this.discSubtitle = discSubtitle;
+      return this;
+    }
+
+    /** Sets the disc number. */
+    @CanIgnoreReturnValue
+    public Builder setDiscNumber(@Nullable Integer discNumber) {
+      this.discNumber = discNumber;
       return this;
     }
 
@@ -616,11 +616,11 @@ public final class MediaMetadata {
       if (mediaMetadata.conductor != null) {
         setConductor(mediaMetadata.conductor);
       }
-      if (mediaMetadata.discNumber != null) {
-        setDiscNumber(mediaMetadata.discNumber);
-      }
       if (mediaMetadata.discSubtitle != null) {
         setDiscSubtitle(mediaMetadata.discSubtitle);
+      }
+      if (mediaMetadata.discNumber != null) {
+        setDiscNumber(mediaMetadata.discNumber);
       }
       if (mediaMetadata.totalDiscCount != null) {
         setTotalDiscCount(mediaMetadata.totalDiscCount);
@@ -1151,11 +1151,11 @@ public final class MediaMetadata {
   /** Optional conductor. */
   @Nullable public final CharSequence conductor;
 
-  /** Optional disc number. */
-  @Nullable public final Integer discNumber;
-
   /** Optional disc subtitle. */
   @Nullable public final CharSequence discSubtitle;
+
+  /** Optional disc number. */
+  @Nullable public final Integer discNumber;
 
   /** Optional total number of discs. */
   @Nullable public final Integer totalDiscCount;
@@ -1235,8 +1235,8 @@ public final class MediaMetadata {
     this.author = builder.author;
     this.composer = builder.composer;
     this.conductor = builder.conductor;
-    this.discNumber = builder.discNumber;
     this.discSubtitle = builder.discSubtitle;
+    this.discNumber = builder.discNumber;
     this.totalDiscCount = builder.totalDiscCount;
     this.genre = builder.genre;
     this.compilation = builder.compilation;
@@ -1289,8 +1289,8 @@ public final class MediaMetadata {
         && TextUtils.equals(writer, that.writer)
         && TextUtils.equals(composer, that.composer)
         && TextUtils.equals(conductor, that.conductor)
-        && Objects.equals(discNumber, that.discNumber)
         && TextUtils.equals(discSubtitle, that.discSubtitle)
+        && Objects.equals(discNumber, that.discNumber)
         && Objects.equals(totalDiscCount, that.totalDiscCount)
         && TextUtils.equals(genre, that.genre)
         && TextUtils.equals(compilation, that.compilation)
@@ -1331,8 +1331,8 @@ public final class MediaMetadata {
         writer,
         composer,
         conductor,
-        discNumber,
         discSubtitle,
+        discNumber,
         totalDiscCount,
         genre,
         compilation,

--- a/libraries/common/src/test/java/androidx/media3/common/MediaMetadataTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/MediaMetadataTest.java
@@ -63,8 +63,8 @@ public class MediaMetadataTest {
     assertThat(mediaMetadata.composer).isNull();
     assertThat(mediaMetadata.conductor).isNull();
     assertThat(mediaMetadata.writer).isNull();
-    assertThat(mediaMetadata.discNumber).isNull();
     assertThat(mediaMetadata.discSubtitle).isNull();
+    assertThat(mediaMetadata.discNumber).isNull();
     assertThat(mediaMetadata.totalDiscCount).isNull();
     assertThat(mediaMetadata.genre).isNull();
     assertThat(mediaMetadata.compilation).isNull();
@@ -328,8 +328,8 @@ public class MediaMetadataTest {
         .setComposer("Composer")
         .setConductor("Conductor")
         .setWriter("Writer")
-        .setDiscNumber(1)
         .setDiscSubtitle("Disc Subtitle")
+        .setDiscNumber(1)
         .setTotalDiscCount(3)
         .setGenre("Pop")
         .setCompilation("Amazing songs.")

--- a/libraries/common/src/test/java/androidx/media3/common/MediaMetadataTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/MediaMetadataTest.java
@@ -64,6 +64,7 @@ public class MediaMetadataTest {
     assertThat(mediaMetadata.conductor).isNull();
     assertThat(mediaMetadata.writer).isNull();
     assertThat(mediaMetadata.discNumber).isNull();
+    assertThat(mediaMetadata.discSubtitle).isNull();
     assertThat(mediaMetadata.totalDiscCount).isNull();
     assertThat(mediaMetadata.genre).isNull();
     assertThat(mediaMetadata.compilation).isNull();
@@ -328,6 +329,7 @@ public class MediaMetadataTest {
         .setConductor("Conductor")
         .setWriter("Writer")
         .setDiscNumber(1)
+        .setDiscSubtitle("Disc Subtitle")
         .setTotalDiscCount(3)
         .setGenre("Pop")
         .setCompilation("Amazing songs.")

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/TextInformationFrame.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/TextInformationFrame.java
@@ -178,7 +178,10 @@ public final class TextInformationFrame extends Id3Frame {
         }
         // Don't set a numeric genre that we don't recognize.
         break;
-      default:
+     case "TSST":
+        builder.setDiscSubtitle(values.get(0));
+        break;
+     default:
         break;
     }
   }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/TextInformationFrame.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/TextInformationFrame.java
@@ -178,10 +178,10 @@ public final class TextInformationFrame extends Id3Frame {
         }
         // Don't set a numeric genre that we don't recognize.
         break;
-     case "TSST":
+      case "TSST":
         builder.setDiscSubtitle(values.get(0));
         break;
-     default:
+      default:
         break;
     }
   }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/vorbis/VorbisComment.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/vorbis/VorbisComment.java
@@ -80,6 +80,9 @@ public final class VorbisComment implements Metadata.Entry {
           builder.setDiscNumber(discNumber);
         }
         break;
+      case "DISCSUBTITLE":
+        builder.setDiscSubtitle(value);
+        break;
       case "TOTALDISCS":
         @Nullable Integer totalDiscs = Ints.tryParse(value);
         if (totalDiscs != null) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/vorbis/VorbisComment.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/vorbis/VorbisComment.java
@@ -74,14 +74,14 @@ public final class VorbisComment implements Metadata.Entry {
           builder.setTotalTrackCount(totalTracks);
         }
         break;
+      case "DISCSUBTITLE":
+        builder.setDiscSubtitle(value);
+        break;
       case "DISCNUMBER":
         @Nullable Integer discNumber = Ints.tryParse(value);
         if (discNumber != null) {
           builder.setDiscNumber(discNumber);
         }
-        break;
-      case "DISCSUBTITLE":
-        builder.setDiscSubtitle(value);
         break;
       case "TOTALDISCS":
         @Nullable Integer totalDiscs = Ints.tryParse(value);

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/id3/TextInformationFrameTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/id3/TextInformationFrameTest.java
@@ -43,6 +43,7 @@ public class TextInformationFrameTest {
     String composer = "composer";
     String conductor = "conductor";
     String writer = "writer";
+    String discSubtitle = "disc subtitle";
 
     List<Metadata.Entry> entries =
         ImmutableList.of(
@@ -81,7 +82,9 @@ public class TextInformationFrameTest {
                 /* description= */ null,
                 /* values= */ ImmutableList.of(conductor)),
             new TextInformationFrame(
-                /* id= */ "TXT", /* description= */ null, /* values= */ ImmutableList.of(writer)));
+                /* id= */ "TXT", /* description= */ null, /* values= */ ImmutableList.of(writer)),
+            new TextInformationFrame(
+                /* id= */ "TSST", /* description= */ null, /* values= */ ImmutableList.of(discSubtitle)));
     MediaMetadata.Builder builder = MediaMetadata.EMPTY.buildUpon();
 
     for (Metadata.Entry entry : entries) {
@@ -105,6 +108,7 @@ public class TextInformationFrameTest {
     assertThat(mediaMetadata.composer.toString()).isEqualTo(composer);
     assertThat(mediaMetadata.conductor.toString()).isEqualTo(conductor);
     assertThat(mediaMetadata.writer.toString()).isEqualTo(writer);
+    assertThat(mediaMetadata.discSubtitle).isEqualTo(discSubtitle);
   }
 
   @Test

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/id3/TextInformationFrameTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/id3/TextInformationFrameTest.java
@@ -84,7 +84,9 @@ public class TextInformationFrameTest {
             new TextInformationFrame(
                 /* id= */ "TXT", /* description= */ null, /* values= */ ImmutableList.of(writer)),
             new TextInformationFrame(
-                /* id= */ "TSST", /* description= */ null, /* values= */ ImmutableList.of(discSubtitle)));
+                /* id= */ "TSST",
+                /* description= */ null,
+                /* values= */ ImmutableList.of(discSubtitle)));
     MediaMetadata.Builder builder = MediaMetadata.EMPTY.buildUpon();
 
     for (Metadata.Entry entry : entries) {

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/id3/TextInformationFrameTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/id3/TextInformationFrameTest.java
@@ -110,7 +110,7 @@ public class TextInformationFrameTest {
     assertThat(mediaMetadata.composer.toString()).isEqualTo(composer);
     assertThat(mediaMetadata.conductor.toString()).isEqualTo(conductor);
     assertThat(mediaMetadata.writer.toString()).isEqualTo(writer);
-    assertThat(mediaMetadata.discSubtitle).isEqualTo(discSubtitle);
+    assertThat(mediaMetadata.discSubtitle.toString()).isEqualTo(discSubtitle);
   }
 
   @Test

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/vorbis/VorbisCommentTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/vorbis/VorbisCommentTest.java
@@ -36,8 +36,8 @@ public final class VorbisCommentTest {
     String albumArtist = "album Artist";
     int trackNumber = 3;
     int totalTracks = 12;
-    int discNumber = 1;
     String discSubtitle = "disc subtitle";
+    int discNumber = 1;
     int totalDiscs = 3;
     String genre = "Metal";
     String description = "a description about the audio.";
@@ -49,8 +49,8 @@ public final class VorbisCommentTest {
             new VorbisComment("albumartist", albumArtist),
             new VorbisComment("TRACKNUMBER", String.valueOf(trackNumber)),
             new VorbisComment("TOTALTRACKS", String.valueOf(totalTracks)),
-            new VorbisComment("DISCNUMBER", String.valueOf(discNumber)),
             new VorbisComment("DISCSUBTITLE", discSubtitle),
+            new VorbisComment("DISCNUMBER", String.valueOf(discNumber)),
             new VorbisComment("TOTALDISCS", String.valueOf(totalDiscs)),
             new VorbisComment("GENRE", genre),
             new VorbisComment("DESCRIPTION", description));
@@ -67,8 +67,8 @@ public final class VorbisCommentTest {
     assertThat(mediaMetadata.albumArtist.toString()).isEqualTo(albumArtist);
     assertThat(mediaMetadata.trackNumber).isEqualTo(trackNumber);
     assertThat(mediaMetadata.totalTrackCount).isEqualTo(totalTracks);
+    assertThat(mediaMetadata.discSubtitle.toString()).isEqualTo(discSubtitle);
     assertThat(mediaMetadata.discNumber).isEqualTo(discNumber);
-    assertThat(mediaMetadata.discSubtitle).isEqualTo(discSubtitle);
     assertThat(mediaMetadata.totalDiscCount).isEqualTo(totalDiscs);
     assertThat(mediaMetadata.genre.toString()).isEqualTo(genre);
     assertThat(mediaMetadata.description.toString()).isEqualTo(description);

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/vorbis/VorbisCommentTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/vorbis/VorbisCommentTest.java
@@ -37,6 +37,7 @@ public final class VorbisCommentTest {
     int trackNumber = 3;
     int totalTracks = 12;
     int discNumber = 1;
+    String discSubtitle = "disc subtitle";
     int totalDiscs = 3;
     String genre = "Metal";
     String description = "a description about the audio.";
@@ -49,6 +50,7 @@ public final class VorbisCommentTest {
             new VorbisComment("TRACKNUMBER", String.valueOf(trackNumber)),
             new VorbisComment("TOTALTRACKS", String.valueOf(totalTracks)),
             new VorbisComment("DISCNUMBER", String.valueOf(discNumber)),
+            new VorbisComment("DISCSUBTITLE", discSubtitle),
             new VorbisComment("TOTALDISCS", String.valueOf(totalDiscs)),
             new VorbisComment("GENRE", genre),
             new VorbisComment("DESCRIPTION", description));
@@ -66,6 +68,7 @@ public final class VorbisCommentTest {
     assertThat(mediaMetadata.trackNumber).isEqualTo(trackNumber);
     assertThat(mediaMetadata.totalTrackCount).isEqualTo(totalTracks);
     assertThat(mediaMetadata.discNumber).isEqualTo(discNumber);
+    assertThat(mediaMetadata.discSubtitle).isEqualTo(discSubtitle);
     assertThat(mediaMetadata.totalDiscCount).isEqualTo(totalDiscs);
     assertThat(mediaMetadata.genre.toString()).isEqualTo(genre);
     assertThat(mediaMetadata.description.toString()).isEqualTo(description);

--- a/libraries/test_utils_robolectric/src/main/java/androidx/media3/test/utils/robolectric/PlaybackOutput.java
+++ b/libraries/test_utils_robolectric/src/main/java/androidx/media3/test/utils/robolectric/PlaybackOutput.java
@@ -229,8 +229,8 @@ public final class PlaybackOutput implements Dumper.Dumpable {
       dumper.addIfNonDefault("writer", mediaMetadata.writer, null);
       dumper.addIfNonDefault("composer", mediaMetadata.composer, null);
       dumper.addIfNonDefault("conductor", mediaMetadata.conductor, null);
-      dumper.addIfNonDefault("discNumber", mediaMetadata.discNumber, null);
       dumper.addIfNonDefault("discSubtitle", mediaMetadata.discSubtitle, null);
+      dumper.addIfNonDefault("discNumber", mediaMetadata.discNumber, null);
       dumper.addIfNonDefault("totalDiscCount", mediaMetadata.totalDiscCount, null);
       dumper.addIfNonDefault("genre", mediaMetadata.genre, null);
       dumper.addIfNonDefault("compilation", mediaMetadata.compilation, null);

--- a/libraries/test_utils_robolectric/src/main/java/androidx/media3/test/utils/robolectric/PlaybackOutput.java
+++ b/libraries/test_utils_robolectric/src/main/java/androidx/media3/test/utils/robolectric/PlaybackOutput.java
@@ -230,6 +230,7 @@ public final class PlaybackOutput implements Dumper.Dumpable {
       dumper.addIfNonDefault("composer", mediaMetadata.composer, null);
       dumper.addIfNonDefault("conductor", mediaMetadata.conductor, null);
       dumper.addIfNonDefault("discNumber", mediaMetadata.discNumber, null);
+      dumper.addIfNonDefault("discSubtitle", mediaMetadata.discSubtitle, null);
       dumper.addIfNonDefault("totalDiscCount", mediaMetadata.totalDiscCount, null);
       dumper.addIfNonDefault("genre", mediaMetadata.genre, null);
       dumper.addIfNonDefault("compilation", mediaMetadata.compilation, null);


### PR DESCRIPTION
For ID3 we read the [`TSST` frame][1] which is part of ID3v2.4.

Vorbis comments don't have an ['official'][2] equivalent.
However, there is the de-facto standard `DISCSUBTITLE` field which is
used by taggers such as [Picard][3] and libraries such as [taglib][4].

I also noticed that the disc number is only read from vorbis comments but not from ID3 tags.
Let me know if I should submit that commit as its own PR.


[1]: https://id3.org/id3v2.4.0-frames
[2]: https://xiph.org/vorbis/doc/v-comment.html
[3]: https://picard-docs.musicbrainz.org/en/latest/appendices/tag_mapping.html#disc-subtitle
[4]: https://taglib.org/api/p_propertymapping.html#:~:text=DISCSUBTITLE