### PR TITLE
Handle gapless MP3 Xing/Info durations

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -120,6 +120,8 @@
         `FLAG_READ_MFRA_FOR_SEEK_MAP` to the `FragmentedMp4Extractor`, which is
         now done by default in `DefaultExtractorsFactory`
         ([#3088](https://github.com/androidx/media/issues/3088)).
+    *   MP3: Use gapless-aware durations from Xing/Info headers
+        ([#3183](https://github.com/androidx/media/issues/3183)).
     *   Ignore `av1C` data with unsupported version.
     *   MP4: Add support for big-endian floating point PCM in `fpcm` boxes.
     *   Matroska: Parse chapter info to `Chapter` entries in a track's

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -2233,7 +2233,21 @@ public final class Util {
    */
   @UnstableApi
   public static String toHexString(byte[] bytes) {
-    return BaseEncoding.base16().lowerCase().encode(bytes);
+    return toHexString(bytes, 0, bytes.length);
+  }
+
+  /**
+   * Returns a string containing a lower-case hex representation of the bytes provided.
+   *
+   * @param bytes The byte data to convert to hex.
+   * @param offset The offset into data to read from.
+   * @param length The number of bytes to read from data.
+   * @return A String containing the hex representation of {@code bytes} (considering {@code offset}
+   *     and {@code length}).
+   */
+  @UnstableApi
+  public static String toHexString(byte[] bytes, int offset, int length) {
+    return BaseEncoding.base16().lowerCase().encode(bytes, offset, length);
   }
 
   @UnstableApi

--- a/libraries/common/src/test/java/androidx/media3/common/util/UtilTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/util/UtilTest.java
@@ -1067,6 +1067,13 @@ public class UtilTest {
   }
 
   @Test
+  public void toHexString_withOffsetAndLength_returnsHexString() {
+    byte[] bytes = createByteArray(0x12, 0xFC, 0x06, 0x2B);
+
+    assertThat(Util.toHexString(bytes, /* offset= */ 1, /* length= */ 2)).isEqualTo("fc06");
+  }
+
+  @Test
   public void getCodecsOfType_withNull_returnsNull() {
     assertThat(getCodecsOfType(null, C.TRACK_TYPE_VIDEO)).isNull();
   }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ConstantBitrateSeekMap.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ConstantBitrateSeekMap.java
@@ -166,6 +166,32 @@ public class ConstantBitrateSeekMap implements SeekMap {
     return getTimeUsAtPosition(position, firstFrameBytePosition, bitrate);
   }
 
+  /** Returns the byte position of the first frame in the stream (as passed to the constructor). */
+  protected final long getFirstFramePosition() {
+    return firstFrameBytePosition;
+  }
+
+  /**
+   * Returns the size of each frame in the stream in bytes, or {@code 1} if {@link C#LENGTH_UNSET}
+   * was passed to the constructor.
+   */
+  protected final int getFrameSize() {
+    return frameSize;
+  }
+
+  /** Returns the bitrate of the stream (as passed to the constructor). */
+  protected final int getBitrate() {
+    return bitrate;
+  }
+
+  /**
+   * Returns whether seeking is permitted if the stream length is unknown (as passed to the
+   * constructor).
+   */
+  protected final boolean shouldAllowSeeksIfLengthUnknown() {
+    return allowSeeksIfLengthUnknown;
+  }
+
   // Internal methods
 
   /**

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/ConstantBitrateSeeker.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/ConstantBitrateSeeker.java
@@ -37,7 +37,8 @@ import androidx.media3.extractor.SeekPoint;
    * Constructs an instance.
    *
    * <p>The duration exposed from {@link #getDurationUs()} is computed from {@code inputLength} and
-   * the frame bitrate, or is {@link C#TIME_UNSET} if {@code inputLength} is unknown.
+   * the bitrate of {@code mpegAudioHeader}, or is {@link C#TIME_UNSET} if {@code inputLength} is
+   * unknown.
    *
    * @param inputLength The length of the stream in bytes, or {@link C#LENGTH_UNSET} if unknown.
    * @param firstFramePosition The position of the first frame in the stream.

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/ConstantBitrateSeeker.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/ConstantBitrateSeeker.java
@@ -18,6 +18,8 @@ package androidx.media3.extractor.mp3;
 import androidx.media3.common.C;
 import androidx.media3.extractor.ConstantBitrateSeekMap;
 import androidx.media3.extractor.MpegAudioUtil;
+import androidx.media3.extractor.SeekMap.SeekPoints;
+import androidx.media3.extractor.SeekPoint;
 
 /**
  * MP3 seeker that doesn't rely on metadata and seeks assuming the source has a constant bitrate.
@@ -28,10 +30,14 @@ import androidx.media3.extractor.MpegAudioUtil;
   private final int bitrate;
   private final int frameSize;
   private final boolean allowSeeksIfLengthUnknown;
+  private final long durationUs;
   private final long dataEndPosition;
 
   /**
    * Constructs an instance.
+   *
+   * <p>The duration exposed from {@link #getDurationUs()} is computed from {@code inputLength} and
+   * the frame bitrate, or is {@link C#TIME_UNSET} if {@code inputLength} is unknown.
    *
    * @param inputLength The length of the stream in bytes, or {@link C#LENGTH_UNSET} if unknown.
    * @param firstFramePosition The position of the first frame in the stream.
@@ -53,23 +59,30 @@ import androidx.media3.extractor.MpegAudioUtil;
         mpegAudioHeader.bitrate,
         mpegAudioHeader.frameSize,
         allowSeeksIfLengthUnknown,
-        /* isEstimated= */ true);
+        /* durationUs= */ C.TIME_UNSET);
   }
 
-  /** See {@link ConstantBitrateSeekMap#ConstantBitrateSeekMap(long, long, int, int, boolean)}. */
+  /**
+   * See {@link ConstantBitrateSeekMap#ConstantBitrateSeekMap(long, long, int, int, boolean)}. Uses
+   * {@code durationUs} as the duration exposed from {@link #getDurationUs()}, or computes the
+   * duration from {@code inputLength} and {@code bitrate} if {@code durationUs} is {@link
+   * C#TIME_UNSET}.
+   */
   public ConstantBitrateSeeker(
       long inputLength,
       long firstFramePosition,
       int bitrate,
       int frameSize,
-      boolean allowSeeksIfLengthUnknown) {
+      boolean allowSeeksIfLengthUnknown,
+      long durationUs) {
     this(
         inputLength,
         firstFramePosition,
         bitrate,
         frameSize,
         allowSeeksIfLengthUnknown,
-        /* isEstimated= */ true);
+        /* isEstimated= */ true,
+        durationUs);
   }
 
   private ConstantBitrateSeeker(
@@ -78,7 +91,8 @@ import androidx.media3.extractor.MpegAudioUtil;
       int bitrate,
       int frameSize,
       boolean allowSeeksIfLengthUnknown,
-      boolean isEstimated) {
+      boolean isEstimated,
+      long durationUs) {
     super(
         inputLength,
         firstFramePosition,
@@ -88,14 +102,26 @@ import androidx.media3.extractor.MpegAudioUtil;
         isEstimated);
     this.firstFramePosition = firstFramePosition;
     this.bitrate = bitrate;
-    this.frameSize = frameSize;
+    this.frameSize = frameSize == C.LENGTH_UNSET ? 1 : frameSize;
     this.allowSeeksIfLengthUnknown = allowSeeksIfLengthUnknown;
+    this.durationUs = durationUs;
     dataEndPosition = inputLength != C.LENGTH_UNSET ? inputLength : C.INDEX_UNSET;
   }
 
   @Override
   public long getTimeUs(long position) {
     return getTimeUsAtPosition(position);
+  }
+
+  @Override
+  public SeekPoints getSeekPoints(long timeUs) {
+    if (durationUs != C.TIME_UNSET && timeUs >= durationUs && dataEndPosition != C.INDEX_UNSET) {
+      long finalFramePosition = Math.max(firstFramePosition, dataEndPosition - frameSize);
+      long frameDurationUs = getTimeUsAtPosition(firstFramePosition + frameSize);
+      return new SeekPoints(
+          new SeekPoint(Math.max(0, durationUs - frameDurationUs), finalFramePosition));
+    }
+    return super.getSeekPoints(timeUs);
   }
 
   @Override
@@ -106,6 +132,11 @@ import androidx.media3.extractor.MpegAudioUtil;
   @Override
   public long getDataEndPosition() {
     return dataEndPosition;
+  }
+
+  @Override
+  public long getDurationUs() {
+    return durationUs != C.TIME_UNSET ? durationUs : super.getDurationUs();
   }
 
   @Override
@@ -120,6 +151,7 @@ import androidx.media3.extractor.MpegAudioUtil;
         bitrate,
         frameSize,
         allowSeeksIfLengthUnknown,
-        /* isEstimated= */ false);
+        /* isEstimated= */ false,
+        durationUs);
   }
 }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/ConstantBitrateSeeker.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/ConstantBitrateSeeker.java
@@ -26,10 +26,6 @@ import androidx.media3.extractor.SeekPoint;
  */
 /* package */ final class ConstantBitrateSeeker extends ConstantBitrateSeekMap implements Seeker {
 
-  private final long firstFramePosition;
-  private final int bitrate;
-  private final int frameSize;
-  private final boolean allowSeeksIfLengthUnknown;
   private final long durationUs;
   private final long dataEndPosition;
 
@@ -101,10 +97,6 @@ import androidx.media3.extractor.SeekPoint;
         frameSize,
         allowSeeksIfLengthUnknown,
         isEstimated);
-    this.firstFramePosition = firstFramePosition;
-    this.bitrate = bitrate;
-    this.frameSize = frameSize == C.LENGTH_UNSET ? 1 : frameSize;
-    this.allowSeeksIfLengthUnknown = allowSeeksIfLengthUnknown;
     this.durationUs = durationUs;
     dataEndPosition = inputLength != C.LENGTH_UNSET ? inputLength : C.INDEX_UNSET;
   }
