### PR TITLE
Adjust LAME MP3 trim metadata to decoded PCM timeline

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -13,6 +13,9 @@
 *   Extractors:
     *   MP3: Use gapless-aware durations from Xing/Info headers
         ([#3183](https://github.com/androidx/media/issues/3183)).
+    *   MP3: Adjust LAME/Xing encoder delay and padding metadata to match
+        decoded PCM trimming
+        ([#3200](https://github.com/androidx/media/pull/3200)).
 *   Inspector:
 *   Inspector Frame:
 *   Audio:

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/e2etest/EndToEndGaplessTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/e2etest/EndToEndGaplessTest.java
@@ -92,8 +92,8 @@ public class EndToEndGaplessTest {
     int bytesPerFrame = audioTrackListener.getAudioTrackOutputFormat().getFrameSizeInBytes();
     int paddingBytes = max(0, playerAudioFormat.encoderPadding) * bytesPerFrame;
     int delayBytes = max(0, playerAudioFormat.encoderDelay) * bytesPerFrame;
-    assertThat(paddingBytes).isEqualTo(2808);
-    assertThat(delayBytes).isEqualTo(1152);
+    assertThat(paddingBytes).isEqualTo(1750);
+    assertThat(delayBytes).isEqualTo(2210);
 
     byte[] decoderOutputBytes = Bytes.concat(mp3Decoder.getAllOutputBytes().toArray(new byte[0][]));
     int bytesPerAudioFile = decoderOutputBytes.length / 2;

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/XingFrame.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp3/XingFrame.java
@@ -25,6 +25,13 @@ import androidx.media3.extractor.MpegAudioUtil;
 /** Representation of a LAME Xing or Info frame. */
 /* package */ final class XingFrame {
 
+  /**
+   * Offset between LAME/Xing delay/padding fields and decoded PCM trim samples. FFmpeg's MP3 muxer
+   * subtracts this offset when writing LAME metadata, and its demuxer adds it back when exposing
+   * decoded PCM skip/discard samples.
+   */
+  private static final int LAME_TO_DECODED_PCM_TRIM_OFFSET_SAMPLES = 528 + 1;
+
   /** The header of the Xing or Info frame. */
   public final MpegAudioUtil.Header header;
 
@@ -107,12 +114,13 @@ import androidx.media3.extractor.MpegAudioUtil;
     @Nullable Mp3InfoReplayGain replayGain;
     int encoderDelay;
     int encoderPadding;
-    // Skip: version string (9), revision & VBR method (1), lowpass filter (1).
-    int bytesToSkipBeforeReplayGain = 9 + 1 + 1;
+    // Skip: revision & VBR method (1), lowpass filter (1).
+    int bytesToSkipBeforeReplayGain = 1 + 1;
     // Skip: encoding flags & ATH type (1), bitrate (1).
     int bytesToSkipAfterReplayGain = 1 + 1;
-    // And account for values we parse, ReplayGain (8) and encoder delay & padding (3).
-    if (frame.bytesLeft() >= bytesToSkipBeforeReplayGain + 8 + bytesToSkipAfterReplayGain + 3) {
+    // And account for values we parse: version string (9), ReplayGain (8) and encoder delay & padding (3).
+    if (frame.bytesLeft() >= 9 + bytesToSkipBeforeReplayGain + 8 + bytesToSkipAfterReplayGain + 3) {
+      String encoderIdentifier = frame.readString(9);
       frame.skipBytes(bytesToSkipBeforeReplayGain);
       float peak = frame.readFloat();
       int field1 = frame.readUnsignedShort();
@@ -123,6 +131,10 @@ import androidx.media3.extractor.MpegAudioUtil;
       int encoderDelayAndPadding = frame.readUnsignedInt24();
       encoderDelay = (encoderDelayAndPadding & 0xFFF000) >> 12;
       encoderPadding = (encoderDelayAndPadding & 0xFFF);
+      if (usesLameGaplessEncoding(encoderIdentifier)) {
+        encoderDelay += LAME_TO_DECODED_PCM_TRIM_OFFSET_SAMPLES;
+        encoderPadding = Math.max(0, encoderPadding - LAME_TO_DECODED_PCM_TRIM_OFFSET_SAMPLES);
+      }
     } else {
       replayGain = null;
       encoderDelay = C.LENGTH_UNSET;
@@ -159,6 +171,12 @@ import androidx.media3.extractor.MpegAudioUtil;
     // Audio requires both a start and end PCM sample, so subtract one from the sample count before
     // calculating the duration.
     return Util.sampleCountToDurationUs(sampleCount - 1, header.sampleRate);
+  }
+
+  private static boolean usesLameGaplessEncoding(String encoderIdentifier) {
+    return encoderIdentifier.startsWith("LAME")
+        || encoderIdentifier.startsWith("Lavf")
+        || encoderIdentifier.startsWith("Lavc");
   }
 
   /** Provide the metadata derived from this Xing frame, such as ReplayGain data. */

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/XingFrameTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/mp3/XingFrameTest.java
@@ -74,14 +74,61 @@ public final class XingFrameTest {
     assertThat(frame.computeDurationUs()).isEqualTo(C.TIME_UNSET);
   }
 
+  @Test
+  public void parse_withLameEncoderIdentifier_adjustsDelayAndPaddingForDecodedPcm() {
+    XingFrame frame =
+        createXingFrame(
+            INFO_FRAME_HEADER_DATA,
+            /* frameCount= */ 40,
+            /* dataSize= */ 8_541,
+            /* encoderDelay= */ 576,
+            /* encoderPadding= */ 1_404,
+            /* encoderIdentifier= */ "LAME3.99r");
+
+    assertThat(frame.encoderDelay).isEqualTo(1_105);
+    assertThat(frame.encoderPadding).isEqualTo(875);
+  }
+
+  @Test
+  public void parse_withLameEncoderIdentifierAndSmallPadding_clampsPaddingToZero() {
+    XingFrame frame =
+        createXingFrame(
+            INFO_FRAME_HEADER_DATA,
+            /* frameCount= */ 40,
+            /* dataSize= */ 8_541,
+            /* encoderDelay= */ 576,
+            /* encoderPadding= */ 398,
+            /* encoderIdentifier= */ "LAME3.99r");
+
+    assertThat(frame.encoderDelay).isEqualTo(1_105);
+    assertThat(frame.encoderPadding).isEqualTo(0);
+  }
+
   private static XingFrame createXingFrame(
       int headerData, int frameCount, int dataSize, int encoderDelay, int encoderPadding) {
+    return createXingFrame(
+        headerData,
+        frameCount,
+        dataSize,
+        encoderDelay,
+        encoderPadding,
+        /* encoderIdentifier= */ "");
+  }
+
+  private static XingFrame createXingFrame(
+      int headerData,
+      int frameCount,
+      int dataSize,
+      int encoderDelay,
+      int encoderPadding,
+      String encoderIdentifier) {
     int encoderDelayAndPadding = (encoderDelay << 12) | encoderPadding;
     ByteBuffer payload = ByteBuffer.allocate(4 + 4 + 4 + 11 + 8 + 2 + 3);
     payload.putInt(0x03);
     payload.putInt(frameCount);
     payload.putInt(dataSize);
-    payload.position(payload.position() + 11 + 8 + 2);
+    payload.put(createFixedLengthEncoderIdentifier(encoderIdentifier));
+    payload.position(payload.position() + 2 + 8 + 2);
     payload.put((byte) (encoderDelayAndPadding >> 16));
     payload.put((byte) (encoderDelayAndPadding >> 8));
     payload.put((byte) encoderDelayAndPadding);
@@ -92,5 +139,17 @@ public final class XingFrameTest {
     MpegAudioUtil.Header xingFrameHeader = new MpegAudioUtil.Header();
     xingFrameHeader.setForHeaderData(headerData);
     return XingFrame.parse(xingFrameHeader, new ParsableByteArray(payload));
+  }
+
+  private static byte[] createFixedLengthEncoderIdentifier(String encoderIdentifier) {
+    byte[] fixedLengthIdentifier = new byte[9];
+    byte[] identifierBytes = Util.getUtf8Bytes(encoderIdentifier);
+    System.arraycopy(
+        identifierBytes,
+        /* srcPos= */ 0,
+        fixedLengthIdentifier,
+        /* destPos= */ 0,
+        Math.min(identifierBytes.length, fixedLengthIdentifier.length));
+    return fixedLengthIdentifier;
   }
 }

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3-numeric-genre.mp3.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3-numeric-genre.mp3.0.dump
@@ -16,8 +16,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TIT2: description=null: values=[Test title], TPE1: description=null: values=[Test Artist], TALB: description=null: values=[Test Album], TXXX: description=Test description: values=[Test user info], COMM: language=eng, description=Test description, text=Test comment, WXXX: url=Test URL, TSSE: description=null: values=[Lavf58.29.100], MLLT, PRIV: owner=test@gmail.com, UNKN, GEOB: mimeType=test/mime, filename=Testfilename.txt, description=Test description, CHAP, CHAP, CTOC, APIC: mimeType=image/jpeg, description=Test description, TCON: description=null: values=[9]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3-numeric-genre.mp3.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3-numeric-genre.mp3.1.dump
@@ -16,8 +16,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TIT2: description=null: values=[Test title], TPE1: description=null: values=[Test Artist], TALB: description=null: values=[Test Album], TXXX: description=Test description: values=[Test user info], COMM: language=eng, description=Test description, text=Test comment, WXXX: url=Test URL, TSSE: description=null: values=[Lavf58.29.100], MLLT, PRIV: owner=test@gmail.com, UNKN, GEOB: mimeType=test/mime, filename=Testfilename.txt, description=Test description, CHAP, CHAP, CTOC, APIC: mimeType=image/jpeg, description=Test description, TCON: description=null: values=[9]]
   sample 0:
     time = 943000

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3-numeric-genre.mp3.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3-numeric-genre.mp3.2.dump
@@ -16,8 +16,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TIT2: description=null: values=[Test title], TPE1: description=null: values=[Test Artist], TALB: description=null: values=[Test Album], TXXX: description=Test description: values=[Test user info], COMM: language=eng, description=Test description, text=Test comment, WXXX: url=Test URL, TSSE: description=null: values=[Lavf58.29.100], MLLT, PRIV: owner=test@gmail.com, UNKN, GEOB: mimeType=test/mime, filename=Testfilename.txt, description=Test description, CHAP, CHAP, CTOC, APIC: mimeType=image/jpeg, description=Test description, TCON: description=null: values=[9]]
   sample 0:
     time = 1879000

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3-numeric-genre.mp3.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3-numeric-genre.mp3.3.dump
@@ -16,7 +16,7 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TIT2: description=null: values=[Test title], TPE1: description=null: values=[Test Artist], TALB: description=null: values=[Test Album], TXXX: description=Test description: values=[Test user info], COMM: language=eng, description=Test description, text=Test comment, WXXX: url=Test URL, TSSE: description=null: values=[Lavf58.29.100], MLLT, PRIV: owner=test@gmail.com, UNKN, GEOB: mimeType=test/mime, filename=Testfilename.txt, description=Test description, CHAP, CHAP, CTOC, APIC: mimeType=image/jpeg, description=Test description, TCON: description=null: values=[9]]
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3-numeric-genre.mp3.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3-numeric-genre.mp3.unknown_length.dump
@@ -16,8 +16,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TIT2: description=null: values=[Test title], TPE1: description=null: values=[Test Artist], TALB: description=null: values=[Test Album], TXXX: description=Test description: values=[Test user info], COMM: language=eng, description=Test description, text=Test comment, WXXX: url=Test URL, TSSE: description=null: values=[Lavf58.29.100], MLLT, PRIV: owner=test@gmail.com, UNKN, GEOB: mimeType=test/mime, filename=Testfilename.txt, description=Test description, CHAP, CHAP, CTOC, APIC: mimeType=image/jpeg, description=Test description, TCON: description=null: values=[9]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-disabled.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-disabled.0.dump
@@ -16,8 +16,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-disabled.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-disabled.1.dump
@@ -16,8 +16,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
   sample 0:
     time = 943000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-disabled.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-disabled.2.dump
@@ -16,8 +16,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
   sample 0:
     time = 1879000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-disabled.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-disabled.3.dump
@@ -16,6 +16,6 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-disabled.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-disabled.unknown_length.dump
@@ -16,8 +16,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-enabled.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-enabled.0.dump
@@ -16,8 +16,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TIT2: description=null: values=[Test title], TPE1: description=null: values=[Test Artist], TALB: description=null: values=[Test Album], TXXX: description=Test description: values=[Test user info], COMM: language=eng, description=Test description, text=Test comment, WXXX: url=Test URL, TSSE: description=null: values=[Lavf58.29.100], MLLT, PRIV: owner=test@gmail.com, UNKN, GEOB: mimeType=test/mime, filename=Testfilename.txt, description=Test description, CHAP, CHAP, CTOC, APIC: mimeType=image/jpeg, description=Test description, TCON: description=null: values=[Gorpcore]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-enabled.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-enabled.1.dump
@@ -16,8 +16,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TIT2: description=null: values=[Test title], TPE1: description=null: values=[Test Artist], TALB: description=null: values=[Test Album], TXXX: description=Test description: values=[Test user info], COMM: language=eng, description=Test description, text=Test comment, WXXX: url=Test URL, TSSE: description=null: values=[Lavf58.29.100], MLLT, PRIV: owner=test@gmail.com, UNKN, GEOB: mimeType=test/mime, filename=Testfilename.txt, description=Test description, CHAP, CHAP, CTOC, APIC: mimeType=image/jpeg, description=Test description, TCON: description=null: values=[Gorpcore]]
   sample 0:
     time = 943000

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-enabled.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-enabled.2.dump
@@ -16,8 +16,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TIT2: description=null: values=[Test title], TPE1: description=null: values=[Test Artist], TALB: description=null: values=[Test Album], TXXX: description=Test description: values=[Test user info], COMM: language=eng, description=Test description, text=Test comment, WXXX: url=Test URL, TSSE: description=null: values=[Lavf58.29.100], MLLT, PRIV: owner=test@gmail.com, UNKN, GEOB: mimeType=test/mime, filename=Testfilename.txt, description=Test description, CHAP, CHAP, CTOC, APIC: mimeType=image/jpeg, description=Test description, TCON: description=null: values=[Gorpcore]]
   sample 0:
     time = 1879000

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-enabled.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-enabled.3.dump
@@ -16,7 +16,7 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TIT2: description=null: values=[Test title], TPE1: description=null: values=[Test Artist], TALB: description=null: values=[Test Album], TXXX: description=Test description: values=[Test user info], COMM: language=eng, description=Test description, text=Test comment, WXXX: url=Test URL, TSSE: description=null: values=[Lavf58.29.100], MLLT, PRIV: owner=test@gmail.com, UNKN, GEOB: mimeType=test/mime, filename=Testfilename.txt, description=Test description, CHAP, CHAP, CTOC, APIC: mimeType=image/jpeg, description=Test description, TCON: description=null: values=[Gorpcore]]
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-enabled.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-id3.mp3.id3-enabled.unknown_length.dump
@@ -16,8 +16,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TIT2: description=null: values=[Test title], TPE1: description=null: values=[Test Artist], TALB: description=null: values=[Test Album], TXXX: description=Test description: values=[Test user info], COMM: language=eng, description=Test description, text=Test comment, WXXX: url=Test URL, TSSE: description=null: values=[Lavf58.29.100], MLLT, PRIV: owner=test@gmail.com, UNKN, GEOB: mimeType=test/mime, filename=Testfilename.txt, description=Test description, CHAP, CHAP, CTOC, APIC: mimeType=image/jpeg, description=Test description, TCON: description=null: values=[Gorpcore]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.0.dump
@@ -14,8 +14,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.0.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.1.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 934996

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.2.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 1862989

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.3.dump
@@ -17,7 +17,7 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking-always.unknown_length.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.0.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.1.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 934996

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.2.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 1862989

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.3.dump
@@ -17,7 +17,7 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.cbr-seeking.unknown_length.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.0.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.1.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 840000

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.2.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 1800000

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.3.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 2760000

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.index-seeking.unknown_length.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-no-toc.mp3.unknown_length.dump
@@ -14,8 +14,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.0.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=8.14048E-40, field 1=GainField{name=1, originator=3, gain=23.3}, field 2=null]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.1.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=8.14048E-40, field 1=GainField{name=1, originator=3, gain=23.3}, field 2=null]
   sample 0:
     time = 904201

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.2.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=8.14048E-40, field 1=GainField{name=1, originator=3, gain=23.3}, field 2=null]
   sample 0:
     time = 1832197

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.3.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=8.14048E-40, field 1=GainField{name=1, originator=3, gain=23.3}, field 2=null]
   sample 0:
     time = 2760193

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-accurate.mp3.unknown_length.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=8.14048E-40, field 1=GainField{name=1, originator=3, gain=23.3}, field 2=null]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.0.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=0.0, field 1=GainField{name=1, originator=3, gain=23.0}, field 2=null]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.1.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=0.0, field 1=GainField{name=1, originator=3, gain=23.0}, field 2=null]
   sample 0:
     time = 904201

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.2.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=0.0, field 1=GainField{name=1, originator=3, gain=23.0}, field 2=null]
   sample 0:
     time = 1832197

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.3.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=0.0, field 1=GainField{name=1, originator=3, gain=23.0}, field 2=null]
   sample 0:
     time = 2760193

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header-replaygain-fast.mp3.unknown_length.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100], ReplayGain Xing/Info: peak=0.0, field 1=GainField{name=1, originator=3, gain=23.0}, field 2=null]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.0.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.1.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 949845

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.2.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 1870631

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.3.dump
@@ -17,7 +17,7 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/bear-vbr-xing-header.mp3.unknown_length.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 2
     sampleRate = 48000