@@ -117,8 +109,8 @@ import androidx.media3.extractor.SeekPoint;
   @Override
   public SeekPoints getSeekPoints(long timeUs) {
     if (durationUs != C.TIME_UNSET && timeUs >= durationUs && dataEndPosition != C.INDEX_UNSET) {
-      long finalFramePosition = Math.max(firstFramePosition, dataEndPosition - frameSize);
-      long frameDurationUs = getTimeUsAtPosition(firstFramePosition + frameSize);
+      long finalFramePosition = Math.max(getFirstFramePosition(), dataEndPosition - getFrameSize());
+      long frameDurationUs = getTimeUsAtPosition(getFirstFramePosition() + getFrameSize());
       return new SeekPoints(
           new SeekPoint(Math.max(0, durationUs - frameDurationUs), finalFramePosition));
     }
@@ -127,7 +119,7 @@ import androidx.media3.extractor.SeekPoint;
 
   @Override
   public long getDataStartPosition() {
-    return firstFramePosition;
+    return getFirstFramePosition();
   }
 
   @Override
@@ -142,16 +134,16 @@ import androidx.media3.extractor.SeekPoint;
 
   @Override
   public int getAverageBitrate() {
-    return bitrate;
+    return getBitrate();
   }
 
   public ConstantBitrateSeeker copyWithNewDataEndPosition(long dataEndPosition) {
     return new ConstantBitrateSeeker(
         /* inputLength= */ dataEndPosition,
-        firstFramePosition,
-        bitrate,
-        frameSize,
-        allowSeeksIfLengthUnknown,
+        getFirstFramePosition(),
+        getAverageBitrate(),
+        getFrameSize(),
+        shouldAllowSeeksIfLengthUnknown(),
         /* isEstimated= */ false,
         durationUs);
   }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/Mp3Extractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/Mp3Extractor.java
@@ -554,7 +554,7 @@ public final class Mp3Extractor implements Extractor {
             : 0;
     int averageBitrate = computeAverageBitrate(inputLength - dataStart, durationUs);
     if (averageBitrate == C.RATE_UNSET_INT) {
-      // Bitrate couldn't be determined (dataStart > inputLength?)
+      // Bitrate couldn't be determined (dataStart >= inputLength?) so we just do normal CBR seeking
       return getConstantBitrateSeeker(input);
     }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/Mp3Extractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/Mp3Extractor.java
@@ -15,6 +15,7 @@
  */
 package androidx.media3.extractor.mp3;
 
+import static androidx.media3.extractor.mp3.Mp3Util.computeAverageBitrate;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
@@ -391,6 +392,28 @@ public final class Mp3Extractor implements Extractor {
     return basisTimeUs + samplesRead * C.MICROS_PER_SECOND / synchronizedHeader.sampleRate;
   }
 
+  /**
+   * Returns the final duration to expose for an {@link IndexSeeker}.
+   *
+   * <p>Index seeking finalizes duration from the encoded samples read at EOF. When gapless metadata
+   * is present, this trims the encoder delay and padding so EOF finalization does not replace an
+   * initially gapless Xing/Info duration with the longer encoded duration.
+   */
+  private long computeFinalIndexSeekerDurationUs(long samplesRead) {
+    long durationUs = computeTimeUs(samplesRead);
+    if (!gaplessInfoHolder.hasGaplessInfo()) {
+      return durationUs;
+    }
+    long finalGaplessSampleIndex =
+        Util.durationUsToSampleCount(durationUs, synchronizedHeader.sampleRate)
+            - gaplessInfoHolder.encoderDelay
+            - gaplessInfoHolder.encoderPadding
+            - 1;
+    return finalGaplessSampleIndex >= 0
+        ? Util.sampleCountToDurationUs(finalGaplessSampleIndex, synchronizedHeader.sampleRate)
+        : C.TIME_UNSET;
+  }
+
   private boolean synchronize(ExtractorInput input, boolean sniffing) throws IOException {
     int validFrameCount = 0;
     int candidateSynchronizedHeaderData = 0;
@@ -522,37 +545,37 @@ public final class Mp3Extractor implements Extractor {
       return resultSeeker;
     }
 
+    long durationUs = resultSeeker.getDurationUs();
     long inputLength =
         resultSeeker.getDataEndPosition() != C.INDEX_UNSET
             ? resultSeeker.getDataEndPosition()
             : input.getLength();
-    if (resultSeeker.getDurationUs() == C.TIME_UNSET || inputLength == C.LENGTH_UNSET) {
+    if (durationUs == C.TIME_UNSET || inputLength == C.LENGTH_UNSET) {
       // resultSeeker doesn't provide enough info to do 'enhanced' CBR seeking, so we just do
       // normal CBR seeking without any additional info from the file.
       return getConstantBitrateSeeker(input);
     }
-    // resultSeeker provides a duration and we know the input length, and CBR seeking has been
-    // requested, so we can do 'enhanced' CBR seeking using this info.
     long dataStart =
         resultSeeker.getDataStartPosition() != C.INDEX_UNSET
             ? resultSeeker.getDataStartPosition()
             : 0;
-    long audioLength = inputLength - dataStart;
-    int bitrate =
-        Ints.saturatedCast(
-            Util.scaleLargeValue(
-                audioLength,
-                Byte.SIZE * C.MICROS_PER_SECOND,
-                resultSeeker.getDurationUs(),
-                RoundingMode.HALF_UP));
-    // inputLength will never be LENGTH_UNSET because of the if-condition above, so we can
+    int averageBitrate = computeAverageBitrate(inputLength - dataStart, durationUs);
+    if (averageBitrate == C.RATE_UNSET_INT) {
+      // Bitrate couldn't be determined (dataStart > inputLength?)
+      return getConstantBitrateSeeker(input);
+    }
+
+    // resultSeeker provides a duration and we know the input length, and CBR seeking has been
+    // requested, so we can do 'enhanced' CBR seeking using this info. inputLength will never be
+    // LENGTH_UNSET because of the if-condition above, so we can
     // pass (vacuously) false here for allowSeeksIfLengthUnknown.
     return new ConstantBitrateSeeker(
         inputLength,
         dataStart,
-        bitrate,
+        averageBitrate,
         /* frameSize= */ C.LENGTH_UNSET,
-        /* allowSeeksIfLengthUnknown= */ false);
+        /* allowSeeksIfLengthUnknown= */ false,
+        durationUs);
   }
 
   private boolean shouldFallbackToConstantBitrateSeeking(Seeker seeker) {
@@ -663,15 +686,13 @@ public final class Mp3Extractor implements Extractor {
 
     // Derive the bitrate and frame size by averaging over the length of playable audio, to allow
     // for 'mostly' CBR streams that might have a small number of frames with a different bitrate.
-    // We can assume infoFrame.frameCount is set, because otherwise computeDurationUs() would
-    // have returned C.TIME_UNSET above. See also https://github.com/androidx/media/issues/1376.
-    int averageBitrate =
-        Ints.checkedCast(
-            Util.scaleLargeValue(
-                audioLength,
-                C.BITS_PER_BYTE * C.MICROS_PER_SECOND,
-                durationUs,
-                RoundingMode.HALF_UP));
+    // See also https://github.com/androidx/media/issues/1376.
+    int averageBitrate = computeAverageBitrate(audioLength, durationUs);
+    if (averageBitrate == C.RATE_UNSET_INT) {
+      // Invalid Info sizes or durations should fall back to the next frame header bitrate rather
+      // than constructing a ConstantBitrateSeeker with an unset bitrate.
+      return null;
+    }
     int frameSize =
         Ints.checkedCast(LongMath.divide(audioLength, infoFrame.frameCount, RoundingMode.HALF_UP));
     // Set the seeker frame size to the average frame size (even though some constant bitrate
@@ -682,7 +703,8 @@ public final class Mp3Extractor implements Extractor {
         /* firstFramePosition= */ infoFramePosition + infoFrame.header.frameSize,
         averageBitrate,
         frameSize,
-        /* allowSeeksIfLengthUnknown= */ false);
+        /* allowSeeksIfLengthUnknown= */ false,
+        durationUs);
   }
 
   /**

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/Mp3Extractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/Mp3Extractor.java
@@ -266,7 +266,7 @@ public final class Mp3Extractor implements Extractor {
     if (readResult == RESULT_END_OF_INPUT && seeker instanceof IndexSeeker) {
       // Duration is exact when index seeker is used.
       long finalSampleIndex = samplesRead - 1;
-      long durationUs = finalSampleIndex >= 0 ? computeTimeUs(finalSampleIndex) : C.TIME_UNSET;
+      long durationUs = finalSampleIndex >= 0 ? computeFinalIndexSeekerDurationUs(finalSampleIndex) : C.TIME_UNSET;
       if (seeker.getDurationUs() != durationUs) {
         ((IndexSeeker) seeker).setDurationUs(durationUs);
         extractorOutput.seekMap(seeker);
@@ -399,19 +399,12 @@ public final class Mp3Extractor implements Extractor {
    * is present, this trims the encoder delay and padding so EOF finalization does not replace an
    * initially gapless Xing/Info duration with the longer encoded duration.
    */
-  private long computeFinalIndexSeekerDurationUs(long samplesRead) {
-    long durationUs = computeTimeUs(samplesRead);
-    if (!gaplessInfoHolder.hasGaplessInfo()) {
-      return durationUs;
-    }
+  private long computeFinalIndexSeekerDurationUs(long finalSampleIndex) {
     long finalGaplessSampleIndex =
-        Util.durationUsToSampleCount(durationUs, synchronizedHeader.sampleRate)
-            - gaplessInfoHolder.encoderDelay
-            - gaplessInfoHolder.encoderPadding
-            - 1;
-    return finalGaplessSampleIndex >= 0
-        ? Util.sampleCountToDurationUs(finalGaplessSampleIndex, synchronizedHeader.sampleRate)
-        : C.TIME_UNSET;
+        gaplessInfoHolder.hasGaplessInfo()
+            ? finalSampleIndex - gaplessInfoHolder.encoderDelay - gaplessInfoHolder.encoderPadding
+            : finalSampleIndex;
+    return finalGaplessSampleIndex >= 0 ? computeTimeUs(finalGaplessSampleIndex) : C.TIME_UNSET;
   }
 
   private boolean synchronize(ExtractorInput input, boolean sniffing) throws IOException {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/XingFrame.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/XingFrame.java
@@ -141,18 +141,35 @@ import androidx.media3.extractor.MpegAudioUtil;
 
   /**
    * Compute the stream duration, in microseconds, represented by this frame. Returns {@link
-   * C#LENGTH_UNSET} if the frame doesn't contain enough information to compute a duration.
+   * C#TIME_UNSET} if the frame doesn't contain enough information to compute a duration. Encoder
+   * delay and padding are subtracted if present.
    */
-  // TODO: b/319235116 - Handle encoder delay and padding when calculating duration.
   public long computeDurationUs() {
-    if (frameCount == C.LENGTH_UNSET || frameCount == 0) {
-      // If the frame count is missing/invalid, the header can't be used to determine the duration.
+    long sampleCount = getSampleCount();
+    if (sampleCount == C.LENGTH_UNSET) {
       return C.TIME_UNSET;
     }
+    if (encoderDelay != C.LENGTH_UNSET && encoderPadding != C.LENGTH_UNSET) {
+      sampleCount -= encoderDelay + encoderPadding;
+    }
+    if (sampleCount <= 0) {
+      return C.TIME_UNSET;
+    }
+    return computeDurationUs(sampleCount);
+  }
+
+  private long getSampleCount() {
+    if (frameCount == C.LENGTH_UNSET || frameCount == 0) {
+      // If the frame count is missing/invalid, the header can't be used to determine the duration.
+      return C.LENGTH_UNSET;
+    }
+    return frameCount * header.samplesPerFrame;
+  }
+
+  private long computeDurationUs(long sampleCount) {
     // Audio requires both a start and end PCM sample, so subtract one from the sample count before
     // calculating the duration.
-    return Util.sampleCountToDurationUs(
-        (frameCount * header.samplesPerFrame) - 1, header.sampleRate);
+    return Util.sampleCountToDurationUs(sampleCount - 1, header.sampleRate);
   }
 
   /** Provide the metadata derived from this Xing frame, such as ReplayGain data. */

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/XingFrame.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/XingFrame.java
@@ -147,7 +147,7 @@ import androidx.media3.extractor.MpegAudioUtil;
   public long computeDurationUs() {
     if (frameCount == C.LENGTH_UNSET || frameCount == 0) {
       // If the frame count is missing/invalid, the header can't be used to determine the duration.
-      return C.LENGTH_UNSET;
+      return C.TIME_UNSET;
     }
     long sampleCount = frameCount * header.samplesPerFrame;
     if (encoderDelay != C.LENGTH_UNSET && encoderPadding != C.LENGTH_UNSET) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/XingFrame.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/XingFrame.java
@@ -145,28 +145,17 @@ import androidx.media3.extractor.MpegAudioUtil;
    * delay and padding are subtracted if present.
    */
   public long computeDurationUs() {
-    long sampleCount = getSampleCount();
-    if (sampleCount == C.LENGTH_UNSET) {
-      return C.TIME_UNSET;
+    if (frameCount == C.LENGTH_UNSET || frameCount == 0) {
+      // If the frame count is missing/invalid, the header can't be used to determine the duration.
+      return C.LENGTH_UNSET;
     }
+    long sampleCount = frameCount * header.samplesPerFrame;
     if (encoderDelay != C.LENGTH_UNSET && encoderPadding != C.LENGTH_UNSET) {
       sampleCount -= encoderDelay + encoderPadding;
     }
     if (sampleCount <= 0) {
       return C.TIME_UNSET;
     }
-    return computeDurationUs(sampleCount);
-  }
-
-  private long getSampleCount() {
-    if (frameCount == C.LENGTH_UNSET || frameCount == 0) {
-      // If the frame count is missing/invalid, the header can't be used to determine the duration.
-      return C.LENGTH_UNSET;
-    }
-    return frameCount * header.samplesPerFrame;
-  }
-
-  private long computeDurationUs(long sampleCount) {
     // Audio requires both a start and end PCM sample, so subtract one from the sample count before
     // calculating the duration.
     return Util.sampleCountToDurationUs(sampleCount - 1, header.sampleRate);

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/ConstantBitrateSeekerTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/ConstantBitrateSeekerTest.java
@@ -22,6 +22,7 @@ import androidx.media3.common.C;
 import androidx.media3.common.util.Util;
 import androidx.media3.datasource.DefaultDataSource;
 import androidx.media3.extractor.SeekMap;
+import androidx.media3.extractor.SeekPoint;
 import androidx.media3.test.utils.FakeExtractorOutput;
 import androidx.media3.test.utils.FakeTrackOutput;
 import androidx.media3.test.utils.TestUtil;
@@ -64,6 +65,23 @@ public class ConstantBitrateSeekerTest {
     assertThat(seekMap.getClass()).isEqualTo(ConstantBitrateSeeker.class);
     assertThat(seekMap.getDurationUs()).isEqualTo(2_784_000);
     assertThat(seekMap.isSeekable()).isTrue();
+  }
+
+  @Test
+  public void getSeekPoints_atExplicitDuration_returnsFinalFrameSeekPoint() {
+    ConstantBitrateSeeker seeker =
+        new ConstantBitrateSeeker(
+            /* inputLength= */ 1_125,
+            /* firstFramePosition= */ 125,
+            /* bitrate= */ 8_000,
+            /* frameSize= */ 1,
+            /* allowSeeksIfLengthUnknown= */ false,
+            /* durationUs= */ 900_000);
+
+    assertThat(seeker.getDurationUs()).isEqualTo(900_000);
+    assertThat(seeker.getTimeUs(1_025)).isEqualTo(900_000);
+    assertThat(seeker.getSeekPoints(800_000).first.position).isEqualTo(925);
+    assertThat(seeker.getSeekPoints(900_000).first).isEqualTo(new SeekPoint(899_000, 1_124));
   }
 
   @Test

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/IndexSeekerTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/IndexSeekerTest.java
@@ -40,7 +40,7 @@ import org.junit.runner.RunWith;
 public class IndexSeekerTest {
 
   private static final String TEST_FILE_XING_NO_TOC = "media/mp3/bear-vbr-xing-header-no-toc.mp3";
-  private static final int TEST_FILE_XING_NO_TOC_DURATION = 2_807_979;
+  private static final int TEST_FILE_XING_NO_TOC_GAPLESS_DURATION_US = 2_783_979;
 
   private Mp3Extractor extractor;
   private FakeExtractorOutput extractorOutput;
@@ -65,14 +65,14 @@ public class IndexSeekerTest {
   }
 
   @Test
-  public void mp3ExtractorReads_correctsInexactDuration() throws Exception {
+  public void mp3ExtractorReads_preservesGaplessDurationAfterEof() throws Exception {
     FakeExtractorOutput extractorOutput =
         TestUtil.extractAllSamplesFromFile(
             extractor, ApplicationProvider.getApplicationContext(), TEST_FILE_XING_NO_TOC);
 
     SeekMap seekMap = extractorOutput.seekMap;
 
-    assertThat(seekMap.getDurationUs()).isEqualTo(TEST_FILE_XING_NO_TOC_DURATION);
+    assertThat(seekMap.getDurationUs()).isEqualTo(TEST_FILE_XING_NO_TOC_GAPLESS_DURATION_US);
   }
 
   @Test
@@ -84,6 +84,17 @@ public class IndexSeekerTest {
     IndexSeeker seeker = new IndexSeeker(durationUs, dataStartPosition, dataEndPosition);
 
     assertThat(seeker.getAverageBitrate()).isEqualTo(8_000);
+  }
+
+  @Test
+  public void constructor_returnsUnsetAverageBitrateWhenAverageCannotBeCalculated() {
+    IndexSeeker seeker =
+        new IndexSeeker(
+            /* durationUs= */ C.TIME_UNSET,
+            /* dataStartPosition= */ 100,
+            /* dataEndPosition= */ C.INDEX_UNSET);
+
+    assertThat(seeker.getAverageBitrate()).isEqualTo(C.RATE_UNSET_INT);
   }
 
   @Test
@@ -111,7 +122,7 @@ public class IndexSeekerTest {
     SeekMap seekMap = TestUtil.extractSeekMap(extractor, extractorOutput, dataSource, fileUri);
     FakeTrackOutput trackOutput = extractorOutput.trackOutputs.get(0);
 
-    long targetSeekTimeUs = TEST_FILE_XING_NO_TOC_DURATION;
+    long targetSeekTimeUs = TEST_FILE_XING_NO_TOC_GAPLESS_DURATION_US;
     int extractedFrameIndex =
         TestUtil.seekToTimeUs(
             extractor, seekMap, targetSeekTimeUs, dataSource, trackOutput, fileUri);

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/Mp3ExtractorTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/Mp3ExtractorTest.java
@@ -469,6 +469,7 @@ public final class Mp3ExtractorTest {
         return framePosition;
       }
     }
-    throw new IllegalArgumentException("No tag found in " + Util.toHexString(data.array()));
+    throw new IllegalArgumentException(
+        "No tag found in " + Util.toHexString(data.array(), data.arrayOffset(), data.limit()));
   }
 }

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/Mp3ExtractorTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/Mp3ExtractorTest.java
@@ -15,14 +15,15 @@
  */
 package androidx.media3.extractor.mp3;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assume.assumeFalse;
 
 import androidx.annotation.Nullable;
-import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.Metadata;
+import androidx.media3.common.util.Util;
 import androidx.media3.extractor.Extractor;
 import androidx.media3.extractor.MpegAudioUtil;
 import androidx.media3.extractor.PositionHolder;
@@ -37,8 +38,10 @@ import androidx.media3.test.utils.TestUtil;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Bytes;
 import com.google.testing.junit.testparameterinjector.TestParameter;
 import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider;
+import java.nio.ByteBuffer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestParameterInjector;
@@ -129,14 +132,13 @@ public final class Mp3ExtractorTest {
     byte[] fileBytes =
         TestUtil.getByteArray(
             ApplicationProvider.getApplicationContext(), "media/mp3/test-cbr-info-header.mp3");
-    int infoTagOffset = indexOf(fileBytes, new byte[] {'I', 'n', 'f', 'o'});
-    assertThat(infoTagOffset).isAtLeast(0);
-    int infoFramePosition = findMpegFramePositionBeforeTag(fileBytes, infoTagOffset);
-    assertThat(infoFramePosition).isNotEqualTo(C.INDEX_UNSET);
+    int infoTagOffset = Bytes.indexOf(fileBytes, new byte[] {'I', 'n', 'f', 'o'});
+    checkState(infoTagOffset >= 0);
+    ByteBuffer fileBytesBuffer = ByteBuffer.wrap(fileBytes);
+    int infoFramePosition = findMpegFramePositionBeforeTag(fileBytesBuffer, infoTagOffset);
     MpegAudioUtil.Header infoFrameHeader = new MpegAudioUtil.Header();
-    assertThat(infoFrameHeader.setForHeaderData(readBigEndianInt(fileBytes, infoFramePosition)))
-        .isTrue();
-    writeBigEndianInt(fileBytes, infoTagOffset + 12, infoFrameHeader.frameSize);
+    checkState(infoFrameHeader.setForHeaderData(fileBytesBuffer.getInt(infoFramePosition)));
+    fileBytesBuffer.putInt(infoTagOffset + 12, infoFrameHeader.frameSize);
 
     FakeExtractorOutput output =
         extractUntilSeekMap(new Mp3Extractor(), fileBytes, /* simulateUnknownLength= */ false);
@@ -458,42 +460,15 @@ public final class Mp3ExtractorTest {
     return output;
   }
 
-  private static int findMpegFramePositionBeforeTag(byte[] data, int tagOffset) {
+  private static int findMpegFramePositionBeforeTag(ByteBuffer data, int tagOffset) {
     for (int tagOffsetFromFrameStart : new int[] {13, 21, 36}) {
       int framePosition = tagOffset - tagOffsetFromFrameStart;
       if (framePosition >= 0
-          && framePosition + 4 <= data.length
-          && new MpegAudioUtil.Header().setForHeaderData(readBigEndianInt(data, framePosition))) {
+          && framePosition + 4 <= data.remaining()
+          && new MpegAudioUtil.Header().setForHeaderData(data.getInt(framePosition))) {
         return framePosition;
       }
     }
-    return C.INDEX_UNSET;
-  }
-
-  private static int indexOf(byte[] data, byte[] target) {
-    for (int i = 0; i <= data.length - target.length; i++) {
-      boolean matches = true;
-      for (int j = 0; j < target.length; j++) {
-        matches &= data[i + j] == target[j];
-      }
-      if (matches) {
-        return i;
-      }
-    }
-    return C.INDEX_UNSET;
-  }
-
-  private static int readBigEndianInt(byte[] data, int offset) {
-    return ((data[offset] & 0xFF) << 24)
-        | ((data[offset + 1] & 0xFF) << 16)
-        | ((data[offset + 2] & 0xFF) << 8)
-        | (data[offset + 3] & 0xFF);
-  }
-
-  private static void writeBigEndianInt(byte[] data, int offset, int value) {
-    data[offset] = (byte) (value >> 24);
-    data[offset + 1] = (byte) (value >> 16);
-    data[offset + 2] = (byte) (value >> 8);
-    data[offset + 3] = (byte) value;
+    throw new IllegalArgumentException("No tag found in " + Util.toHexString(data.array()));
   }
 }

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/Mp3ExtractorTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/Mp3ExtractorTest.java
@@ -20,9 +20,11 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assume.assumeFalse;
 
 import androidx.annotation.Nullable;
+import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.Metadata;
 import androidx.media3.extractor.Extractor;
+import androidx.media3.extractor.MpegAudioUtil;
 import androidx.media3.extractor.PositionHolder;
 import androidx.media3.extractor.SeekPoint;
 import androidx.media3.extractor.metadata.id3.ApicFrame;
@@ -107,6 +109,40 @@ public final class Mp3ExtractorTest {
         "media/mp3/test-cbr-info-header.mp3",
         /* peekLimit= */ 1200,
         simulationConfig);
+  }
+
+  @Test
+  public void mp3SampleWithInfoHeader_usesGaplessDurationAndAverageBitrate() throws Exception {
+    FakeExtractorOutput output =
+        TestUtil.extractAllSamplesFromFile(
+            new Mp3Extractor(),
+            ApplicationProvider.getApplicationContext(),
+            "media/mp3/test-cbr-info-header.mp3");
+
+    assertThat(output.seekMap.getDurationUs()).isEqualTo(999_977);
+    assertThat(output.trackOutputs.get(0).getDurationUs()).isEqualTo(999_977);
+    assertThat(output.trackOutputs.get(0).lastFormat.averageBitrate).isEqualTo(66_874);
+  }
+
+  @Test
+  public void mp3SampleWithInfoHeader_invalidDataSizeFallsBackToFrameBitrate() throws Exception {
+    byte[] fileBytes =
+        TestUtil.getByteArray(
+            ApplicationProvider.getApplicationContext(), "media/mp3/test-cbr-info-header.mp3");
+    int infoTagOffset = indexOf(fileBytes, new byte[] {'I', 'n', 'f', 'o'});
+    assertThat(infoTagOffset).isAtLeast(0);
+    int infoFramePosition = findMpegFramePositionBeforeTag(fileBytes, infoTagOffset);
+    assertThat(infoFramePosition).isNotEqualTo(C.INDEX_UNSET);
+    MpegAudioUtil.Header infoFrameHeader = new MpegAudioUtil.Header();
+    assertThat(infoFrameHeader.setForHeaderData(readBigEndianInt(fileBytes, infoFramePosition)))
+        .isTrue();
+    writeBigEndianInt(fileBytes, infoTagOffset + 12, infoFrameHeader.frameSize);
+
+    FakeExtractorOutput output =
+        extractUntilSeekMap(
+            new Mp3Extractor(), fileBytes, /* simulateUnknownLength= */ false);
+
+    assertThat(output.trackOutputs.get(0).lastFormat.averageBitrate).isEqualTo(64_000);
   }
 
   // https://github.com/androidx/media/issues/1376#issuecomment-2117393653
@@ -212,6 +248,24 @@ public final class Mp3ExtractorTest {
         "media/mp3/bear-vbr-no-seek-table.mp3",
         /* peekLimit= */ 1500,
         simulationConfig);
+  }
+
+  @Test
+  public void mp3CbrSampleWithIndexSeekingFlagAndUnknownLength_reportsUnsetAverageBitrate()
+      throws Exception {
+    byte[] fileBytes =
+        TestUtil.getByteArray(
+            ApplicationProvider.getApplicationContext(),
+            "media/mp3/bear-cbr-variable-frame-size-no-seek-table.mp3");
+
+    FakeExtractorOutput output =
+        extractUntilSeekMap(
+            new Mp3Extractor(Mp3Extractor.FLAG_ENABLE_INDEX_SEEKING),
+            fileBytes,
+            /* simulateUnknownLength= */ true);
+
+    assertThat(output.seekMap).isInstanceOf(IndexSeeker.class);
+    assertThat(output.trackOutputs.get(0).lastFormat.averageBitrate).isEqualTo(Format.NO_VALUE);
   }
 
   // https://github.com/androidx/media/issues/1563
@@ -386,5 +440,62 @@ public final class Mp3ExtractorTest {
     }
     String suffix = "." + Ascii.toLowerCase(configName).replace('_', '-');
     return inputFilePath.replaceFirst("media", "extractordumps") + suffix;
+  }
+
+  private static FakeExtractorOutput extractUntilSeekMap(
+      Mp3Extractor extractor, byte[] fileBytes, boolean simulateUnknownLength) throws Exception {
+    FakeExtractorOutput output = new FakeExtractorOutput();
+    extractor.init(output);
+    FakeExtractorInput input =
+        new FakeExtractorInput.Builder()
+            .setData(fileBytes)
+            .setSimulateUnknownLength(simulateUnknownLength)
+            .build();
+    PositionHolder positionHolder = new PositionHolder();
+
+    while (output.seekMap == null) {
+      assertThat(extractor.read(input, positionHolder))
+          .isNotEqualTo(Extractor.RESULT_END_OF_INPUT);
+    }
+    return output;
+  }
+
+  private static int findMpegFramePositionBeforeTag(byte[] data, int tagOffset) {
+    for (int tagOffsetFromFrameStart : new int[] {13, 21, 36}) {
+      int framePosition = tagOffset - tagOffsetFromFrameStart;
+      if (framePosition >= 0
+          && framePosition + 4 <= data.length
+          && new MpegAudioUtil.Header().setForHeaderData(readBigEndianInt(data, framePosition))) {
+        return framePosition;
+      }
+    }
+    return C.INDEX_UNSET;
+  }
+
+  private static int indexOf(byte[] data, byte[] target) {
+    for (int i = 0; i <= data.length - target.length; i++) {
+      boolean matches = true;
+      for (int j = 0; j < target.length; j++) {
+        matches &= data[i + j] == target[j];
+      }
+      if (matches) {
+        return i;
+      }
+    }
+    return C.INDEX_UNSET;
+  }
+
+  private static int readBigEndianInt(byte[] data, int offset) {
+    return ((data[offset] & 0xFF) << 24)
+        | ((data[offset + 1] & 0xFF) << 16)
+        | ((data[offset + 2] & 0xFF) << 8)
+        | (data[offset + 3] & 0xFF);
+  }
+
+  private static void writeBigEndianInt(byte[] data, int offset, int value) {
+    data[offset] = (byte) (value >> 24);
+    data[offset + 1] = (byte) (value >> 16);
+    data[offset + 2] = (byte) (value >> 8);
+    data[offset + 3] = (byte) value;
   }
 }

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/Mp3ExtractorTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/Mp3ExtractorTest.java
@@ -139,8 +139,7 @@ public final class Mp3ExtractorTest {
     writeBigEndianInt(fileBytes, infoTagOffset + 12, infoFrameHeader.frameSize);
 
     FakeExtractorOutput output =
-        extractUntilSeekMap(
-            new Mp3Extractor(), fileBytes, /* simulateUnknownLength= */ false);
+        extractUntilSeekMap(new Mp3Extractor(), fileBytes, /* simulateUnknownLength= */ false);
 
     assertThat(output.trackOutputs.get(0).lastFormat.averageBitrate).isEqualTo(64_000);
   }
@@ -454,8 +453,7 @@ public final class Mp3ExtractorTest {
     PositionHolder positionHolder = new PositionHolder();
 
     while (output.seekMap == null) {
-      assertThat(extractor.read(input, positionHolder))
-          .isNotEqualTo(Extractor.RESULT_END_OF_INPUT);
+      assertThat(extractor.read(input, positionHolder)).isNotEqualTo(Extractor.RESULT_END_OF_INPUT);
     }
     return output;
   }

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/XingFrameTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/XingFrameTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.extractor.mp3;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import androidx.media3.common.C;
+import androidx.media3.common.util.ParsableByteArray;
+import androidx.media3.common.util.Util;
+import androidx.media3.extractor.MpegAudioUtil;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.nio.ByteBuffer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Tests for {@link XingFrame}. */
+@RunWith(AndroidJUnit4.class)
+public final class XingFrameTest {
+
+  private static final int INFO_FRAME_HEADER_DATA = 0xFFFB40C0;
+
+  @Test
+  public void computeDurationUs_withEncoderDelayAndPadding_subtractsGaplessSamples() {
+    XingFrame frame =
+        createXingFrame(
+            INFO_FRAME_HEADER_DATA,
+            /* frameCount= */ 40,
+            /* dataSize= */ 8_541,
+            /* encoderDelay= */ 576,
+            /* encoderPadding= */ 1_404);
+
+    long gaplessSampleCount =
+        frame.frameCount * frame.header.samplesPerFrame
+            - frame.encoderDelay
+            - frame.encoderPadding;
+
+    assertThat(frame.computeDurationUs())
+        .isEqualTo(Util.sampleCountToDurationUs(gaplessSampleCount - 1, frame.header.sampleRate));
+  }
+
+  @Test
+  public void computeDurationUs_withoutEncoderDelayAndPadding_returnsFullDuration() {
+    XingFrame frame =
+        createXingFrame(
+            INFO_FRAME_HEADER_DATA,
+            /* payload= */ Util.getBytesFromHexString("00000003000000280000215d"));
+
+    long sampleCount = frame.frameCount * frame.header.samplesPerFrame;
+    assertThat(frame.computeDurationUs())
+        .isEqualTo(Util.sampleCountToDurationUs(sampleCount - 1, frame.header.sampleRate));
+  }
+
+  @Test
+  public void computeDurationUs_withInvalidGaplessSampleCount_returnsTimeUnset() {
+    XingFrame frame =
+        createXingFrame(
+            INFO_FRAME_HEADER_DATA,
+            /* frameCount= */ 1,
+            /* dataSize= */ 8_541,
+            /* encoderDelay= */ 576,
+            /* encoderPadding= */ 576);
+
+    assertThat(frame.computeDurationUs()).isEqualTo(C.TIME_UNSET);
+  }
+
+  private static XingFrame createXingFrame(
+      int headerData, int frameCount, int dataSize, int encoderDelay, int encoderPadding) {
+    int encoderDelayAndPadding = (encoderDelay << 12) | encoderPadding;
+    ByteBuffer payload = ByteBuffer.allocate(4 + 4 + 4 + 11 + 8 + 2 + 3);
+    payload.putInt(0x03);
+    payload.putInt(frameCount);
+    payload.putInt(dataSize);
+    payload.position(payload.position() + 11 + 8 + 2);
+    payload.put((byte) (encoderDelayAndPadding >> 16));
+    payload.put((byte) (encoderDelayAndPadding >> 8));
+    payload.put((byte) encoderDelayAndPadding);
+    return createXingFrame(headerData, payload.array());
+  }
+
+  private static XingFrame createXingFrame(int headerData, byte[] payload) {
+    MpegAudioUtil.Header xingFrameHeader = new MpegAudioUtil.Header();
+    xingFrameHeader.setForHeaderData(headerData);
+    return XingFrame.parse(xingFrameHeader, new ParsableByteArray(payload));
+  }
+}

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/XingFrameTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/XingFrameTest.java
@@ -43,9 +43,7 @@ public final class XingFrameTest {
             /* encoderPadding= */ 1_404);
 
     long gaplessSampleCount =
-        frame.frameCount * frame.header.samplesPerFrame
-            - frame.encoderDelay
-            - frame.encoderPadding;
+        frame.frameCount * frame.header.samplesPerFrame - frame.encoderDelay - frame.encoderPadding;
 
     assertThat(frame.computeDurationUs())
         .isEqualTo(Util.sampleCountToDurationUs(gaplessSampleCount - 1, frame.header.sampleRate));

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/XingSeekerTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/XingSeekerTest.java
@@ -25,6 +25,7 @@ import androidx.media3.extractor.SeekMap.SeekPoints;
 import androidx.media3.extractor.SeekPoint;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.math.RoundingMode;
+import java.nio.ByteBuffer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -99,6 +100,42 @@ public final class XingSeekerTest {
 
     assertThat(seeker.getAverageBitrate()).isEqualTo(expectedAverageBitrate);
     assertThat(seeker.getAverageBitrate()).isNotEqualTo(XING_FRAME.header.bitrate);
+  }
+
+  @Test
+  public void getAverageBitrate_withEncoderDelayAndPadding_usesGaplessDuration() {
+    XingFrame frame =
+        createXingFrame(
+            XING_FRAME_HEADER_DATA,
+            /* frameCount= */ 40,
+            /* dataSize= */ 8_541,
+            /* encoderDelay= */ 576,
+            /* encoderPadding= */ 1_404);
+    XingSeeker seeker =
+        XingSeeker.create(
+            frame, XING_FRAME_POSITION, /* streamLength= */ XING_FRAME_POSITION + frame.dataSize);
+    long gaplessDurationUs = frame.computeDurationUs();
+    long encodedDurationUs =
+        Util.sampleCountToDurationUs(
+            frame.frameCount * frame.header.samplesPerFrame - 1, frame.header.sampleRate);
+    int expectedAverageBitrate =
+        (int)
+            Util.scaleLargeValue(
+                frame.dataSize - frame.header.frameSize,
+                C.BITS_PER_BYTE * C.MICROS_PER_SECOND,
+                gaplessDurationUs,
+                RoundingMode.HALF_UP);
+    int encodedDurationAverageBitrate =
+        (int)
+            Util.scaleLargeValue(
+                frame.dataSize - frame.header.frameSize,
+                C.BITS_PER_BYTE * C.MICROS_PER_SECOND,
+                encodedDurationUs,
+                RoundingMode.HALF_UP);
+
+    assertThat(seeker.getDurationUs()).isEqualTo(gaplessDurationUs);
+    assertThat(seeker.getAverageBitrate()).isEqualTo(expectedAverageBitrate);
+    assertThat(seeker.getAverageBitrate()).isNotEqualTo(encodedDurationAverageBitrate);
   }
 
   // https://github.com/androidx/media/issues/3117#issuecomment-4046538506
@@ -203,5 +240,19 @@ public final class XingSeekerTest {
     MpegAudioUtil.Header xingFrameHeader = new MpegAudioUtil.Header();
     xingFrameHeader.setForHeaderData(header);
     return XingFrame.parse(xingFrameHeader, new ParsableByteArray(payload));
+  }
+
+  private static XingFrame createXingFrame(
+      int headerData, int frameCount, int dataSize, int encoderDelay, int encoderPadding) {
+    int encoderDelayAndPadding = (encoderDelay << 12) | encoderPadding;
+    ByteBuffer payload = ByteBuffer.allocate(4 + 4 + 4 + 11 + 8 + 2 + 3);
+    payload.putInt(0x03);
+    payload.putInt(frameCount);
+    payload.putInt(dataSize);
+    payload.position(payload.position() + 11 + 8 + 2);
+    payload.put((byte) (encoderDelayAndPadding >> 16));
+    payload.put((byte) (encoderDelayAndPadding >> 8));
+    payload.put((byte) encoderDelayAndPadding);
+    return createXingFrame(headerData, payload.array());
   }
 }

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.0.dump
@@ -1,14 +1,14 @@
 seekMap:
   isSeekable = false
-  duration = 2807979
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
 numberOfTracks = 1
 track 0:
   total output bytes = 38160
   sample count = 117
-  track duration = 2807979
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.0.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807972
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
-  getPosition(1) = [[timeUs=0, position=237], [timeUs=73, position=238]]
-  getPosition(1403986) = [[timeUs=1403912, position=19316], [timeUs=1403986, position=19317]]
-  getPosition(2807972) = [[timeUs=2807899, position=38396]]
+  getPosition(1) = [[timeUs=0, position=237], [timeUs=72, position=238]]
+  getPosition(1391989) = [[timeUs=1391916, position=19316], [timeUs=1391989, position=19317]]
+  getPosition(2783979) = [[timeUs=2783907, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 38160
   sample count = 117
-  track duration = 2807972
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.1.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807972
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
-  getPosition(1) = [[timeUs=0, position=237], [timeUs=73, position=238]]
-  getPosition(1403986) = [[timeUs=1403912, position=19316], [timeUs=1403986, position=19317]]
-  getPosition(2807972) = [[timeUs=2807899, position=38396]]
+  getPosition(1) = [[timeUs=0, position=237], [timeUs=72, position=238]]
+  getPosition(1391989) = [[timeUs=1391916, position=19316], [timeUs=1391989, position=19317]]
+  getPosition(2783979) = [[timeUs=2783907, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 25344
   sample count = 80
-  track duration = 2807972
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,323 +21,323 @@ track 0:
     encoderPadding = 576
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
-    time = 943055
+    time = 934996
     flags = 1
     data = length 336, hash E917C122
   sample 1:
-    time = 967055
+    time = 958996
     flags = 1
     data = length 336, hash 10ED1470
   sample 2:
-    time = 991055
+    time = 982996
     flags = 1
     data = length 288, hash 706B8A7C
   sample 3:
-    time = 1015055
+    time = 1006996
     flags = 1
     data = length 336, hash 71FFE4A0
   sample 4:
-    time = 1039055
+    time = 1030996
     flags = 1
     data = length 336, hash D4160463
   sample 5:
-    time = 1063055
+    time = 1054996
     flags = 1
     data = length 336, hash EC557B14
   sample 6:
-    time = 1087055
+    time = 1078996
     flags = 1
     data = length 288, hash 5598CF8B
   sample 7:
-    time = 1111055
+    time = 1102996
     flags = 1
     data = length 336, hash 7E0AB41
   sample 8:
-    time = 1135055
+    time = 1126996
     flags = 1
     data = length 336, hash 1C585FEF
   sample 9:
-    time = 1159055
+    time = 1150996
     flags = 1
     data = length 336, hash A4A4855E
   sample 10:
-    time = 1183055
+    time = 1174996
     flags = 1
     data = length 336, hash CECA51D3
   sample 11:
-    time = 1207055
+    time = 1198996
     flags = 1
     data = length 288, hash 2D362DC5
   sample 12:
-    time = 1231055
+    time = 1222996
     flags = 1
     data = length 336, hash 9EB2609D
   sample 13:
-    time = 1255055
+    time = 1246996
     flags = 1
     data = length 336, hash 28FFB3FE
   sample 14:
-    time = 1279055
+    time = 1270996
     flags = 1
     data = length 288, hash 2AA2D216
   sample 15:
-    time = 1303055
+    time = 1294996
     flags = 1
     data = length 336, hash CDBC7032
   sample 16:
-    time = 1327055
+    time = 1318996
     flags = 1
     data = length 336, hash 25B13FE7
   sample 17:
-    time = 1351055
+    time = 1342996
     flags = 1
     data = length 336, hash DB6BB1E
   sample 18:
-    time = 1375055
+    time = 1366996
     flags = 1
     data = length 336, hash EBE951F4
   sample 19:
-    time = 1399055
+    time = 1390996
     flags = 1
     data = length 288, hash 9E2EBFF7
   sample 20:
-    time = 1423055
+    time = 1414996
     flags = 1
     data = length 336, hash 36A7D455
   sample 21:
-    time = 1447055
+    time = 1438996
     flags = 1
     data = length 336, hash 84545F8C
   sample 22:
-    time = 1471055
+    time = 1462996
     flags = 1
     data = length 336, hash F66F3045
   sample 23:
-    time = 1495055
+    time = 1486996
     flags = 1
     data = length 576, hash 5AB089EA
   sample 24:
-    time = 1519055
+    time = 1510996
     flags = 1
     data = length 336, hash 8868086
   sample 25:
-    time = 1543055
+    time = 1534996
     flags = 1
     data = length 336, hash D5EB6D63
   sample 26:
-    time = 1567055
+    time = 1558996
     flags = 1
     data = length 288, hash 7A5374B7
   sample 27:
-    time = 1591055
+    time = 1582996
     flags = 1
     data = length 336, hash BEB27A75
   sample 28:
-    time = 1615055
+    time = 1606996
     flags = 1
     data = length 336, hash E251E0FD
   sample 29:
-    time = 1639055
+    time = 1630996
     flags = 1
     data = length 288, hash D54C970
   sample 30:
-    time = 1663055
+    time = 1654996
     flags = 1
     data = length 336, hash 52C473B9
   sample 31:
-    time = 1687055
+    time = 1678996
     flags = 1
     data = length 336, hash F5F13334
   sample 32:
-    time = 1711055
+    time = 1702996
     flags = 1
     data = length 480, hash A5F1E987
   sample 33:
-    time = 1735055
+    time = 1726996
     flags = 1
     data = length 288, hash 453A1267
   sample 34:
-    time = 1759055
+    time = 1750996
     flags = 1
     data = length 288, hash 7C6C2EA9
   sample 35:
-    time = 1783055
+    time = 1774996
     flags = 1
     data = length 336, hash F4BFECA4
   sample 36:
-    time = 1807055
+    time = 1798996
     flags = 1
     data = length 336, hash 751A395A
   sample 37:
-    time = 1831055
+    time = 1822996
     flags = 1
     data = length 336, hash EE38DB02
   sample 38:
-    time = 1855055
+    time = 1846996
     flags = 1
     data = length 336, hash F18837E2
   sample 39:
-    time = 1879055
+    time = 1870996
     flags = 1
     data = length 336, hash ED36B78E
   sample 40:
-    time = 1903055
+    time = 1894996
     flags = 1
     data = length 336, hash B3D28289
   sample 41:
-    time = 1927055
+    time = 1918996
     flags = 1
     data = length 288, hash 8BDE28E1
   sample 42:
-    time = 1951055
+    time = 1942996
     flags = 1
     data = length 336, hash CFD5E966
   sample 43:
-    time = 1975055
+    time = 1966996
     flags = 1
     data = length 288, hash DC08E267
   sample 44:
-    time = 1999055
+    time = 1990996
     flags = 1
     data = length 336, hash 6530CB78
   sample 45:
-    time = 2023055
+    time = 2014996
     flags = 1
     data = length 336, hash 6CC6636E
   sample 46:
-    time = 2047055
+    time = 2038996
     flags = 1
     data = length 336, hash 613047C1
   sample 47:
-    time = 2071055
+    time = 2062996
     flags = 1
     data = length 288, hash CDC747BF
   sample 48:
-    time = 2095055
+    time = 2086996
     flags = 1
     data = length 336, hash AF22AA74
   sample 49:
-    time = 2119055
+    time = 2110996
     flags = 1
     data = length 384, hash 82F326AA
   sample 50:
-    time = 2143055
+    time = 2134996
     flags = 1
     data = length 384, hash EDA26C4D
   sample 51:
-    time = 2167055
+    time = 2158996
     flags = 1
     data = length 336, hash 94C643DC
   sample 52:
-    time = 2191055
+    time = 2182996
     flags = 1
     data = length 288, hash CB5D9C40
   sample 53:
-    time = 2215055
+    time = 2206996
     flags = 1
     data = length 336, hash 1E69DE3F
   sample 54:
-    time = 2239055
+    time = 2230996
     flags = 1
     data = length 336, hash 7E472219
   sample 55:
-    time = 2263055
+    time = 2254996
     flags = 1
     data = length 336, hash DA47B9FA
   sample 56:
-    time = 2287055
+    time = 2278996
     flags = 1
     data = length 336, hash DD0ABB7C
   sample 57:
-    time = 2311055
+    time = 2302996
     flags = 1
     data = length 288, hash DBF93FAC
   sample 58:
-    time = 2335055
+    time = 2326996
     flags = 1
     data = length 336, hash 243F4B2
   sample 59:
-    time = 2359055
+    time = 2350996
     flags = 1
     data = length 336, hash 2E881490
   sample 60:
-    time = 2383055
+    time = 2374996
     flags = 1
     data = length 288, hash 1C28C8BE
   sample 61:
-    time = 2407055
+    time = 2398996
     flags = 1
     data = length 336, hash C73E5D30
   sample 62:
-    time = 2431055
+    time = 2422996
     flags = 1
     data = length 288, hash 98B5BFF6
   sample 63:
-    time = 2455055
+    time = 2446996
     flags = 1
     data = length 336, hash E0135533
   sample 64:
-    time = 2479055
+    time = 2470996
     flags = 1
     data = length 336, hash D13C9DBC
   sample 65:
-    time = 2503055
+    time = 2494996
     flags = 1
     data = length 336, hash 63D524CA
   sample 66:
-    time = 2527055
+    time = 2518996
     flags = 1
     data = length 288, hash A28514C3
   sample 67:
-    time = 2551055
+    time = 2542996
     flags = 1
     data = length 336, hash 72B647FF
   sample 68:
-    time = 2575055
+    time = 2566996
     flags = 1
     data = length 336, hash 8F740AB1
   sample 69:
-    time = 2599055
+    time = 2590996
     flags = 1
     data = length 336, hash 5E3C7E93
   sample 70:
-    time = 2623055
+    time = 2614996
     flags = 1
     data = length 336, hash 121B913B
   sample 71:
-    time = 2647055
+    time = 2638996
     flags = 1
     data = length 336, hash 578FCCF2
   sample 72:
-    time = 2671055
+    time = 2662996
     flags = 1
     data = length 336, hash 5B5823DE
   sample 73:
-    time = 2695055
+    time = 2686996
     flags = 1
     data = length 384, hash D8B83F78
   sample 74:
-    time = 2719055
+    time = 2710996
     flags = 1
     data = length 240, hash E649682F
   sample 75:
-    time = 2743055
+    time = 2734996
     flags = 1
     data = length 96, hash C559A6F4
   sample 76:
-    time = 2767055
+    time = 2758996
     flags = 1
     data = length 96, hash 792796BC
   sample 77:
-    time = 2791055
+    time = 2782996
     flags = 1
     data = length 120, hash 8172CD0E
   sample 78:
-    time = 2815055
+    time = 2806996
     flags = 1
     data = length 120, hash F562B52F
   sample 79:
-    time = 2839055
+    time = 2830996
     flags = 1
     data = length 96, hash FF8D5B98
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.2.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807972
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
-  getPosition(1) = [[timeUs=0, position=237], [timeUs=73, position=238]]
-  getPosition(1403986) = [[timeUs=1403912, position=19316], [timeUs=1403986, position=19317]]
-  getPosition(2807972) = [[timeUs=2807899, position=38396]]
+  getPosition(1) = [[timeUs=0, position=237], [timeUs=72, position=238]]
+  getPosition(1391989) = [[timeUs=1391916, position=19316], [timeUs=1391989, position=19317]]
+  getPosition(2783979) = [[timeUs=2783907, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 12624
   sample count = 42
-  track duration = 2807972
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,171 +21,171 @@ track 0:
     encoderPadding = 576
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
-    time = 1879045
+    time = 1862989
     flags = 1
     data = length 336, hash F18837E2
   sample 1:
-    time = 1903045
+    time = 1886989
     flags = 1
     data = length 336, hash ED36B78E
   sample 2:
-    time = 1927045
+    time = 1910989
     flags = 1
     data = length 336, hash B3D28289
   sample 3:
-    time = 1951045
+    time = 1934989
     flags = 1
     data = length 288, hash 8BDE28E1
   sample 4:
-    time = 1975045
+    time = 1958989
     flags = 1
     data = length 336, hash CFD5E966
   sample 5:
-    time = 1999045
+    time = 1982989
     flags = 1
     data = length 288, hash DC08E267
   sample 6:
-    time = 2023045
+    time = 2006989
     flags = 1
     data = length 336, hash 6530CB78
   sample 7:
-    time = 2047045
+    time = 2030989
     flags = 1
     data = length 336, hash 6CC6636E
   sample 8:
-    time = 2071045
+    time = 2054989
     flags = 1
     data = length 336, hash 613047C1
   sample 9:
-    time = 2095045
+    time = 2078989
     flags = 1
     data = length 288, hash CDC747BF
   sample 10:
-    time = 2119045
+    time = 2102989
     flags = 1
     data = length 336, hash AF22AA74
   sample 11:
-    time = 2143045
+    time = 2126989
     flags = 1
     data = length 384, hash 82F326AA
   sample 12:
-    time = 2167045
+    time = 2150989
     flags = 1
     data = length 384, hash EDA26C4D
   sample 13:
-    time = 2191045
+    time = 2174989
     flags = 1
     data = length 336, hash 94C643DC
   sample 14:
-    time = 2215045
+    time = 2198989
     flags = 1
     data = length 288, hash CB5D9C40
   sample 15:
-    time = 2239045
+    time = 2222989
     flags = 1
     data = length 336, hash 1E69DE3F
   sample 16:
-    time = 2263045
+    time = 2246989
     flags = 1
     data = length 336, hash 7E472219
   sample 17:
-    time = 2287045
+    time = 2270989
     flags = 1
     data = length 336, hash DA47B9FA
   sample 18:
-    time = 2311045
+    time = 2294989
     flags = 1
     data = length 336, hash DD0ABB7C
   sample 19:
-    time = 2335045
+    time = 2318989
     flags = 1
     data = length 288, hash DBF93FAC
   sample 20:
-    time = 2359045
+    time = 2342989
     flags = 1
     data = length 336, hash 243F4B2
   sample 21:
-    time = 2383045
+    time = 2366989
     flags = 1
     data = length 336, hash 2E881490
   sample 22:
-    time = 2407045
+    time = 2390989
     flags = 1
     data = length 288, hash 1C28C8BE
   sample 23:
-    time = 2431045
+    time = 2414989
     flags = 1
     data = length 336, hash C73E5D30
   sample 24:
-    time = 2455045
+    time = 2438989
     flags = 1
     data = length 288, hash 98B5BFF6
   sample 25:
-    time = 2479045
+    time = 2462989
     flags = 1
     data = length 336, hash E0135533
   sample 26:
-    time = 2503045
+    time = 2486989
     flags = 1
     data = length 336, hash D13C9DBC
   sample 27:
-    time = 2527045
+    time = 2510989
     flags = 1
     data = length 336, hash 63D524CA
   sample 28:
-    time = 2551045
+    time = 2534989
     flags = 1
     data = length 288, hash A28514C3
   sample 29:
-    time = 2575045
+    time = 2558989
     flags = 1
     data = length 336, hash 72B647FF
   sample 30:
-    time = 2599045
+    time = 2582989
     flags = 1
     data = length 336, hash 8F740AB1
   sample 31:
-    time = 2623045
+    time = 2606989
     flags = 1
     data = length 336, hash 5E3C7E93
   sample 32:
-    time = 2647045
+    time = 2630989
     flags = 1
     data = length 336, hash 121B913B
   sample 33:
-    time = 2671045
+    time = 2654989
     flags = 1
     data = length 336, hash 578FCCF2
   sample 34:
-    time = 2695045
+    time = 2678989
     flags = 1
     data = length 336, hash 5B5823DE
   sample 35:
-    time = 2719045
+    time = 2702989
     flags = 1
     data = length 384, hash D8B83F78
   sample 36:
-    time = 2743045
+    time = 2726989
     flags = 1
     data = length 240, hash E649682F
   sample 37:
-    time = 2767045
+    time = 2750989
     flags = 1
     data = length 96, hash C559A6F4
   sample 38:
-    time = 2791045
+    time = 2774989
     flags = 1
     data = length 96, hash 792796BC
   sample 39:
-    time = 2815045
+    time = 2798989
     flags = 1
     data = length 120, hash 8172CD0E
   sample 40:
-    time = 2839045
+    time = 2822989
     flags = 1
     data = length 120, hash F562B52F
   sample 41:
-    time = 2863045
+    time = 2846989
     flags = 1
     data = length 96, hash FF8D5B98
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.3.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807972
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
-  getPosition(1) = [[timeUs=0, position=237], [timeUs=73, position=238]]
-  getPosition(1403986) = [[timeUs=1403912, position=19316], [timeUs=1403986, position=19317]]
-  getPosition(2807972) = [[timeUs=2807899, position=38396]]
+  getPosition(1) = [[timeUs=0, position=237], [timeUs=72, position=238]]
+  getPosition(1391989) = [[timeUs=1391916, position=19316], [timeUs=1391989, position=19317]]
+  getPosition(2783979) = [[timeUs=2783907, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 0
   sample count = 0
-  track duration = 2807972
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.unknown_length.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807972
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
-  getPosition(1) = [[timeUs=0, position=237], [timeUs=73, position=238]]
-  getPosition(1403986) = [[timeUs=1403912, position=19316], [timeUs=1403986, position=19317]]
-  getPosition(2807972) = [[timeUs=2807899, position=38396]]
+  getPosition(1) = [[timeUs=0, position=237], [timeUs=72, position=238]]
+  getPosition(1391989) = [[timeUs=1391916, position=19316], [timeUs=1391989, position=19317]]
+  getPosition(2783979) = [[timeUs=2783907, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 38160
   sample count = 117
-  track duration = 2807972
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.0.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807972
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
-  getPosition(1) = [[timeUs=0, position=237], [timeUs=73, position=238]]
-  getPosition(1403986) = [[timeUs=1403912, position=19316], [timeUs=1403986, position=19317]]
-  getPosition(2807972) = [[timeUs=2807899, position=38396]]
+  getPosition(1) = [[timeUs=0, position=237], [timeUs=72, position=238]]
+  getPosition(1391989) = [[timeUs=1391916, position=19316], [timeUs=1391989, position=19317]]
+  getPosition(2783979) = [[timeUs=2783907, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 38160
   sample count = 117
-  track duration = 2807972
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.1.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807972
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
-  getPosition(1) = [[timeUs=0, position=237], [timeUs=73, position=238]]
-  getPosition(1403986) = [[timeUs=1403912, position=19316], [timeUs=1403986, position=19317]]
-  getPosition(2807972) = [[timeUs=2807899, position=38396]]
+  getPosition(1) = [[timeUs=0, position=237], [timeUs=72, position=238]]
+  getPosition(1391989) = [[timeUs=1391916, position=19316], [timeUs=1391989, position=19317]]
+  getPosition(2783979) = [[timeUs=2783907, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 25344
   sample count = 80
-  track duration = 2807972
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,323 +21,323 @@ track 0:
     encoderPadding = 576
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
-    time = 943055
+    time = 934996
     flags = 1
     data = length 336, hash E917C122
   sample 1:
-    time = 967055
+    time = 958996
     flags = 1
     data = length 336, hash 10ED1470
   sample 2:
-    time = 991055
+    time = 982996
     flags = 1
     data = length 288, hash 706B8A7C
   sample 3:
-    time = 1015055
+    time = 1006996
     flags = 1
     data = length 336, hash 71FFE4A0
   sample 4:
-    time = 1039055
+    time = 1030996
     flags = 1
     data = length 336, hash D4160463
   sample 5:
-    time = 1063055
+    time = 1054996
     flags = 1
     data = length 336, hash EC557B14
   sample 6:
-    time = 1087055
+    time = 1078996
     flags = 1
     data = length 288, hash 5598CF8B
   sample 7:
-    time = 1111055
+    time = 1102996
     flags = 1
     data = length 336, hash 7E0AB41
   sample 8:
-    time = 1135055
+    time = 1126996
     flags = 1
     data = length 336, hash 1C585FEF
   sample 9:
-    time = 1159055
+    time = 1150996
     flags = 1
     data = length 336, hash A4A4855E
   sample 10:
-    time = 1183055
+    time = 1174996
     flags = 1
     data = length 336, hash CECA51D3
   sample 11:
-    time = 1207055
+    time = 1198996
     flags = 1
     data = length 288, hash 2D362DC5
   sample 12:
-    time = 1231055
+    time = 1222996
     flags = 1
     data = length 336, hash 9EB2609D
   sample 13:
-    time = 1255055
+    time = 1246996
     flags = 1
     data = length 336, hash 28FFB3FE
   sample 14:
-    time = 1279055
+    time = 1270996
     flags = 1
     data = length 288, hash 2AA2D216
   sample 15:
-    time = 1303055
+    time = 1294996
     flags = 1
     data = length 336, hash CDBC7032
   sample 16:
-    time = 1327055
+    time = 1318996
     flags = 1
     data = length 336, hash 25B13FE7
   sample 17:
-    time = 1351055
+    time = 1342996
     flags = 1
     data = length 336, hash DB6BB1E
   sample 18:
-    time = 1375055
+    time = 1366996
     flags = 1
     data = length 336, hash EBE951F4
   sample 19:
-    time = 1399055
+    time = 1390996
     flags = 1
     data = length 288, hash 9E2EBFF7
   sample 20:
-    time = 1423055
+    time = 1414996
     flags = 1
     data = length 336, hash 36A7D455
   sample 21:
-    time = 1447055
+    time = 1438996
     flags = 1
     data = length 336, hash 84545F8C
   sample 22:
-    time = 1471055
+    time = 1462996
     flags = 1
     data = length 336, hash F66F3045
   sample 23:
-    time = 1495055
+    time = 1486996
     flags = 1
     data = length 576, hash 5AB089EA
   sample 24:
-    time = 1519055
+    time = 1510996
     flags = 1
     data = length 336, hash 8868086
   sample 25:
-    time = 1543055
+    time = 1534996
     flags = 1
     data = length 336, hash D5EB6D63
   sample 26:
-    time = 1567055
+    time = 1558996
     flags = 1
     data = length 288, hash 7A5374B7
   sample 27:
-    time = 1591055
+    time = 1582996
     flags = 1
     data = length 336, hash BEB27A75
   sample 28:
-    time = 1615055
+    time = 1606996
     flags = 1
     data = length 336, hash E251E0FD
   sample 29:
-    time = 1639055
+    time = 1630996
     flags = 1
     data = length 288, hash D54C970
   sample 30:
-    time = 1663055
+    time = 1654996
     flags = 1
     data = length 336, hash 52C473B9
   sample 31:
-    time = 1687055
+    time = 1678996
     flags = 1
     data = length 336, hash F5F13334
   sample 32:
-    time = 1711055
+    time = 1702996
     flags = 1
     data = length 480, hash A5F1E987
   sample 33:
-    time = 1735055
+    time = 1726996
     flags = 1
     data = length 288, hash 453A1267
   sample 34:
-    time = 1759055
+    time = 1750996
     flags = 1
     data = length 288, hash 7C6C2EA9
   sample 35:
-    time = 1783055
+    time = 1774996
     flags = 1
     data = length 336, hash F4BFECA4
   sample 36:
-    time = 1807055
+    time = 1798996
     flags = 1
     data = length 336, hash 751A395A
   sample 37:
-    time = 1831055
+    time = 1822996
     flags = 1
     data = length 336, hash EE38DB02
   sample 38:
-    time = 1855055
+    time = 1846996
     flags = 1
     data = length 336, hash F18837E2
   sample 39:
-    time = 1879055
+    time = 1870996
     flags = 1
     data = length 336, hash ED36B78E
   sample 40:
-    time = 1903055
+    time = 1894996
     flags = 1
     data = length 336, hash B3D28289
   sample 41:
-    time = 1927055
+    time = 1918996
     flags = 1
     data = length 288, hash 8BDE28E1
   sample 42:
-    time = 1951055
+    time = 1942996
     flags = 1
     data = length 336, hash CFD5E966
   sample 43:
-    time = 1975055
+    time = 1966996
     flags = 1
     data = length 288, hash DC08E267
   sample 44:
-    time = 1999055
+    time = 1990996
     flags = 1
     data = length 336, hash 6530CB78
   sample 45:
-    time = 2023055
+    time = 2014996
     flags = 1
     data = length 336, hash 6CC6636E
   sample 46:
-    time = 2047055
+    time = 2038996
     flags = 1
     data = length 336, hash 613047C1
   sample 47:
-    time = 2071055
+    time = 2062996
     flags = 1
     data = length 288, hash CDC747BF
   sample 48:
-    time = 2095055
+    time = 2086996
     flags = 1
     data = length 336, hash AF22AA74
   sample 49:
-    time = 2119055
+    time = 2110996
     flags = 1
     data = length 384, hash 82F326AA
   sample 50:
-    time = 2143055
+    time = 2134996
     flags = 1
     data = length 384, hash EDA26C4D
   sample 51:
-    time = 2167055
+    time = 2158996
     flags = 1
     data = length 336, hash 94C643DC
   sample 52:
-    time = 2191055
+    time = 2182996
     flags = 1
     data = length 288, hash CB5D9C40
   sample 53:
-    time = 2215055
+    time = 2206996
     flags = 1
     data = length 336, hash 1E69DE3F
   sample 54:
-    time = 2239055
+    time = 2230996
     flags = 1
     data = length 336, hash 7E472219
   sample 55:
-    time = 2263055
+    time = 2254996
     flags = 1
     data = length 336, hash DA47B9FA
   sample 56:
-    time = 2287055
+    time = 2278996
     flags = 1
     data = length 336, hash DD0ABB7C
   sample 57:
-    time = 2311055
+    time = 2302996
     flags = 1
     data = length 288, hash DBF93FAC
   sample 58:
-    time = 2335055
+    time = 2326996
     flags = 1
     data = length 336, hash 243F4B2
   sample 59:
-    time = 2359055
+    time = 2350996
     flags = 1
     data = length 336, hash 2E881490
   sample 60:
-    time = 2383055
+    time = 2374996
     flags = 1
     data = length 288, hash 1C28C8BE
   sample 61:
-    time = 2407055
+    time = 2398996
     flags = 1
     data = length 336, hash C73E5D30
   sample 62:
-    time = 2431055
+    time = 2422996
     flags = 1
     data = length 288, hash 98B5BFF6
   sample 63:
-    time = 2455055
+    time = 2446996
     flags = 1
     data = length 336, hash E0135533
   sample 64:
-    time = 2479055
+    time = 2470996
     flags = 1
     data = length 336, hash D13C9DBC
   sample 65:
-    time = 2503055
+    time = 2494996
     flags = 1
     data = length 336, hash 63D524CA
   sample 66:
-    time = 2527055
+    time = 2518996
     flags = 1
     data = length 288, hash A28514C3
   sample 67:
-    time = 2551055
+    time = 2542996
     flags = 1
     data = length 336, hash 72B647FF
   sample 68:
-    time = 2575055
+    time = 2566996
     flags = 1
     data = length 336, hash 8F740AB1
   sample 69:
-    time = 2599055
+    time = 2590996
     flags = 1
     data = length 336, hash 5E3C7E93
   sample 70:
-    time = 2623055
+    time = 2614996
     flags = 1
     data = length 336, hash 121B913B
   sample 71:
-    time = 2647055
+    time = 2638996
     flags = 1
     data = length 336, hash 578FCCF2
   sample 72:
-    time = 2671055
+    time = 2662996
     flags = 1
     data = length 336, hash 5B5823DE
   sample 73:
-    time = 2695055
+    time = 2686996
     flags = 1
     data = length 384, hash D8B83F78
   sample 74:
-    time = 2719055
+    time = 2710996
     flags = 1
     data = length 240, hash E649682F
   sample 75:
-    time = 2743055
+    time = 2734996
     flags = 1
     data = length 96, hash C559A6F4
   sample 76:
-    time = 2767055
+    time = 2758996
     flags = 1
     data = length 96, hash 792796BC
   sample 77:
-    time = 2791055
+    time = 2782996
     flags = 1
     data = length 120, hash 8172CD0E
   sample 78:
-    time = 2815055
+    time = 2806996
     flags = 1
     data = length 120, hash F562B52F
   sample 79:
-    time = 2839055
+    time = 2830996
     flags = 1
     data = length 96, hash FF8D5B98
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.2.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807972
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
-  getPosition(1) = [[timeUs=0, position=237], [timeUs=73, position=238]]
-  getPosition(1403986) = [[timeUs=1403912, position=19316], [timeUs=1403986, position=19317]]
-  getPosition(2807972) = [[timeUs=2807899, position=38396]]
+  getPosition(1) = [[timeUs=0, position=237], [timeUs=72, position=238]]
+  getPosition(1391989) = [[timeUs=1391916, position=19316], [timeUs=1391989, position=19317]]
+  getPosition(2783979) = [[timeUs=2783907, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 12624
   sample count = 42
-  track duration = 2807972
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,171 +21,171 @@ track 0:
     encoderPadding = 576
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
-    time = 1879045
+    time = 1862989
     flags = 1
     data = length 336, hash F18837E2
   sample 1:
-    time = 1903045
+    time = 1886989
     flags = 1
     data = length 336, hash ED36B78E
   sample 2:
-    time = 1927045
+    time = 1910989
     flags = 1
     data = length 336, hash B3D28289
   sample 3:
-    time = 1951045
+    time = 1934989
     flags = 1
     data = length 288, hash 8BDE28E1
   sample 4:
-    time = 1975045
+    time = 1958989
     flags = 1
     data = length 336, hash CFD5E966
   sample 5:
-    time = 1999045
+    time = 1982989
     flags = 1
     data = length 288, hash DC08E267
   sample 6:
-    time = 2023045
+    time = 2006989
     flags = 1
     data = length 336, hash 6530CB78
   sample 7:
-    time = 2047045
+    time = 2030989
     flags = 1
     data = length 336, hash 6CC6636E
   sample 8:
-    time = 2071045
+    time = 2054989
     flags = 1
     data = length 336, hash 613047C1
   sample 9:
-    time = 2095045
+    time = 2078989
     flags = 1
     data = length 288, hash CDC747BF
   sample 10:
-    time = 2119045
+    time = 2102989
     flags = 1
     data = length 336, hash AF22AA74
   sample 11:
-    time = 2143045
+    time = 2126989
     flags = 1
     data = length 384, hash 82F326AA
   sample 12:
-    time = 2167045
+    time = 2150989
     flags = 1
     data = length 384, hash EDA26C4D
   sample 13:
-    time = 2191045
+    time = 2174989
     flags = 1
     data = length 336, hash 94C643DC
   sample 14:
-    time = 2215045
+    time = 2198989
     flags = 1
     data = length 288, hash CB5D9C40
   sample 15:
-    time = 2239045
+    time = 2222989
     flags = 1
     data = length 336, hash 1E69DE3F
   sample 16:
-    time = 2263045
+    time = 2246989
     flags = 1
     data = length 336, hash 7E472219
   sample 17:
-    time = 2287045
+    time = 2270989
     flags = 1
     data = length 336, hash DA47B9FA
   sample 18:
-    time = 2311045
+    time = 2294989
     flags = 1
     data = length 336, hash DD0ABB7C
   sample 19:
-    time = 2335045
+    time = 2318989
     flags = 1
     data = length 288, hash DBF93FAC
   sample 20:
-    time = 2359045
+    time = 2342989
     flags = 1
     data = length 336, hash 243F4B2
   sample 21:
-    time = 2383045
+    time = 2366989
     flags = 1
     data = length 336, hash 2E881490
   sample 22:
-    time = 2407045
+    time = 2390989
     flags = 1
     data = length 288, hash 1C28C8BE
   sample 23:
-    time = 2431045
+    time = 2414989
     flags = 1
     data = length 336, hash C73E5D30
   sample 24:
-    time = 2455045
+    time = 2438989
     flags = 1
     data = length 288, hash 98B5BFF6
   sample 25:
-    time = 2479045
+    time = 2462989
     flags = 1
     data = length 336, hash E0135533
   sample 26:
-    time = 2503045
+    time = 2486989
     flags = 1
     data = length 336, hash D13C9DBC
   sample 27:
-    time = 2527045
+    time = 2510989
     flags = 1
     data = length 336, hash 63D524CA
   sample 28:
-    time = 2551045
+    time = 2534989
     flags = 1
     data = length 288, hash A28514C3
   sample 29:
-    time = 2575045
+    time = 2558989
     flags = 1
     data = length 336, hash 72B647FF
   sample 30:
-    time = 2599045
+    time = 2582989
     flags = 1
     data = length 336, hash 8F740AB1
   sample 31:
-    time = 2623045
+    time = 2606989
     flags = 1
     data = length 336, hash 5E3C7E93
   sample 32:
-    time = 2647045
+    time = 2630989
     flags = 1
     data = length 336, hash 121B913B
   sample 33:
-    time = 2671045
+    time = 2654989
     flags = 1
     data = length 336, hash 578FCCF2
   sample 34:
-    time = 2695045
+    time = 2678989
     flags = 1
     data = length 336, hash 5B5823DE
   sample 35:
-    time = 2719045
+    time = 2702989
     flags = 1
     data = length 384, hash D8B83F78
   sample 36:
-    time = 2743045
+    time = 2726989
     flags = 1
     data = length 240, hash E649682F
   sample 37:
-    time = 2767045
+    time = 2750989
     flags = 1
     data = length 96, hash C559A6F4
   sample 38:
-    time = 2791045
+    time = 2774989
     flags = 1
     data = length 96, hash 792796BC
   sample 39:
-    time = 2815045
+    time = 2798989
     flags = 1
     data = length 120, hash 8172CD0E
   sample 40:
-    time = 2839045
+    time = 2822989
     flags = 1
     data = length 120, hash F562B52F
   sample 41:
-    time = 2863045
+    time = 2846989
     flags = 1
     data = length 96, hash FF8D5B98
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.3.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807972
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
-  getPosition(1) = [[timeUs=0, position=237], [timeUs=73, position=238]]
-  getPosition(1403986) = [[timeUs=1403912, position=19316], [timeUs=1403986, position=19317]]
-  getPosition(2807972) = [[timeUs=2807899, position=38396]]
+  getPosition(1) = [[timeUs=0, position=237], [timeUs=72, position=238]]
+  getPosition(1391989) = [[timeUs=1391916, position=19316], [timeUs=1391989, position=19317]]
+  getPosition(2783979) = [[timeUs=2783907, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 0
   sample count = 0
-  track duration = 2807972
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.unknown_length.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807972
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
-  getPosition(1) = [[timeUs=0, position=237], [timeUs=73, position=238]]
-  getPosition(1403986) = [[timeUs=1403912, position=19316], [timeUs=1403986, position=19317]]
-  getPosition(2807972) = [[timeUs=2807899, position=38396]]
+  getPosition(1) = [[timeUs=0, position=237], [timeUs=72, position=238]]
+  getPosition(1391989) = [[timeUs=1391916, position=19316], [timeUs=1391989, position=19317]]
+  getPosition(2783979) = [[timeUs=2783907, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 38160
   sample count = 117
-  track duration = 2807972
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.0.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807979
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
   getPosition(1) = [[timeUs=0, position=237], [timeUs=120000, position=2061]]
-  getPosition(1403989) = [[timeUs=1320000, position=18909], [timeUs=1440000, position=20541]]
-  getPosition(2807979) = [[timeUs=2760000, position=38181]]
+  getPosition(1391989) = [[timeUs=1320000, position=18909], [timeUs=1440000, position=20541]]
+  getPosition(2783979) = [[timeUs=2760000, position=38181]]
 numberOfTracks = 1
 track 0:
   total output bytes = 38160
   sample count = 117
-  track duration = 2807979
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.1.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807979
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
   getPosition(1) = [[timeUs=0, position=237], [timeUs=120000, position=2061]]
-  getPosition(1403989) = [[timeUs=1320000, position=18909], [timeUs=1440000, position=20541]]
-  getPosition(2807979) = [[timeUs=2760000, position=38181]]
+  getPosition(1391989) = [[timeUs=1320000, position=18909], [timeUs=1440000, position=20541]]
+  getPosition(2783979) = [[timeUs=2760000, position=38181]]
 numberOfTracks = 1
 track 0:
   total output bytes = 25920
   sample count = 82
-  track duration = 2807979
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.2.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807979
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
   getPosition(1) = [[timeUs=0, position=237], [timeUs=120000, position=2061]]
-  getPosition(1403989) = [[timeUs=1320000, position=18909], [timeUs=1440000, position=20541]]
-  getPosition(2807979) = [[timeUs=2760000, position=38181]]
+  getPosition(1391989) = [[timeUs=1320000, position=18909], [timeUs=1440000, position=20541]]
+  getPosition(2783979) = [[timeUs=2760000, position=38181]]
 numberOfTracks = 1
 track 0:
   total output bytes = 12624
   sample count = 42
-  track duration = 2807979
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.3.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807979
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
   getPosition(1) = [[timeUs=0, position=237], [timeUs=120000, position=2061]]
-  getPosition(1403989) = [[timeUs=1320000, position=18909], [timeUs=1440000, position=20541]]
-  getPosition(2807979) = [[timeUs=2760000, position=38181]]
+  getPosition(1391989) = [[timeUs=1320000, position=18909], [timeUs=1440000, position=20541]]
+  getPosition(2783979) = [[timeUs=2760000, position=38181]]
 numberOfTracks = 1
 track 0:
   total output bytes = 216
   sample count = 2
-  track duration = 2807979
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.unknown_length.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807979
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
   getPosition(1) = [[timeUs=0, position=237], [timeUs=120000, position=2061]]
-  getPosition(1403989) = [[timeUs=1320000, position=18909], [timeUs=1440000, position=20541]]
-  getPosition(2807979) = [[timeUs=2760000, position=38181]]
+  getPosition(1391989) = [[timeUs=1320000, position=18909], [timeUs=1440000, position=20541]]
+  getPosition(2783979) = [[timeUs=2760000, position=38181]]
 numberOfTracks = 1
 track 0:
   total output bytes = 38160
   sample count = 117
-  track duration = 2807979
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.unknown_length.dump
@@ -1,14 +1,14 @@
 seekMap:
   isSeekable = false
-  duration = 2807979
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
 numberOfTracks = 1
 track 0:
   total output bytes = 38160
   sample count = 117
-  track duration = 2807979
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.0.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807978
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=429]]
-  getPosition(1) = [[timeUs=0, position=429], [timeUs=23999, position=813]]
-  getPosition(1403989) = [[timeUs=1391989, position=22701], [timeUs=1415988, position=23085]]
-  getPosition(2807978) = [[timeUs=2783978, position=44973]]
+  getPosition(1) = [[timeUs=0, position=429], [timeUs=23794, position=813]]
+  getPosition(1391989) = [[timeUs=1380096, position=22701], [timeUs=1403891, position=23085]]
+  getPosition(2783979) = [[timeUs=2760185, position=44973]]
 numberOfTracks = 1
 track 0:
   total output bytes = 44928
   sample count = 117
-  track duration = 2807978
+  track duration = 2783979
   format 0:
-    averageBitrate = 128001
+    averageBitrate = 129104
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.1.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807978
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=429]]
-  getPosition(1) = [[timeUs=0, position=429], [timeUs=23999, position=813]]
-  getPosition(1403989) = [[timeUs=1391989, position=22701], [timeUs=1415988, position=23085]]
-  getPosition(2807978) = [[timeUs=2783978, position=44973]]
+  getPosition(1) = [[timeUs=0, position=429], [timeUs=23794, position=813]]
+  getPosition(1391989) = [[timeUs=1380096, position=22701], [timeUs=1403891, position=23085]]
+  getPosition(2783979) = [[timeUs=2760185, position=44973]]
 numberOfTracks = 1
 track 0:
   total output bytes = 30336
   sample count = 79
-  track duration = 2807978
+  track duration = 2783979
   format 0:
-    averageBitrate = 128001
+    averageBitrate = 129104
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,319 +21,319 @@ track 0:
     encoderPadding = 576
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=8.14048E-40, field 1=GainField{name=1, originator=3, gain=23.3}, field 2=null]
   sample 0:
-    time = 911992
+    time = 904201
     flags = 1
     data = length 384, hash 40914CAF
   sample 1:
-    time = 935992
+    time = 928201
     flags = 1
     data = length 384, hash F7EFB71E
   sample 2:
-    time = 959992
+    time = 952201
     flags = 1
     data = length 384, hash 53FBE77C
   sample 3:
-    time = 983992
+    time = 976201
     flags = 1
     data = length 384, hash 77E58178
   sample 4:
-    time = 1007992
+    time = 1000201
     flags = 1
     data = length 384, hash E3B86048
   sample 5:
-    time = 1031992
+    time = 1024201
     flags = 1
     data = length 384, hash 6E64349
   sample 6:
-    time = 1055992
+    time = 1048201
     flags = 1
     data = length 384, hash AC0B5E18
   sample 7:
-    time = 1079992
+    time = 1072201
     flags = 1
     data = length 384, hash 7B4CE779
   sample 8:
-    time = 1103992
+    time = 1096201
     flags = 1
     data = length 384, hash 50D10931
   sample 9:
-    time = 1127992
+    time = 1120201
     flags = 1
     data = length 384, hash F0D97D3E
   sample 10:
-    time = 1151992
+    time = 1144201
     flags = 1
     data = length 384, hash ED786460
   sample 11:
-    time = 1175992
+    time = 1168201
     flags = 1
     data = length 384, hash 435543F4
   sample 12:
-    time = 1199992
+    time = 1192201
     flags = 1
     data = length 384, hash 523ED198
   sample 13:
-    time = 1223992
+    time = 1216201
     flags = 1
     data = length 384, hash 705705D3
   sample 14:
-    time = 1247992
+    time = 1240201
     flags = 1
     data = length 384, hash 4A95F442
   sample 15:
-    time = 1271992
+    time = 1264201
     flags = 1
     data = length 384, hash 56D7EF4B
   sample 16:
-    time = 1295992
+    time = 1288201
     flags = 1
     data = length 384, hash B47AAC17
   sample 17:
-    time = 1319992
+    time = 1312201
     flags = 1
     data = length 384, hash 38E76A4D
   sample 18:
-    time = 1343992
+    time = 1336201
     flags = 1
     data = length 384, hash ADF5E978
   sample 19:
-    time = 1367992
+    time = 1360201
     flags = 1
     data = length 384, hash 349125C2
   sample 20:
-    time = 1391992
+    time = 1384201
     flags = 1
     data = length 384, hash D69B3903
   sample 21:
-    time = 1415992
+    time = 1408201
     flags = 1
     data = length 384, hash 852DA91C
   sample 22:
-    time = 1439992
+    time = 1432201
     flags = 1
     data = length 384, hash 21F87C6E
   sample 23:
-    time = 1463992
+    time = 1456201
     flags = 1
     data = length 384, hash 68686E41
   sample 24:
-    time = 1487992
+    time = 1480201
     flags = 1
     data = length 384, hash 4DAC9F6A
   sample 25:
-    time = 1511992
+    time = 1504201
     flags = 1
     data = length 384, hash B5CA6FCF
   sample 26:
-    time = 1535992
+    time = 1528201
     flags = 1
     data = length 384, hash 9B7216B3
   sample 27:
-    time = 1559992
+    time = 1552201
     flags = 1
     data = length 384, hash AC7162DA
   sample 28:
-    time = 1583992
+    time = 1576201
     flags = 1
     data = length 384, hash 545A4B9C
   sample 29:
-    time = 1607992
+    time = 1600201
     flags = 1
     data = length 384, hash 380FA5D4
   sample 30:
-    time = 1631992
+    time = 1624201
     flags = 1
     data = length 384, hash 53BF79E9
   sample 31:
-    time = 1655992
+    time = 1648201
     flags = 1
     data = length 384, hash FE2460DB
   sample 32:
-    time = 1679992
+    time = 1672201
     flags = 1
     data = length 384, hash 2525E09
   sample 33:
-    time = 1703992
+    time = 1696201
     flags = 1
     data = length 384, hash ECCB42AA
   sample 34:
-    time = 1727992
+    time = 1720201
     flags = 1
     data = length 384, hash 1E5EC5FA
   sample 35:
-    time = 1751992
+    time = 1744201
     flags = 1
     data = length 384, hash C2597D09
   sample 36:
-    time = 1775992
+    time = 1768201
     flags = 1
     data = length 384, hash 32CD263E
   sample 37:
-    time = 1799992
+    time = 1792201
     flags = 1
     data = length 384, hash 6B3A0DC7
   sample 38:
-    time = 1823992
+    time = 1816201
     flags = 1
     data = length 384, hash 5155B353
   sample 39:
-    time = 1847992
+    time = 1840201
     flags = 1
     data = length 384, hash 220C783
   sample 40:
-    time = 1871992
+    time = 1864201
     flags = 1
     data = length 384, hash E0925905
   sample 41:
-    time = 1895992
+    time = 1888201
     flags = 1
     data = length 384, hash 824C0D02
   sample 42:
-    time = 1919992
+    time = 1912201
     flags = 1
     data = length 384, hash 5166F8F3
   sample 43:
-    time = 1943992
+    time = 1936201
     flags = 1
     data = length 384, hash B5F38EE6
   sample 44:
-    time = 1967992
+    time = 1960201
     flags = 1
     data = length 384, hash 659E483F
   sample 45:
-    time = 1991992
+    time = 1984201
     flags = 1
     data = length 384, hash A022EFCB
   sample 46:
-    time = 2015992
+    time = 2008201
     flags = 1
     data = length 384, hash 93DCF4B5
   sample 47:
-    time = 2039992
+    time = 2032201
     flags = 1
     data = length 384, hash C965128
   sample 48:
-    time = 2063992
+    time = 2056201
     flags = 1
     data = length 384, hash 6FD595F4
   sample 49:
-    time = 2087992
+    time = 2080201
     flags = 1
     data = length 384, hash BF6CDB31
   sample 50:
-    time = 2111992
+    time = 2104201
     flags = 1
     data = length 384, hash 67C738C0
   sample 51:
-    time = 2135992
+    time = 2128201
     flags = 1
     data = length 384, hash BCFCD1CC
   sample 52:
-    time = 2159992
+    time = 2152201
     flags = 1
     data = length 384, hash A4A85D04
   sample 53:
-    time = 2183992
+    time = 2176201
     flags = 1
     data = length 384, hash 6CD26641
   sample 54:
-    time = 2207992
+    time = 2200201
     flags = 1
     data = length 384, hash 53817862
   sample 55:
-    time = 2231992
+    time = 2224201
     flags = 1
     data = length 384, hash 1C98DD10
   sample 56:
-    time = 2255992
+    time = 2248201
     flags = 1
     data = length 384, hash 5B8EE2C9
   sample 57:
-    time = 2279992
+    time = 2272201
     flags = 1
     data = length 384, hash 227883D0
   sample 58:
-    time = 2303992
+    time = 2296201
     flags = 1
     data = length 384, hash 50267C46
   sample 59:
-    time = 2327992
+    time = 2320201
     flags = 1
     data = length 384, hash F02EA205
   sample 60:
-    time = 2351992
+    time = 2344201
     flags = 1
     data = length 384, hash ED7BE6DF
   sample 61:
-    time = 2375992
+    time = 2368201
     flags = 1
     data = length 384, hash AEE4E608
   sample 62:
-    time = 2399992
+    time = 2392201
     flags = 1
     data = length 384, hash 8EA81A05
   sample 63:
-    time = 2423992
+    time = 2416201
     flags = 1
     data = length 384, hash C9D6BC51
   sample 64:
-    time = 2447992
+    time = 2440201
     flags = 1
     data = length 384, hash FBE2EF0F
   sample 65:
-    time = 2471992
+    time = 2464201
     flags = 1
     data = length 384, hash 64E44326
   sample 66:
-    time = 2495992
+    time = 2488201
     flags = 1
     data = length 384, hash 2A371FEA
   sample 67:
-    time = 2519992
+    time = 2512201
     flags = 1
     data = length 384, hash BC1F17B6
   sample 68:
-    time = 2543992
+    time = 2536201
     flags = 1
     data = length 384, hash 759FA7C2
   sample 69:
-    time = 2567992
+    time = 2560201
     flags = 1
     data = length 384, hash ED978C15
   sample 70:
-    time = 2591992
+    time = 2584201
     flags = 1
     data = length 384, hash 2393BA70
   sample 71:
-    time = 2615992
+    time = 2608201
     flags = 1
     data = length 384, hash F84E2847
   sample 72:
-    time = 2639992
+    time = 2632201
     flags = 1
     data = length 384, hash FF006E14
   sample 73:
-    time = 2663992
+    time = 2656201
     flags = 1
     data = length 384, hash 840D19F5
   sample 74:
-    time = 2687992
+    time = 2680201
     flags = 1
     data = length 384, hash B17A5934
   sample 75:
-    time = 2711992
+    time = 2704201
     flags = 1
     data = length 384, hash 2879F06E
   sample 76:
-    time = 2735992
+    time = 2728201
     flags = 1
     data = length 384, hash 386AB993
   sample 77:
-    time = 2759992
+    time = 2752201
     flags = 1
     data = length 384, hash 276609B5
   sample 78:
-    time = 2783992
+    time = 2776201
     flags = 1
     data = length 384, hash 5FE294B5
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.2.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807978
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=429]]
-  getPosition(1) = [[timeUs=0, position=429], [timeUs=23999, position=813]]
-  getPosition(1403989) = [[timeUs=1391989, position=22701], [timeUs=1415988, position=23085]]
-  getPosition(2807978) = [[timeUs=2783978, position=44973]]
+  getPosition(1) = [[timeUs=0, position=429], [timeUs=23794, position=813]]
+  getPosition(1391989) = [[timeUs=1380096, position=22701], [timeUs=1403891, position=23085]]
+  getPosition(2783979) = [[timeUs=2760185, position=44973]]
 numberOfTracks = 1
 track 0:
   total output bytes = 15360
   sample count = 40
-  track duration = 2807978
+  track duration = 2783979
   format 0:
-    averageBitrate = 128001
+    averageBitrate = 129104
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,163 +21,163 @@ track 0:
     encoderPadding = 576
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=8.14048E-40, field 1=GainField{name=1, originator=3, gain=23.3}, field 2=null]
   sample 0:
-    time = 1847985
+    time = 1832197
     flags = 1
     data = length 384, hash 220C783
   sample 1:
-    time = 1871985
+    time = 1856197
     flags = 1
     data = length 384, hash E0925905
   sample 2:
-    time = 1895985
+    time = 1880197
     flags = 1
     data = length 384, hash 824C0D02
   sample 3:
-    time = 1919985
+    time = 1904197
     flags = 1
     data = length 384, hash 5166F8F3
   sample 4:
-    time = 1943985
+    time = 1928197
     flags = 1
     data = length 384, hash B5F38EE6
   sample 5:
-    time = 1967985
+    time = 1952197
     flags = 1
     data = length 384, hash 659E483F
   sample 6:
-    time = 1991985
+    time = 1976197
     flags = 1
     data = length 384, hash A022EFCB
   sample 7:
-    time = 2015985
+    time = 2000197
     flags = 1
     data = length 384, hash 93DCF4B5
   sample 8:
-    time = 2039985
+    time = 2024197
     flags = 1
     data = length 384, hash C965128
   sample 9:
-    time = 2063985
+    time = 2048197
     flags = 1
     data = length 384, hash 6FD595F4
   sample 10:
-    time = 2087985
+    time = 2072197
     flags = 1
     data = length 384, hash BF6CDB31
   sample 11:
-    time = 2111985
+    time = 2096197
     flags = 1
     data = length 384, hash 67C738C0
   sample 12:
-    time = 2135985
+    time = 2120197
     flags = 1
     data = length 384, hash BCFCD1CC
   sample 13:
-    time = 2159985
+    time = 2144197
     flags = 1
     data = length 384, hash A4A85D04
   sample 14:
-    time = 2183985
+    time = 2168197
     flags = 1
     data = length 384, hash 6CD26641
   sample 15:
-    time = 2207985
+    time = 2192197
     flags = 1
     data = length 384, hash 53817862
   sample 16:
-    time = 2231985
+    time = 2216197
     flags = 1
     data = length 384, hash 1C98DD10
   sample 17:
-    time = 2255985
+    time = 2240197
     flags = 1
     data = length 384, hash 5B8EE2C9
   sample 18:
-    time = 2279985
+    time = 2264197
     flags = 1
     data = length 384, hash 227883D0
   sample 19:
-    time = 2303985
+    time = 2288197
     flags = 1
     data = length 384, hash 50267C46
   sample 20:
-    time = 2327985
+    time = 2312197
     flags = 1
     data = length 384, hash F02EA205
   sample 21:
-    time = 2351985
+    time = 2336197
     flags = 1
     data = length 384, hash ED7BE6DF
   sample 22:
-    time = 2375985
+    time = 2360197
     flags = 1
     data = length 384, hash AEE4E608
   sample 23:
-    time = 2399985
+    time = 2384197
     flags = 1
     data = length 384, hash 8EA81A05
   sample 24:
-    time = 2423985
+    time = 2408197
     flags = 1
     data = length 384, hash C9D6BC51
   sample 25:
-    time = 2447985
+    time = 2432197
     flags = 1
     data = length 384, hash FBE2EF0F
   sample 26:
-    time = 2471985
+    time = 2456197
     flags = 1
     data = length 384, hash 64E44326
   sample 27:
-    time = 2495985
+    time = 2480197
     flags = 1
     data = length 384, hash 2A371FEA
   sample 28:
-    time = 2519985
+    time = 2504197
     flags = 1
     data = length 384, hash BC1F17B6
   sample 29:
-    time = 2543985
+    time = 2528197
     flags = 1
     data = length 384, hash 759FA7C2
   sample 30:
-    time = 2567985
+    time = 2552197
     flags = 1
     data = length 384, hash ED978C15
   sample 31:
-    time = 2591985
+    time = 2576197
     flags = 1
     data = length 384, hash 2393BA70
   sample 32:
-    time = 2615985
+    time = 2600197
     flags = 1
     data = length 384, hash F84E2847
   sample 33:
-    time = 2639985
+    time = 2624197
     flags = 1
     data = length 384, hash FF006E14
   sample 34:
-    time = 2663985
+    time = 2648197
     flags = 1
     data = length 384, hash 840D19F5
   sample 35:
-    time = 2687985
+    time = 2672197
     flags = 1
     data = length 384, hash B17A5934
   sample 36:
-    time = 2711985
+    time = 2696197
     flags = 1
     data = length 384, hash 2879F06E
   sample 37:
-    time = 2735985
+    time = 2720197
     flags = 1
     data = length 384, hash 386AB993
   sample 38:
-    time = 2759985
+    time = 2744197
     flags = 1
     data = length 384, hash 276609B5
   sample 39:
-    time = 2783985
+    time = 2768197
     flags = 1
     data = length 384, hash 5FE294B5
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.3.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807978
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=429]]
-  getPosition(1) = [[timeUs=0, position=429], [timeUs=23999, position=813]]
-  getPosition(1403989) = [[timeUs=1391989, position=22701], [timeUs=1415988, position=23085]]
-  getPosition(2807978) = [[timeUs=2783978, position=44973]]
+  getPosition(1) = [[timeUs=0, position=429], [timeUs=23794, position=813]]
+  getPosition(1391989) = [[timeUs=1380096, position=22701], [timeUs=1403891, position=23085]]
+  getPosition(2783979) = [[timeUs=2760185, position=44973]]
 numberOfTracks = 1
 track 0:
   total output bytes = 384
   sample count = 1
-  track duration = 2807978
+  track duration = 2783979
   format 0:
-    averageBitrate = 128001
+    averageBitrate = 129104
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,7 +21,7 @@ track 0:
     encoderPadding = 576
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=8.14048E-40, field 1=GainField{name=1, originator=3, gain=23.3}, field 2=null]
   sample 0:
-    time = 2783978
+    time = 2760193
     flags = 1
     data = length 384, hash 5FE294B5
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.unknown_length.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807978
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=429]]
-  getPosition(1) = [[timeUs=0, position=429], [timeUs=23999, position=813]]
-  getPosition(1403989) = [[timeUs=1391989, position=22701], [timeUs=1415988, position=23085]]
-  getPosition(2807978) = [[timeUs=2783978, position=44973]]
+  getPosition(1) = [[timeUs=0, position=429], [timeUs=23794, position=813]]
+  getPosition(1391989) = [[timeUs=1380096, position=22701], [timeUs=1403891, position=23085]]
+  getPosition(2783979) = [[timeUs=2760185, position=44973]]
 numberOfTracks = 1
 track 0:
   total output bytes = 44928
   sample count = 117
-  track duration = 2807978
+  track duration = 2783979
   format 0:
-    averageBitrate = 128001
+    averageBitrate = 129104
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.0.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807978
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=429]]
-  getPosition(1) = [[timeUs=0, position=429], [timeUs=23999, position=813]]
-  getPosition(1403989) = [[timeUs=1391989, position=22701], [timeUs=1415988, position=23085]]
-  getPosition(2807978) = [[timeUs=2783978, position=44973]]
+  getPosition(1) = [[timeUs=0, position=429], [timeUs=23794, position=813]]
+  getPosition(1391989) = [[timeUs=1380096, position=22701], [timeUs=1403891, position=23085]]
+  getPosition(2783979) = [[timeUs=2760185, position=44973]]
 numberOfTracks = 1
 track 0:
   total output bytes = 44928
   sample count = 117
-  track duration = 2807978
+  track duration = 2783979
   format 0:
-    averageBitrate = 128001
+    averageBitrate = 129104
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.1.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807978
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=429]]
-  getPosition(1) = [[timeUs=0, position=429], [timeUs=23999, position=813]]
-  getPosition(1403989) = [[timeUs=1391989, position=22701], [timeUs=1415988, position=23085]]
-  getPosition(2807978) = [[timeUs=2783978, position=44973]]
+  getPosition(1) = [[timeUs=0, position=429], [timeUs=23794, position=813]]
+  getPosition(1391989) = [[timeUs=1380096, position=22701], [timeUs=1403891, position=23085]]
+  getPosition(2783979) = [[timeUs=2760185, position=44973]]
 numberOfTracks = 1
 track 0:
   total output bytes = 30336
   sample count = 79
-  track duration = 2807978
+  track duration = 2783979
   format 0:
-    averageBitrate = 128001
+    averageBitrate = 129104
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,319 +21,319 @@ track 0:
     encoderPadding = 576
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=0.0, field 1=GainField{name=1, originator=3, gain=23.0}, field 2=null]
   sample 0:
-    time = 911992
+    time = 904201
     flags = 1
     data = length 384, hash 40914CAF
   sample 1:
-    time = 935992
+    time = 928201
     flags = 1
     data = length 384, hash F7EFB71E
   sample 2:
-    time = 959992
+    time = 952201
     flags = 1
     data = length 384, hash 53FBE77C
   sample 3:
-    time = 983992
+    time = 976201
     flags = 1
     data = length 384, hash 77E58178
   sample 4:
-    time = 1007992
+    time = 1000201
     flags = 1
     data = length 384, hash E3B86048
   sample 5:
-    time = 1031992
+    time = 1024201
     flags = 1
     data = length 384, hash 6E64349
   sample 6:
-    time = 1055992
+    time = 1048201
     flags = 1
     data = length 384, hash AC0B5E18
   sample 7:
-    time = 1079992
+    time = 1072201
     flags = 1
     data = length 384, hash 7B4CE779
   sample 8:
-    time = 1103992
+    time = 1096201
     flags = 1
     data = length 384, hash 50D10931
   sample 9:
-    time = 1127992
+    time = 1120201
     flags = 1
     data = length 384, hash F0D97D3E
   sample 10:
-    time = 1151992
+    time = 1144201
     flags = 1
     data = length 384, hash ED786460
   sample 11:
-    time = 1175992
+    time = 1168201
     flags = 1
     data = length 384, hash 435543F4
   sample 12:
-    time = 1199992
+    time = 1192201
     flags = 1
     data = length 384, hash 523ED198
   sample 13:
-    time = 1223992
+    time = 1216201
     flags = 1
     data = length 384, hash 705705D3
   sample 14:
-    time = 1247992
+    time = 1240201
     flags = 1
     data = length 384, hash 4A95F442
   sample 15:
-    time = 1271992
+    time = 1264201
     flags = 1
     data = length 384, hash 56D7EF4B
   sample 16:
-    time = 1295992
+    time = 1288201
     flags = 1
     data = length 384, hash B47AAC17
   sample 17:
-    time = 1319992
+    time = 1312201
     flags = 1
     data = length 384, hash 38E76A4D
   sample 18:
-    time = 1343992
+    time = 1336201
     flags = 1
     data = length 384, hash ADF5E978
   sample 19:
-    time = 1367992
+    time = 1360201
     flags = 1
     data = length 384, hash 349125C2
   sample 20:
-    time = 1391992
+    time = 1384201
     flags = 1
     data = length 384, hash D69B3903
   sample 21:
-    time = 1415992
+    time = 1408201
     flags = 1
     data = length 384, hash 852DA91C
   sample 22:
-    time = 1439992
+    time = 1432201
     flags = 1
     data = length 384, hash 21F87C6E
   sample 23:
-    time = 1463992
+    time = 1456201
     flags = 1
     data = length 384, hash 68686E41
   sample 24:
-    time = 1487992
+    time = 1480201
     flags = 1
     data = length 384, hash 4DAC9F6A
   sample 25:
-    time = 1511992
+    time = 1504201
     flags = 1
     data = length 384, hash B5CA6FCF
   sample 26:
-    time = 1535992
+    time = 1528201
     flags = 1
     data = length 384, hash 9B7216B3
   sample 27:
-    time = 1559992
+    time = 1552201
     flags = 1
     data = length 384, hash AC7162DA
   sample 28:
-    time = 1583992
+    time = 1576201
     flags = 1
     data = length 384, hash 545A4B9C
   sample 29:
-    time = 1607992
+    time = 1600201
     flags = 1
     data = length 384, hash 380FA5D4
   sample 30:
-    time = 1631992
+    time = 1624201
     flags = 1
     data = length 384, hash 53BF79E9
   sample 31:
-    time = 1655992
+    time = 1648201
     flags = 1
     data = length 384, hash FE2460DB
   sample 32:
-    time = 1679992
+    time = 1672201
     flags = 1
     data = length 384, hash 2525E09
   sample 33:
-    time = 1703992
+    time = 1696201
     flags = 1
     data = length 384, hash ECCB42AA
   sample 34:
-    time = 1727992
+    time = 1720201
     flags = 1
     data = length 384, hash 1E5EC5FA
   sample 35:
-    time = 1751992
+    time = 1744201
     flags = 1
     data = length 384, hash C2597D09
   sample 36:
-    time = 1775992
+    time = 1768201
     flags = 1
     data = length 384, hash 32CD263E
   sample 37:
-    time = 1799992
+    time = 1792201
     flags = 1
     data = length 384, hash 6B3A0DC7
   sample 38:
-    time = 1823992
+    time = 1816201
     flags = 1
     data = length 384, hash 5155B353
   sample 39:
-    time = 1847992
+    time = 1840201
     flags = 1
     data = length 384, hash 220C783
   sample 40:
-    time = 1871992
+    time = 1864201
     flags = 1
     data = length 384, hash E0925905
   sample 41:
-    time = 1895992
+    time = 1888201
     flags = 1
     data = length 384, hash 824C0D02
   sample 42:
-    time = 1919992
+    time = 1912201
     flags = 1
     data = length 384, hash 5166F8F3
   sample 43:
-    time = 1943992
+    time = 1936201
     flags = 1
     data = length 384, hash B5F38EE6
   sample 44:
-    time = 1967992
+    time = 1960201
     flags = 1
     data = length 384, hash 659E483F
   sample 45:
-    time = 1991992
+    time = 1984201
     flags = 1
     data = length 384, hash A022EFCB
   sample 46:
-    time = 2015992
+    time = 2008201
     flags = 1
     data = length 384, hash 93DCF4B5
   sample 47:
-    time = 2039992
+    time = 2032201
     flags = 1
     data = length 384, hash C965128
   sample 48:
-    time = 2063992
+    time = 2056201
     flags = 1
     data = length 384, hash 6FD595F4
   sample 49:
-    time = 2087992
+    time = 2080201
     flags = 1
     data = length 384, hash BF6CDB31
   sample 50:
-    time = 2111992
+    time = 2104201
     flags = 1
     data = length 384, hash 67C738C0
   sample 51:
-    time = 2135992
+    time = 2128201
     flags = 1
     data = length 384, hash BCFCD1CC
   sample 52:
-    time = 2159992
+    time = 2152201
     flags = 1
     data = length 384, hash A4A85D04
   sample 53:
-    time = 2183992
+    time = 2176201
     flags = 1
     data = length 384, hash 6CD26641
   sample 54:
-    time = 2207992
+    time = 2200201
     flags = 1
     data = length 384, hash 53817862
   sample 55:
-    time = 2231992
+    time = 2224201
     flags = 1
     data = length 384, hash 1C98DD10
   sample 56:
-    time = 2255992
+    time = 2248201
     flags = 1
     data = length 384, hash 5B8EE2C9
   sample 57:
-    time = 2279992
+    time = 2272201
     flags = 1
     data = length 384, hash 227883D0
   sample 58:
-    time = 2303992
+    time = 2296201
     flags = 1
     data = length 384, hash 50267C46
   sample 59:
-    time = 2327992
+    time = 2320201
     flags = 1
     data = length 384, hash F02EA205
   sample 60:
-    time = 2351992
+    time = 2344201
     flags = 1
     data = length 384, hash ED7BE6DF
   sample 61:
-    time = 2375992
+    time = 2368201
     flags = 1
     data = length 384, hash AEE4E608
   sample 62:
-    time = 2399992
+    time = 2392201
     flags = 1
     data = length 384, hash 8EA81A05
   sample 63:
-    time = 2423992
+    time = 2416201
     flags = 1
     data = length 384, hash C9D6BC51
   sample 64:
-    time = 2447992
+    time = 2440201
     flags = 1
     data = length 384, hash FBE2EF0F
   sample 65:
-    time = 2471992
+    time = 2464201
     flags = 1
     data = length 384, hash 64E44326
   sample 66:
-    time = 2495992
+    time = 2488201
     flags = 1
     data = length 384, hash 2A371FEA
   sample 67:
-    time = 2519992
+    time = 2512201
     flags = 1
     data = length 384, hash BC1F17B6
   sample 68:
-    time = 2543992
+    time = 2536201
     flags = 1
     data = length 384, hash 759FA7C2
   sample 69:
-    time = 2567992
+    time = 2560201
     flags = 1
     data = length 384, hash ED978C15
   sample 70:
-    time = 2591992
+    time = 2584201
     flags = 1
     data = length 384, hash 2393BA70
   sample 71:
-    time = 2615992
+    time = 2608201
     flags = 1
     data = length 384, hash F84E2847
   sample 72:
-    time = 2639992
+    time = 2632201
     flags = 1
     data = length 384, hash FF006E14
   sample 73:
-    time = 2663992
+    time = 2656201
     flags = 1
     data = length 384, hash 840D19F5
   sample 74:
-    time = 2687992
+    time = 2680201
     flags = 1
     data = length 384, hash B17A5934
   sample 75:
-    time = 2711992
+    time = 2704201
     flags = 1
     data = length 384, hash 2879F06E
   sample 76:
-    time = 2735992
+    time = 2728201
     flags = 1
     data = length 384, hash 386AB993
   sample 77:
-    time = 2759992
+    time = 2752201
     flags = 1
     data = length 384, hash 276609B5
   sample 78:
-    time = 2783992
+    time = 2776201
     flags = 1
     data = length 384, hash 5FE294B5
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.2.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807978
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=429]]
-  getPosition(1) = [[timeUs=0, position=429], [timeUs=23999, position=813]]
-  getPosition(1403989) = [[timeUs=1391989, position=22701], [timeUs=1415988, position=23085]]
-  getPosition(2807978) = [[timeUs=2783978, position=44973]]
+  getPosition(1) = [[timeUs=0, position=429], [timeUs=23794, position=813]]
+  getPosition(1391989) = [[timeUs=1380096, position=22701], [timeUs=1403891, position=23085]]
+  getPosition(2783979) = [[timeUs=2760185, position=44973]]
 numberOfTracks = 1
 track 0:
   total output bytes = 15360
   sample count = 40
-  track duration = 2807978
+  track duration = 2783979
   format 0:
-    averageBitrate = 128001
+    averageBitrate = 129104
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,163 +21,163 @@ track 0:
     encoderPadding = 576
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=0.0, field 1=GainField{name=1, originator=3, gain=23.0}, field 2=null]
   sample 0:
-    time = 1847985
+    time = 1832197
     flags = 1
     data = length 384, hash 220C783
   sample 1:
-    time = 1871985
+    time = 1856197
     flags = 1
     data = length 384, hash E0925905
   sample 2:
-    time = 1895985
+    time = 1880197
     flags = 1
     data = length 384, hash 824C0D02
   sample 3:
-    time = 1919985
+    time = 1904197
     flags = 1
     data = length 384, hash 5166F8F3
   sample 4:
-    time = 1943985
+    time = 1928197
     flags = 1
     data = length 384, hash B5F38EE6
   sample 5:
-    time = 1967985
+    time = 1952197
     flags = 1
     data = length 384, hash 659E483F
   sample 6:
-    time = 1991985
+    time = 1976197
     flags = 1
     data = length 384, hash A022EFCB
   sample 7:
-    time = 2015985
+    time = 2000197
     flags = 1
     data = length 384, hash 93DCF4B5
   sample 8:
-    time = 2039985
+    time = 2024197
     flags = 1
     data = length 384, hash C965128
   sample 9:
-    time = 2063985
+    time = 2048197
     flags = 1
     data = length 384, hash 6FD595F4
   sample 10:
-    time = 2087985
+    time = 2072197
     flags = 1
     data = length 384, hash BF6CDB31
   sample 11:
-    time = 2111985
+    time = 2096197
     flags = 1
     data = length 384, hash 67C738C0
   sample 12:
-    time = 2135985
+    time = 2120197
     flags = 1
     data = length 384, hash BCFCD1CC
   sample 13:
-    time = 2159985
+    time = 2144197
     flags = 1
     data = length 384, hash A4A85D04
   sample 14:
-    time = 2183985
+    time = 2168197
     flags = 1
     data = length 384, hash 6CD26641
   sample 15:
-    time = 2207985
+    time = 2192197
     flags = 1
     data = length 384, hash 53817862
   sample 16:
-    time = 2231985
+    time = 2216197
     flags = 1
     data = length 384, hash 1C98DD10
   sample 17:
-    time = 2255985
+    time = 2240197
     flags = 1
     data = length 384, hash 5B8EE2C9
   sample 18:
-    time = 2279985
+    time = 2264197
     flags = 1
     data = length 384, hash 227883D0
   sample 19:
-    time = 2303985
+    time = 2288197
     flags = 1
     data = length 384, hash 50267C46
   sample 20:
-    time = 2327985
+    time = 2312197
     flags = 1
     data = length 384, hash F02EA205
   sample 21:
-    time = 2351985
+    time = 2336197
     flags = 1
     data = length 384, hash ED7BE6DF
   sample 22:
-    time = 2375985
+    time = 2360197
     flags = 1
     data = length 384, hash AEE4E608
   sample 23:
-    time = 2399985
+    time = 2384197
     flags = 1
     data = length 384, hash 8EA81A05
   sample 24:
-    time = 2423985
+    time = 2408197
     flags = 1
     data = length 384, hash C9D6BC51
   sample 25:
-    time = 2447985
+    time = 2432197
     flags = 1
     data = length 384, hash FBE2EF0F
   sample 26:
-    time = 2471985
+    time = 2456197
     flags = 1
     data = length 384, hash 64E44326
   sample 27:
-    time = 2495985
+    time = 2480197
     flags = 1
     data = length 384, hash 2A371FEA
   sample 28:
-    time = 2519985
+    time = 2504197
     flags = 1
     data = length 384, hash BC1F17B6
   sample 29:
-    time = 2543985
+    time = 2528197
     flags = 1
     data = length 384, hash 759FA7C2
   sample 30:
-    time = 2567985
+    time = 2552197
     flags = 1
     data = length 384, hash ED978C15
   sample 31:
-    time = 2591985
+    time = 2576197
     flags = 1
     data = length 384, hash 2393BA70
   sample 32:
-    time = 2615985
+    time = 2600197
     flags = 1
     data = length 384, hash F84E2847
   sample 33:
-    time = 2639985
+    time = 2624197
     flags = 1
     data = length 384, hash FF006E14
   sample 34:
-    time = 2663985
+    time = 2648197
     flags = 1
     data = length 384, hash 840D19F5
   sample 35:
-    time = 2687985
+    time = 2672197
     flags = 1
     data = length 384, hash B17A5934
   sample 36:
-    time = 2711985
+    time = 2696197
     flags = 1
     data = length 384, hash 2879F06E
   sample 37:
-    time = 2735985
+    time = 2720197
     flags = 1
     data = length 384, hash 386AB993
   sample 38:
-    time = 2759985
+    time = 2744197
     flags = 1
     data = length 384, hash 276609B5
   sample 39:
-    time = 2783985
+    time = 2768197
     flags = 1
     data = length 384, hash 5FE294B5
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.3.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807978
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=429]]
-  getPosition(1) = [[timeUs=0, position=429], [timeUs=23999, position=813]]
-  getPosition(1403989) = [[timeUs=1391989, position=22701], [timeUs=1415988, position=23085]]
-  getPosition(2807978) = [[timeUs=2783978, position=44973]]
+  getPosition(1) = [[timeUs=0, position=429], [timeUs=23794, position=813]]
+  getPosition(1391989) = [[timeUs=1380096, position=22701], [timeUs=1403891, position=23085]]
+  getPosition(2783979) = [[timeUs=2760185, position=44973]]
 numberOfTracks = 1
 track 0:
   total output bytes = 384
   sample count = 1
-  track duration = 2807978
+  track duration = 2783979
   format 0:
-    averageBitrate = 128001
+    averageBitrate = 129104
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,7 +21,7 @@ track 0:
     encoderPadding = 576
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=0.0, field 1=GainField{name=1, originator=3, gain=23.0}, field 2=null]
   sample 0:
-    time = 2783978
+    time = 2760193
     flags = 1
     data = length 384, hash 5FE294B5
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.unknown_length.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807978
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=429]]
-  getPosition(1) = [[timeUs=0, position=429], [timeUs=23999, position=813]]
-  getPosition(1403989) = [[timeUs=1391989, position=22701], [timeUs=1415988, position=23085]]
-  getPosition(2807978) = [[timeUs=2783978, position=44973]]
+  getPosition(1) = [[timeUs=0, position=429], [timeUs=23794, position=813]]
+  getPosition(1391989) = [[timeUs=1380096, position=22701], [timeUs=1403891, position=23085]]
+  getPosition(2783979) = [[timeUs=2760185, position=44973]]
 numberOfTracks = 1
 track 0:
   total output bytes = 44928
   sample count = 117
-  track duration = 2807978
+  track duration = 2783979
   format 0:
-    averageBitrate = 128001
+    averageBitrate = 129104
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.0.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807979
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
   getPosition(1) = [[timeUs=1, position=237]]
-  getPosition(1403989) = [[timeUs=1403989, position=20120]]
-  getPosition(2807979) = [[timeUs=2807979, position=38396]]
+  getPosition(1391989) = [[timeUs=1391989, position=20120]]
+  getPosition(2783979) = [[timeUs=2783979, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 38160
   sample count = 117
-  track duration = 2807979
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.1.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807979
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
   getPosition(1) = [[timeUs=1, position=237]]
-  getPosition(1403989) = [[timeUs=1403989, position=20120]]
-  getPosition(2807979) = [[timeUs=2807979, position=38396]]
+  getPosition(1391989) = [[timeUs=1391989, position=20120]]
+  getPosition(2783979) = [[timeUs=2783979, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 24384
   sample count = 77
-  track duration = 2807979
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,311 +21,311 @@ track 0:
     encoderPadding = 576
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
-    time = 958033
+    time = 949845
     flags = 1
     data = length 336, hash 71FFE4A0
   sample 1:
-    time = 982033
+    time = 973845
     flags = 1
     data = length 336, hash D4160463
   sample 2:
-    time = 1006033
+    time = 997845
     flags = 1
     data = length 336, hash EC557B14
   sample 3:
-    time = 1030033
+    time = 1021845
     flags = 1
     data = length 288, hash 5598CF8B
   sample 4:
-    time = 1054033
+    time = 1045845
     flags = 1
     data = length 336, hash 7E0AB41
   sample 5:
-    time = 1078033
+    time = 1069845
     flags = 1
     data = length 336, hash 1C585FEF
   sample 6:
-    time = 1102033
+    time = 1093845
     flags = 1
     data = length 336, hash A4A4855E
   sample 7:
-    time = 1126033
+    time = 1117845
     flags = 1
     data = length 336, hash CECA51D3
   sample 8:
-    time = 1150033
+    time = 1141845
     flags = 1
     data = length 288, hash 2D362DC5
   sample 9:
-    time = 1174033
+    time = 1165845
     flags = 1
     data = length 336, hash 9EB2609D
   sample 10:
-    time = 1198033
+    time = 1189845
     flags = 1
     data = length 336, hash 28FFB3FE
   sample 11:
-    time = 1222033
+    time = 1213845
     flags = 1
     data = length 288, hash 2AA2D216
   sample 12:
-    time = 1246033
+    time = 1237845
     flags = 1
     data = length 336, hash CDBC7032
   sample 13:
-    time = 1270033
+    time = 1261845
     flags = 1
     data = length 336, hash 25B13FE7
   sample 14:
-    time = 1294033
+    time = 1285845
     flags = 1
     data = length 336, hash DB6BB1E
   sample 15:
-    time = 1318033
+    time = 1309845
     flags = 1
     data = length 336, hash EBE951F4
   sample 16:
-    time = 1342033
+    time = 1333845
     flags = 1
     data = length 288, hash 9E2EBFF7
   sample 17:
-    time = 1366033
+    time = 1357845
     flags = 1
     data = length 336, hash 36A7D455
   sample 18:
-    time = 1390033
+    time = 1381845
     flags = 1
     data = length 336, hash 84545F8C
   sample 19:
-    time = 1414033
+    time = 1405845
     flags = 1
     data = length 336, hash F66F3045
   sample 20:
-    time = 1438033
+    time = 1429845
     flags = 1
     data = length 576, hash 5AB089EA
   sample 21:
-    time = 1462033
+    time = 1453845
     flags = 1
     data = length 336, hash 8868086
   sample 22:
-    time = 1486033
+    time = 1477845
     flags = 1
     data = length 336, hash D5EB6D63
   sample 23:
-    time = 1510033
+    time = 1501845
     flags = 1
     data = length 288, hash 7A5374B7
   sample 24:
-    time = 1534033
+    time = 1525845
     flags = 1
     data = length 336, hash BEB27A75
   sample 25:
-    time = 1558033
+    time = 1549845
     flags = 1
     data = length 336, hash E251E0FD
   sample 26:
-    time = 1582033
+    time = 1573845
     flags = 1
     data = length 288, hash D54C970
   sample 27:
-    time = 1606033
+    time = 1597845
     flags = 1
     data = length 336, hash 52C473B9
   sample 28:
-    time = 1630033
+    time = 1621845
     flags = 1
     data = length 336, hash F5F13334
   sample 29:
-    time = 1654033
+    time = 1645845
     flags = 1
     data = length 480, hash A5F1E987
   sample 30:
-    time = 1678033
+    time = 1669845
     flags = 1
     data = length 288, hash 453A1267
   sample 31:
-    time = 1702033
+    time = 1693845
     flags = 1
     data = length 288, hash 7C6C2EA9
   sample 32:
-    time = 1726033
+    time = 1717845
     flags = 1
     data = length 336, hash F4BFECA4
   sample 33:
-    time = 1750033
+    time = 1741845
     flags = 1
     data = length 336, hash 751A395A
   sample 34:
-    time = 1774033
+    time = 1765845
     flags = 1
     data = length 336, hash EE38DB02
   sample 35:
-    time = 1798033
+    time = 1789845
     flags = 1
     data = length 336, hash F18837E2
   sample 36:
-    time = 1822033
+    time = 1813845
     flags = 1
     data = length 336, hash ED36B78E
   sample 37:
-    time = 1846033
+    time = 1837845
     flags = 1
     data = length 336, hash B3D28289
   sample 38:
-    time = 1870033
+    time = 1861845
     flags = 1
     data = length 288, hash 8BDE28E1
   sample 39:
-    time = 1894033
+    time = 1885845
     flags = 1
     data = length 336, hash CFD5E966
   sample 40:
-    time = 1918033
+    time = 1909845
     flags = 1
     data = length 288, hash DC08E267
   sample 41:
-    time = 1942033
+    time = 1933845
     flags = 1
     data = length 336, hash 6530CB78
   sample 42:
-    time = 1966033
+    time = 1957845
     flags = 1
     data = length 336, hash 6CC6636E
   sample 43:
-    time = 1990033
+    time = 1981845
     flags = 1
     data = length 336, hash 613047C1
   sample 44:
-    time = 2014033
+    time = 2005845
     flags = 1
     data = length 288, hash CDC747BF
   sample 45:
-    time = 2038033
+    time = 2029845
     flags = 1
     data = length 336, hash AF22AA74
   sample 46:
-    time = 2062033
+    time = 2053845
     flags = 1
     data = length 384, hash 82F326AA
   sample 47:
-    time = 2086033
+    time = 2077845
     flags = 1
     data = length 384, hash EDA26C4D
   sample 48:
-    time = 2110033
+    time = 2101845
     flags = 1
     data = length 336, hash 94C643DC
   sample 49:
-    time = 2134033
+    time = 2125845
     flags = 1
     data = length 288, hash CB5D9C40
   sample 50:
-    time = 2158033
+    time = 2149845
     flags = 1
     data = length 336, hash 1E69DE3F
   sample 51:
-    time = 2182033
+    time = 2173845
     flags = 1
     data = length 336, hash 7E472219
   sample 52:
-    time = 2206033
+    time = 2197845
     flags = 1
     data = length 336, hash DA47B9FA
   sample 53:
-    time = 2230033
+    time = 2221845
     flags = 1
     data = length 336, hash DD0ABB7C
   sample 54:
-    time = 2254033
+    time = 2245845
     flags = 1
     data = length 288, hash DBF93FAC
   sample 55:
-    time = 2278033
+    time = 2269845
     flags = 1
     data = length 336, hash 243F4B2
   sample 56:
-    time = 2302033
+    time = 2293845
     flags = 1
     data = length 336, hash 2E881490
   sample 57:
-    time = 2326033
+    time = 2317845
     flags = 1
     data = length 288, hash 1C28C8BE
   sample 58:
-    time = 2350033
+    time = 2341845
     flags = 1
     data = length 336, hash C73E5D30
   sample 59:
-    time = 2374033
+    time = 2365845
     flags = 1
     data = length 288, hash 98B5BFF6
   sample 60:
-    time = 2398033
+    time = 2389845
     flags = 1
     data = length 336, hash E0135533
   sample 61:
-    time = 2422033
+    time = 2413845
     flags = 1
     data = length 336, hash D13C9DBC
   sample 62:
-    time = 2446033
+    time = 2437845
     flags = 1
     data = length 336, hash 63D524CA
   sample 63:
-    time = 2470033
+    time = 2461845
     flags = 1
     data = length 288, hash A28514C3
   sample 64:
-    time = 2494033
+    time = 2485845
     flags = 1
     data = length 336, hash 72B647FF
   sample 65:
-    time = 2518033
+    time = 2509845
     flags = 1
     data = length 336, hash 8F740AB1
   sample 66:
-    time = 2542033
+    time = 2533845
     flags = 1
     data = length 336, hash 5E3C7E93
   sample 67:
-    time = 2566033
+    time = 2557845
     flags = 1
     data = length 336, hash 121B913B
   sample 68:
-    time = 2590033
+    time = 2581845
     flags = 1
     data = length 336, hash 578FCCF2
   sample 69:
-    time = 2614033
+    time = 2605845
     flags = 1
     data = length 336, hash 5B5823DE
   sample 70:
-    time = 2638033
+    time = 2629845
     flags = 1
     data = length 384, hash D8B83F78
   sample 71:
-    time = 2662033
+    time = 2653845
     flags = 1
     data = length 240, hash E649682F
   sample 72:
-    time = 2686033
+    time = 2677845
     flags = 1
     data = length 96, hash C559A6F4
   sample 73:
-    time = 2710033
+    time = 2701845
     flags = 1
     data = length 96, hash 792796BC
   sample 74:
-    time = 2734033
+    time = 2725845
     flags = 1
     data = length 120, hash 8172CD0E
   sample 75:
-    time = 2758033
+    time = 2749845
     flags = 1
     data = length 120, hash F562B52F
   sample 76:
-    time = 2782033
+    time = 2773845
     flags = 1
     data = length 96, hash FF8D5B98
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.2.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807979
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
   getPosition(1) = [[timeUs=1, position=237]]
-  getPosition(1403989) = [[timeUs=1403989, position=20120]]
-  getPosition(2807979) = [[timeUs=2807979, position=38396]]
+  getPosition(1391989) = [[timeUs=1391989, position=20120]]
+  getPosition(2783979) = [[timeUs=2783979, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 11328
   sample count = 38
-  track duration = 2807979
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,155 +21,155 @@ track 0:
     encoderPadding = 576
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
-    time = 1886757
+    time = 1870631
     flags = 1
     data = length 336, hash CFD5E966
   sample 1:
-    time = 1910757
+    time = 1894631
     flags = 1
     data = length 288, hash DC08E267
   sample 2:
-    time = 1934757
+    time = 1918631
     flags = 1
     data = length 336, hash 6530CB78
   sample 3:
-    time = 1958757
+    time = 1942631
     flags = 1
     data = length 336, hash 6CC6636E
   sample 4:
-    time = 1982757
+    time = 1966631
     flags = 1
     data = length 336, hash 613047C1
   sample 5:
-    time = 2006757
+    time = 1990631
     flags = 1
     data = length 288, hash CDC747BF
   sample 6:
-    time = 2030757
+    time = 2014631
     flags = 1
     data = length 336, hash AF22AA74
   sample 7:
-    time = 2054757
+    time = 2038631
     flags = 1
     data = length 384, hash 82F326AA
   sample 8:
-    time = 2078757
+    time = 2062631
     flags = 1
     data = length 384, hash EDA26C4D
   sample 9:
-    time = 2102757
+    time = 2086631
     flags = 1
     data = length 336, hash 94C643DC
   sample 10:
-    time = 2126757
+    time = 2110631
     flags = 1
     data = length 288, hash CB5D9C40
   sample 11:
-    time = 2150757
+    time = 2134631
     flags = 1
     data = length 336, hash 1E69DE3F
   sample 12:
-    time = 2174757
+    time = 2158631
     flags = 1
     data = length 336, hash 7E472219
   sample 13:
-    time = 2198757
+    time = 2182631
     flags = 1
     data = length 336, hash DA47B9FA
   sample 14:
-    time = 2222757
+    time = 2206631
     flags = 1
     data = length 336, hash DD0ABB7C
   sample 15:
-    time = 2246757
+    time = 2230631
     flags = 1
     data = length 288, hash DBF93FAC
   sample 16:
-    time = 2270757
+    time = 2254631
     flags = 1
     data = length 336, hash 243F4B2
   sample 17:
-    time = 2294757
+    time = 2278631
     flags = 1
     data = length 336, hash 2E881490
   sample 18:
-    time = 2318757
+    time = 2302631
     flags = 1
     data = length 288, hash 1C28C8BE
   sample 19:
-    time = 2342757
+    time = 2326631
     flags = 1
     data = length 336, hash C73E5D30
   sample 20:
-    time = 2366757
+    time = 2350631
     flags = 1
     data = length 288, hash 98B5BFF6
   sample 21:
-    time = 2390757
+    time = 2374631
     flags = 1
     data = length 336, hash E0135533
   sample 22:
-    time = 2414757
+    time = 2398631
     flags = 1
     data = length 336, hash D13C9DBC
   sample 23:
-    time = 2438757
+    time = 2422631
     flags = 1
     data = length 336, hash 63D524CA
   sample 24:
-    time = 2462757
+    time = 2446631
     flags = 1
     data = length 288, hash A28514C3
   sample 25:
-    time = 2486757
+    time = 2470631
     flags = 1
     data = length 336, hash 72B647FF
   sample 26:
-    time = 2510757
+    time = 2494631
     flags = 1
     data = length 336, hash 8F740AB1
   sample 27:
-    time = 2534757
+    time = 2518631
     flags = 1
     data = length 336, hash 5E3C7E93
   sample 28:
-    time = 2558757
+    time = 2542631
     flags = 1
     data = length 336, hash 121B913B
   sample 29:
-    time = 2582757
+    time = 2566631
     flags = 1
     data = length 336, hash 578FCCF2
   sample 30:
-    time = 2606757
+    time = 2590631
     flags = 1
     data = length 336, hash 5B5823DE
   sample 31:
-    time = 2630757
+    time = 2614631
     flags = 1
     data = length 384, hash D8B83F78
   sample 32:
-    time = 2654757
+    time = 2638631
     flags = 1
     data = length 240, hash E649682F
   sample 33:
-    time = 2678757
+    time = 2662631
     flags = 1
     data = length 96, hash C559A6F4
   sample 34:
-    time = 2702757
+    time = 2686631
     flags = 1
     data = length 96, hash 792796BC
   sample 35:
-    time = 2726757
+    time = 2710631
     flags = 1
     data = length 120, hash 8172CD0E
   sample 36:
-    time = 2750757
+    time = 2734631
     flags = 1
     data = length 120, hash F562B52F
   sample 37:
-    time = 2774757
+    time = 2758631
     flags = 1
     data = length 96, hash FF8D5B98
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.3.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807979
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
   getPosition(1) = [[timeUs=1, position=237]]
-  getPosition(1403989) = [[timeUs=1403989, position=20120]]
-  getPosition(2807979) = [[timeUs=2807979, position=38396]]
+  getPosition(1391989) = [[timeUs=1391989, position=20120]]
+  getPosition(2783979) = [[timeUs=2783979, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 0
   sample count = 0
-  track duration = 2807979
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.unknown_length.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 2807979
+  duration = 2783979
   getPosition(0) = [[timeUs=0, position=237]]
   getPosition(1) = [[timeUs=1, position=237]]
-  getPosition(1403989) = [[timeUs=1403989, position=20120]]
-  getPosition(2807979) = [[timeUs=2807979, position=38396]]
+  getPosition(1391989) = [[timeUs=1391989, position=20120]]
+  getPosition(2783979) = [[timeUs=2783979, position=38396]]
 numberOfTracks = 1
 track 0:
   total output bytes = 38160
   sample count = 117
-  track duration = 2807979
+  track duration = 2783979
   format 0:
-    averageBitrate = 108719
+    averageBitrate = 109656
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.0.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 1070994
+  duration = 1026099
   getPosition(0) = [[timeUs=0, position=227]]
-  getPosition(1) = [[timeUs=0, position=227], [timeUs=26069, position=433]]
-  getPosition(535497) = [[timeUs=521386, position=4347], [timeUs=547456, position=4553]]
-  getPosition(1070994) = [[timeUs=1044925, position=8484]]
+  getPosition(1) = [[timeUs=0, position=227], [timeUs=24976, position=433]]
+  getPosition(513049) = [[timeUs=499530, position=4347], [timeUs=524506, position=4553]]
+  getPosition(1026099) = [[timeUs=1001123, position=8484]]
 numberOfTracks = 1
 track 0:
   total output bytes = 8463
   sample count = 41
-  track duration = 1070994
+  track duration = 1026099
   format 0:
-    averageBitrate = 63216
+    averageBitrate = 65982
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.1.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 1070994
+  duration = 1026099
   getPosition(0) = [[timeUs=0, position=227]]
-  getPosition(1) = [[timeUs=0, position=227], [timeUs=26069, position=433]]
-  getPosition(535497) = [[timeUs=521386, position=4347], [timeUs=547456, position=4553]]
-  getPosition(1070994) = [[timeUs=1044925, position=8484]]
+  getPosition(1) = [[timeUs=0, position=227], [timeUs=24976, position=433]]
+  getPosition(513049) = [[timeUs=499530, position=4347], [timeUs=524506, position=4553]]
+  getPosition(1026099) = [[timeUs=1001123, position=8484]]
 numberOfTracks = 1
 track 0:
   total output bytes = 5643
   sample count = 27
-  track duration = 1070994
+  track duration = 1026099
   format 0:
-    averageBitrate = 63216
+    averageBitrate = 65982
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,111 +21,111 @@ track 0:
     encoderPadding = 1404
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
-    time = 356871
+    time = 341911
     flags = 1
     data = length 209, hash 6CCBBB3B
   sample 1:
-    time = 382993
+    time = 368033
     flags = 1
     data = length 209, hash 34191E1
   sample 2:
-    time = 409115
+    time = 394155
     flags = 1
     data = length 209, hash 57323ED7
   sample 3:
-    time = 435238
+    time = 420278
     flags = 1
     data = length 209, hash 75618CF3
   sample 4:
-    time = 461360
+    time = 446400
     flags = 1
     data = length 209, hash 784C973B
   sample 5:
-    time = 487483
+    time = 472523
     flags = 1
     data = length 209, hash 49106390
   sample 6:
-    time = 513605
+    time = 498645
     flags = 1
     data = length 209, hash 70F6A563
   sample 7:
-    time = 539728
+    time = 524768
     flags = 1
     data = length 209, hash 721882B0
   sample 8:
-    time = 565850
+    time = 550890
     flags = 1
     data = length 209, hash 81C62AEE
   sample 9:
-    time = 591973
+    time = 577013
     flags = 1
     data = length 209, hash 16D22463
   sample 10:
-    time = 618095
+    time = 603135
     flags = 1
     data = length 209, hash 47033534
   sample 11:
-    time = 644217
+    time = 629257
     flags = 1
     data = length 209, hash CECB37A6
   sample 12:
-    time = 670340
+    time = 655380
     flags = 1
     data = length 209, hash 6C9C307B
   sample 13:
-    time = 696462
+    time = 681502
     flags = 1
     data = length 209, hash 3EB1A364
   sample 14:
-    time = 722585
+    time = 707625
     flags = 1
     data = length 209, hash 30962500
   sample 15:
-    time = 748707
+    time = 733747
     flags = 1
     data = length 209, hash 2C5CCBB7
   sample 16:
-    time = 774830
+    time = 759870
     flags = 1
     data = length 209, hash F9CB9E37
   sample 17:
-    time = 800952
+    time = 785992
     flags = 1
     data = length 209, hash F75BC8C0
   sample 18:
-    time = 827075
+    time = 812115
     flags = 1
     data = length 209, hash D00ED607
   sample 19:
-    time = 853197
+    time = 838237
     flags = 1
     data = length 209, hash B4338395
   sample 20:
-    time = 879319
+    time = 864359
     flags = 1
     data = length 209, hash E3E838A0
   sample 21:
-    time = 905442
+    time = 890482
     flags = 1
     data = length 209, hash 2B0CF78
   sample 22:
-    time = 931564
+    time = 916604
     flags = 1
     data = length 209, hash 31906FA9
   sample 23:
-    time = 957687
+    time = 942727
     flags = 1
     data = length 209, hash C92FC08F
   sample 24:
-    time = 983809
+    time = 968849
     flags = 1
     data = length 209, hash 7C89994
   sample 25:
-    time = 1009932
+    time = 994972
     flags = 1
     data = length 209, hash EC37743B
   sample 26:
-    time = 1036054
+    time = 1021094
     flags = 1
     data = length 209, hash C974F6FB
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.2.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 1070994
+  duration = 1026099
   getPosition(0) = [[timeUs=0, position=227]]
-  getPosition(1) = [[timeUs=0, position=227], [timeUs=26069, position=433]]
-  getPosition(535497) = [[timeUs=521386, position=4347], [timeUs=547456, position=4553]]
-  getPosition(1070994) = [[timeUs=1044925, position=8484]]
+  getPosition(1) = [[timeUs=0, position=227], [timeUs=24976, position=433]]
+  getPosition(513049) = [[timeUs=499530, position=4347], [timeUs=524506, position=4553]]
+  getPosition(1026099) = [[timeUs=1001123, position=8484]]
 numberOfTracks = 1
 track 0:
   total output bytes = 2717
   sample count = 13
-  track duration = 1070994
+  track duration = 1026099
   format 0:
-    averageBitrate = 63216
+    averageBitrate = 65982
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,55 +21,55 @@ track 0:
     encoderPadding = 1404
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
-    time = 727157
+    time = 696674
     flags = 1
     data = length 209, hash 30962500
   sample 1:
-    time = 753279
+    time = 722796
     flags = 1
     data = length 209, hash 2C5CCBB7
   sample 2:
-    time = 779401
+    time = 748918
     flags = 1
     data = length 209, hash F9CB9E37
   sample 3:
-    time = 805524
+    time = 775041
     flags = 1
     data = length 209, hash F75BC8C0
   sample 4:
-    time = 831646
+    time = 801163
     flags = 1
     data = length 209, hash D00ED607
   sample 5:
-    time = 857769
+    time = 827286
     flags = 1
     data = length 209, hash B4338395
   sample 6:
-    time = 883891
+    time = 853408
     flags = 1
     data = length 209, hash E3E838A0
   sample 7:
-    time = 910014
+    time = 879531
     flags = 1
     data = length 209, hash 2B0CF78
   sample 8:
-    time = 936136
+    time = 905653
     flags = 1
     data = length 209, hash 31906FA9
   sample 9:
-    time = 962259
+    time = 931776
     flags = 1
     data = length 209, hash C92FC08F
   sample 10:
-    time = 988381
+    time = 957898
     flags = 1
     data = length 209, hash 7C89994
   sample 11:
-    time = 1014503
+    time = 984020
     flags = 1
     data = length 209, hash EC37743B
   sample 12:
-    time = 1040626
+    time = 1010143
     flags = 1
     data = length 209, hash C974F6FB
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.3.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 1070994
+  duration = 1026099
   getPosition(0) = [[timeUs=0, position=227]]
-  getPosition(1) = [[timeUs=0, position=227], [timeUs=26069, position=433]]
-  getPosition(535497) = [[timeUs=521386, position=4347], [timeUs=547456, position=4553]]
-  getPosition(1070994) = [[timeUs=1044925, position=8484]]
+  getPosition(1) = [[timeUs=0, position=227], [timeUs=24976, position=433]]
+  getPosition(513049) = [[timeUs=499530, position=4347], [timeUs=524506, position=4553]]
+  getPosition(1026099) = [[timeUs=1001123, position=8484]]
 numberOfTracks = 1
 track 0:
   total output bytes = 0
   sample count = 0
-  track duration = 1070994
+  track duration = 1026099
   format 0:
-    averageBitrate = 63216
+    averageBitrate = 65982
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.unknown_length.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 1070994
+  duration = 1026099
   getPosition(0) = [[timeUs=0, position=227]]
-  getPosition(1) = [[timeUs=0, position=227], [timeUs=26069, position=433]]
-  getPosition(535497) = [[timeUs=521386, position=4347], [timeUs=547456, position=4553]]
-  getPosition(1070994) = [[timeUs=1044925, position=8484]]
+  getPosition(1) = [[timeUs=0, position=227], [timeUs=24976, position=433]]
+  getPosition(513049) = [[timeUs=499530, position=4347], [timeUs=524506, position=4553]]
+  getPosition(1026099) = [[timeUs=1001123, position=8484]]
 numberOfTracks = 1
 track 0:
   total output bytes = 8463
   sample count = 41
-  track duration = 1070994
+  track duration = 1026099
   format 0:
-    averageBitrate = 63216
+    averageBitrate = 65982
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.0.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 1044875
+  duration = 999977
   getPosition(0) = [[timeUs=0, position=227]]
-  getPosition(1) = [[timeUs=0, position=227], [timeUs=26125, position=436]]
-  getPosition(522437) = [[timeUs=496375, position=4198], [timeUs=522500, position=4407]]
-  getPosition(1044875) = [[timeUs=1018750, position=8377]]
+  getPosition(1) = [[timeUs=0, position=227], [timeUs=25002, position=436]]
+  getPosition(499988) = [[timeUs=475042, position=4198], [timeUs=500044, position=4407]]
+  getPosition(999977) = [[timeUs=974975, position=8377]]
 numberOfTracks = 1
 track 0:
   total output bytes = 8359
   sample count = 40
-  track duration = 1044875
+  track duration = 999977
   format 0:
-    averageBitrate = 64000
+    averageBitrate = 66874
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.1.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 1044875
+  duration = 999977
   getPosition(0) = [[timeUs=0, position=227]]
-  getPosition(1) = [[timeUs=0, position=227], [timeUs=26125, position=436]]
-  getPosition(522437) = [[timeUs=496375, position=4198], [timeUs=522500, position=4407]]
-  getPosition(1044875) = [[timeUs=1018750, position=8377]]
+  getPosition(1) = [[timeUs=0, position=227], [timeUs=25002, position=436]]
+  getPosition(499988) = [[timeUs=475042, position=4198], [timeUs=500044, position=4407]]
+  getPosition(999977) = [[timeUs=974975, position=8377]]
 numberOfTracks = 1
 track 0:
   total output bytes = 5434
   sample count = 26
-  track duration = 1044875
+  track duration = 999977
   format 0:
-    averageBitrate = 64000
+    averageBitrate = 66874
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,107 +21,107 @@ track 0:
     encoderPadding = 1404
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
-    time = 365625
+    time = 349911
     flags = 1
     data = length 209, hash 34191E1
   sample 1:
-    time = 391747
+    time = 376033
     flags = 1
     data = length 209, hash 57323ED7
   sample 2:
-    time = 417869
+    time = 402155
     flags = 1
     data = length 209, hash 75618CF3
   sample 3:
-    time = 443992
+    time = 428278
     flags = 1
     data = length 209, hash 784C973B
   sample 4:
-    time = 470114
+    time = 454400
     flags = 1
     data = length 209, hash 49106390
   sample 5:
-    time = 496237
+    time = 480523
     flags = 1
     data = length 209, hash 70F6A563
   sample 6:
-    time = 522359
+    time = 506645
     flags = 1
     data = length 209, hash 721882B0
   sample 7:
-    time = 548482
+    time = 532768
     flags = 1
     data = length 209, hash 81C62AEE
   sample 8:
-    time = 574604
+    time = 558890
     flags = 1
     data = length 209, hash 16D22463
   sample 9:
-    time = 600727
+    time = 585013
     flags = 1
     data = length 209, hash 47033534
   sample 10:
-    time = 626849
+    time = 611135
     flags = 1
     data = length 209, hash CECB37A6
   sample 11:
-    time = 652971
+    time = 637257
     flags = 1
     data = length 209, hash 6C9C307B
   sample 12:
-    time = 679094
+    time = 663380
     flags = 1
     data = length 209, hash 3EB1A364
   sample 13:
-    time = 705216
+    time = 689502
     flags = 1
     data = length 209, hash 30962500
   sample 14:
-    time = 731339
+    time = 715625
     flags = 1
     data = length 209, hash 2C5CCBB7
   sample 15:
-    time = 757461
+    time = 741747
     flags = 1
     data = length 209, hash F9CB9E37
   sample 16:
-    time = 783584
+    time = 767870
     flags = 1
     data = length 209, hash F75BC8C0
   sample 17:
-    time = 809706
+    time = 793992
     flags = 1
     data = length 209, hash D00ED607
   sample 18:
-    time = 835829
+    time = 820115
     flags = 1
     data = length 209, hash B4338395
   sample 19:
-    time = 861951
+    time = 846237
     flags = 1
     data = length 209, hash E3E838A0
   sample 20:
-    time = 888073
+    time = 872359
     flags = 1
     data = length 209, hash 2B0CF78
   sample 21:
-    time = 914196
+    time = 898482
     flags = 1
     data = length 209, hash 31906FA9
   sample 22:
-    time = 940318
+    time = 924604
     flags = 1
     data = length 209, hash C92FC08F
   sample 23:
-    time = 966441
+    time = 950727
     flags = 1
     data = length 209, hash 7C89994
   sample 24:
-    time = 992563
+    time = 976849
     flags = 1
     data = length 209, hash EC37743B
   sample 25:
-    time = 1018686
+    time = 1002972
     flags = 1
     data = length 209, hash C974F6FB
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.2.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 1044875
+  duration = 999977
   getPosition(0) = [[timeUs=0, position=227]]
-  getPosition(1) = [[timeUs=0, position=227], [timeUs=26125, position=436]]
-  getPosition(522437) = [[timeUs=496375, position=4198], [timeUs=522500, position=4407]]
-  getPosition(1044875) = [[timeUs=1018750, position=8377]]
+  getPosition(1) = [[timeUs=0, position=227], [timeUs=25002, position=436]]
+  getPosition(499988) = [[timeUs=475042, position=4198], [timeUs=500044, position=4407]]
+  getPosition(999977) = [[timeUs=974975, position=8377]]
 numberOfTracks = 1
 track 0:
   total output bytes = 2717
   sample count = 13
-  track duration = 1044875
+  track duration = 999977
   format 0:
-    averageBitrate = 64000
+    averageBitrate = 66874
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,55 +21,55 @@ track 0:
     encoderPadding = 1404
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
-    time = 705250
+    time = 674940
     flags = 1
     data = length 209, hash 30962500
   sample 1:
-    time = 731372
+    time = 701062
     flags = 1
     data = length 209, hash 2C5CCBB7
   sample 2:
-    time = 757494
+    time = 727184
     flags = 1
     data = length 209, hash F9CB9E37
   sample 3:
-    time = 783617
+    time = 753307
     flags = 1
     data = length 209, hash F75BC8C0
   sample 4:
-    time = 809739
+    time = 779429
     flags = 1
     data = length 209, hash D00ED607
   sample 5:
-    time = 835862
+    time = 805552
     flags = 1
     data = length 209, hash B4338395
   sample 6:
-    time = 861984
+    time = 831674
     flags = 1
     data = length 209, hash E3E838A0
   sample 7:
-    time = 888107
+    time = 857797
     flags = 1
     data = length 209, hash 2B0CF78
   sample 8:
-    time = 914229
+    time = 883919
     flags = 1
     data = length 209, hash 31906FA9
   sample 9:
-    time = 940352
+    time = 910042
     flags = 1
     data = length 209, hash C92FC08F
   sample 10:
-    time = 966474
+    time = 936164
     flags = 1
     data = length 209, hash 7C89994
   sample 11:
-    time = 992596
+    time = 962286
     flags = 1
     data = length 209, hash EC37743B
   sample 12:
-    time = 1018719
+    time = 988409
     flags = 1
     data = length 209, hash C974F6FB
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.3.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 1044875
+  duration = 999977
   getPosition(0) = [[timeUs=0, position=227]]
-  getPosition(1) = [[timeUs=0, position=227], [timeUs=26125, position=436]]
-  getPosition(522437) = [[timeUs=496375, position=4198], [timeUs=522500, position=4407]]
-  getPosition(1044875) = [[timeUs=1018750, position=8377]]
+  getPosition(1) = [[timeUs=0, position=227], [timeUs=25002, position=436]]
+  getPosition(499988) = [[timeUs=475042, position=4198], [timeUs=500044, position=4407]]
+  getPosition(999977) = [[timeUs=974975, position=8377]]
 numberOfTracks = 1
 track 0:
   total output bytes = 209
   sample count = 1
-  track duration = 1044875
+  track duration = 999977
   format 0:
-    averageBitrate = 64000
+    averageBitrate = 66874
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096
@@ -21,7 +21,7 @@ track 0:
     encoderPadding = 1404
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
-    time = 1018750
+    time = 974967
     flags = 1
     data = length 209, hash C974F6FB
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.unknown_length.dump
@@ -1,17 +1,17 @@
 seekMap:
   isSeekable = true
-  duration = 1044875
+  duration = 999977
   getPosition(0) = [[timeUs=0, position=227]]
-  getPosition(1) = [[timeUs=0, position=227], [timeUs=26125, position=436]]
-  getPosition(522437) = [[timeUs=496375, position=4198], [timeUs=522500, position=4407]]
-  getPosition(1044875) = [[timeUs=1018750, position=8377]]
+  getPosition(1) = [[timeUs=0, position=227], [timeUs=25002, position=436]]
+  getPosition(499988) = [[timeUs=475042, position=4198], [timeUs=500044, position=4407]]
+  getPosition(999977) = [[timeUs=974975, position=8377]]
 numberOfTracks = 1
 track 0:
   total output bytes = 8359
   sample count = 40
-  track duration = 1044875
+  track duration = 999977
   format 0:
-    averageBitrate = 64000
+    averageBitrate = 66874
     containerMimeType = audio/mpeg
     sampleMimeType = audio/mpeg
     maxInputSize = 4096

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerEndToEndTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerEndToEndTest.java
@@ -1834,7 +1834,7 @@ public class TransformerEndToEndTest {
             .build()
             .run(testId, composition);
 
-    assertThat(result.exportResult.processedInputs).hasSize(7);
+    assertThat(result.exportResult.processedInputs).hasSize(6);
     FakeExtractorOutput fakeExtractorOutput =
         extractAllSamplesFromFilePath(
             new Mp4Extractor(new DefaultSubtitleParserFactory()), checkNotNull(result.filePath));
@@ -1844,13 +1844,13 @@ public class TransformerEndToEndTest {
     // seen in this check as the duration is determined by the last video frame.
     // However, if the audio track is roughly as long as the video track, this API difference
     // will be seen in result.exportResult.durationMs.
-    assertThat(fakeExtractorOutput.seekMap.getDurationUs()).isWithin(50_000).of(3_150_000);
+    assertThat(fakeExtractorOutput.seekMap.getDurationUs()).isWithin(50_000).of(3_000_000);
     FakeTrackOutput audioTrackOutput =
         getOnlyElement(fakeExtractorOutput.getTrackOutputsForType(C.TRACK_TYPE_AUDIO));
     assertThat(audioTrackOutput.lastFormat.channelCount).isEqualTo(1);
     FakeTrackOutput videoTrackOutput =
         getOnlyElement(fakeExtractorOutput.getTrackOutputsForType(C.TRACK_TYPE_VIDEO));
-    assertThat(videoTrackOutput.getSampleCount()).isEqualTo(92);
+    assertThat(videoTrackOutput.getSampleCount()).isEqualTo(89);
   }
 
   @Test
@@ -1863,7 +1863,7 @@ public class TransformerEndToEndTest {
             ImmutableList.of(audioEditedMediaItem, audioEditedMediaItem, audioEditedMediaItem));
     EditedMediaItem imageEditedMediaItem =
         new EditedMediaItem.Builder(
-                new MediaItem.Builder().setUri(PNG_ASSET.uri).setImageDurationMs(1000).build())
+                new MediaItem.Builder().setUri(PNG_ASSET.uri).setImageDurationMs(950).build())
             .setFrameRate(30)
             .build();
     EditedMediaItemSequence loopingImageSequence =
@@ -1888,13 +1888,13 @@ public class TransformerEndToEndTest {
     // seen in this check as the duration is determined by the last video frame.
     // However, if the audio track is roughly as long as the video track, this API difference
     // will be seen in result.exportResult.durationMs.
-    assertThat(fakeExtractorOutput.seekMap.getDurationUs()).isWithin(50_000).of(3_140_000);
+    assertThat(fakeExtractorOutput.seekMap.getDurationUs()).isWithin(50_000).of(3_000_000);
     FakeTrackOutput audioTrackOutput =
         getOnlyElement(fakeExtractorOutput.getTrackOutputsForType(C.TRACK_TYPE_AUDIO));
     assertThat(audioTrackOutput.lastFormat.channelCount).isEqualTo(1);
     FakeTrackOutput videoTrackOutput =
         getOnlyElement(fakeExtractorOutput.getTrackOutputsForType(C.TRACK_TYPE_VIDEO));
-    assertThat(videoTrackOutput.getSampleCount()).isEqualTo(95);
+    assertThat(videoTrackOutput.getSampleCount()).isEqualTo(92);
   }
 
   @Test
@@ -1906,7 +1906,7 @@ public class TransformerEndToEndTest {
         EditedMediaItemSequence.withAudioFrom(ImmutableList.of(audioEditedMediaItem));
     EditedMediaItem imageEditedMediaItem =
         new EditedMediaItem.Builder(
-                new MediaItem.Builder().setUri(PNG_ASSET.uri).setImageDurationMs(1050).build())
+                new MediaItem.Builder().setUri(PNG_ASSET.uri).setImageDurationMs(950).build())
             .setFrameRate(20)
             .build();
     EditedMediaItemSequence loopingImageSequence =
@@ -1931,7 +1931,7 @@ public class TransformerEndToEndTest {
     // seen in this check as the duration is determined by the last video frame.
     // However, if the audio track is roughly as long as the video track, this API difference
     // will be seen in result.exportResult.durationMs.
-    assertThat(fakeExtractorOutput.seekMap.getDurationUs()).isWithin(50_000).of(1_050_000);
+    assertThat(fakeExtractorOutput.seekMap.getDurationUs()).isWithin(50_000).of(1_000_000);
     FakeTrackOutput audioTrackOutput =
         getOnlyElement(fakeExtractorOutput.getTrackOutputsForType(C.TRACK_TYPE_AUDIO));
     assertThat(audioTrackOutput.lastFormat.channelCount).isEqualTo(1);
@@ -2399,7 +2399,7 @@ public class TransformerEndToEndTest {
     new TransformerAndroidTestRunner.Builder(context, analyzer)
         .build()
         .run(testId, audioEditedMediaItem);
-    assertThat(audioBytesSeen.get()).isEqualTo(101_760);
+    assertThat(audioBytesSeen.get()).isWithin(1_000).of(97_000);
   }
 
   @Test


### PR DESCRIPTION
LAME Xing/Info headers can include encoder delay and padding. Mp3Extractor already propagates those values into Format so decoded audio is rendered gaplessly, but the SeekMap duration was still computed from the untrimmed MPEG frame count. For CBR Info files this can expose a source duration that is longer than the samples that will actually be played, which can break gapless transitions.

This change also updates average bitrate to be based on the gapless duration.

Fixes #3183.