-    encoderDelay = 576
-    encoderPadding = 576
+    encoderDelay = 1105
+    encoderPadding = 47
     metadata = entries=[TSSE: description=null: values=[Lavf58.29.100]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.0.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 1
     sampleRate = 44100
-    encoderDelay = 576
-    encoderPadding = 1404
+    encoderDelay = 1105
+    encoderPadding = 875
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.1.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 1
     sampleRate = 44100
-    encoderDelay = 576
-    encoderPadding = 1404
+    encoderDelay = 1105
+    encoderPadding = 875
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
     time = 341911

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.2.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 1
     sampleRate = 44100
-    encoderDelay = 576
-    encoderPadding = 1404
+    encoderDelay = 1105
+    encoderPadding = 875
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
     time = 696674

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.3.dump
@@ -17,7 +17,7 @@ track 0:
     maxInputSize = 4096
     channelCount = 1
     sampleRate = 44100
-    encoderDelay = 576
-    encoderPadding = 1404
+    encoderDelay = 1105
+    encoderPadding = 875
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header-pcut-frame.mp3.unknown_length.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 1
     sampleRate = 44100
-    encoderDelay = 576
-    encoderPadding = 1404
+    encoderDelay = 1105
+    encoderPadding = 875
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.0.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 1
     sampleRate = 44100
-    encoderDelay = 576
-    encoderPadding = 1404
+    encoderDelay = 1105
+    encoderPadding = 875
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
     time = 0

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.1.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 1
     sampleRate = 44100
-    encoderDelay = 576
-    encoderPadding = 1404
+    encoderDelay = 1105
+    encoderPadding = 875
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
     time = 349911

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.2.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 1
     sampleRate = 44100
-    encoderDelay = 576
-    encoderPadding = 1404
+    encoderDelay = 1105
+    encoderPadding = 875
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
     time = 674940

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.3.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 1
     sampleRate = 44100
-    encoderDelay = 576
-    encoderPadding = 1404
+    encoderDelay = 1105
+    encoderPadding = 875
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
     time = 974967

--- a/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp3/test-cbr-info-header.mp3.unknown_length.dump
@@ -17,8 +17,8 @@ track 0:
     maxInputSize = 4096
     channelCount = 1
     sampleRate = 44100
-    encoderDelay = 576
-    encoderPadding = 1404
+    encoderDelay = 1105
+    encoderPadding = 875
     metadata = entries=[TSSE: description=null: values=[Lavf58.45.100]]
   sample 0:
     time = 0


### PR DESCRIPTION
LAME/Xing encoder delay and padding fields are offset from the skip/discard samples used when trimming decoded PCM. Account for this offset for LAME, Lavf, and Lavc headers when parsing gapless metadata.

This matches the decoded PCM trimming expectations used by FFmpeg and updates extractor dumps and the gapless end-to-end assertion accordingly.

Test: ./gradlew :lib-extractor:testDebugUnitTest --tests androidx.media3.extractor.mp3.ConstantBitrateSeekerTest --tests androidx.media3.extractor.mp3.Mp3ExtractorTest --tests androidx.media3.extractor.mp3.XingFrameTest

Test: ./gradlew :lib-exoplayer:testDebugUnitTest --tests androidx.media3.exoplayer.e2etest.EndToEndGaplessTest