### PR TITLE
Read the ID3v2.3 TPOS frame

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -111,6 +111,7 @@
 *   Metadata:
     *   Add `MediaMetadata.discSubtitle` field and parse it from ID3v2.4 `TSST`
         and Vorbis `DISCSUBTITLE` data.
+    * Parse disc number & count from ID3 `TPOS` frame.
 *   Image:
 *   DataSource:
 *   DRM:

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/TextInformationFrame.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/TextInformationFrame.java
@@ -181,6 +181,18 @@ public final class TextInformationFrame extends Id3Frame {
       case "TSST":
         builder.setDiscSubtitle(values.get(0));
         break;
+      case "TPOS":
+        String[] discNumbers = Util.split(values.get(0), "/");
+        try {
+          int discNumber = Integer.parseInt(discNumbers[0]);
+          @Nullable
+          Integer totalDiscCount =
+              discNumbers.length > 1 ? Integer.parseInt(discNumbers[1]) : null;
+          builder.setDiscNumber(discNumber).setTotalDiscCount(totalDiscCount);
+        } catch (NumberFormatException e) {
+          // Do nothing, invalid input.
+        }
+        break;
       default:
         break;
     }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/TextInformationFrame.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/metadata/id3/TextInformationFrame.java
@@ -186,8 +186,7 @@ public final class TextInformationFrame extends Id3Frame {
         try {
           int discNumber = Integer.parseInt(discNumbers[0]);
           @Nullable
-          Integer totalDiscCount =
-              discNumbers.length > 1 ? Integer.parseInt(discNumbers[1]) : null;
+          Integer totalDiscCount = discNumbers.length > 1 ? Integer.parseInt(discNumbers[1]) : null;
           builder.setDiscNumber(discNumber).setTotalDiscCount(totalDiscCount);
         } catch (NumberFormatException e) {
           // Do nothing, invalid input.

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/id3/TextInformationFrameTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/id3/TextInformationFrameTest.java
@@ -89,7 +89,9 @@ public class TextInformationFrameTest {
                 /* description= */ null,
                 /* values= */ ImmutableList.of(discSubtitle)),
             new TextInformationFrame(
-                /* id= */ "TPOS", /* description= */ null, /* values= */ ImmutableList.of(discNumber)));
+                /* id= */ "TPOS",
+                /* description= */ null,
+                /* values= */ ImmutableList.of(discNumber)));
     MediaMetadata.Builder builder = MediaMetadata.EMPTY.buildUpon();
 
     for (Metadata.Entry entry : entries) {

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/id3/TextInformationFrameTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/metadata/id3/TextInformationFrameTest.java
@@ -44,6 +44,7 @@ public class TextInformationFrameTest {
     String conductor = "conductor";
     String writer = "writer";
     String discSubtitle = "disc subtitle";
+    String discNumber = "3/4";
 
     List<Metadata.Entry> entries =
         ImmutableList.of(
@@ -86,7 +87,9 @@ public class TextInformationFrameTest {
             new TextInformationFrame(
                 /* id= */ "TSST",
                 /* description= */ null,
-                /* values= */ ImmutableList.of(discSubtitle)));
+                /* values= */ ImmutableList.of(discSubtitle)),
+            new TextInformationFrame(
+                /* id= */ "TPOS", /* description= */ null, /* values= */ ImmutableList.of(discNumber)));
     MediaMetadata.Builder builder = MediaMetadata.EMPTY.buildUpon();
 
     for (Metadata.Entry entry : entries) {
@@ -111,6 +114,8 @@ public class TextInformationFrameTest {
     assertThat(mediaMetadata.conductor.toString()).isEqualTo(conductor);
     assertThat(mediaMetadata.writer.toString()).isEqualTo(writer);
     assertThat(mediaMetadata.discSubtitle.toString()).isEqualTo(discSubtitle);
+    assertThat(mediaMetadata.discNumber).isEqualTo(3);
+    assertThat(mediaMetadata.totalDiscCount).isEqualTo(4);
   }
 
   @Test

--- a/libraries/test_data/src/test/assets/playbackdumps/mp4/sample_with_metadata.mp4.dump
+++ b/libraries/test_data/src/test/assets/playbackdumps/mp4/sample_with_metadata.mp4.dump
@@ -689,4 +689,6 @@ Listener.onMediaMetadata:
     trackNumber = 2
     totalTrackCount = 12
     recordingYear = 2024
+    discNumber = 2
+    totalDiscCount = 3
     genre = Gorpcore


### PR DESCRIPTION
Split off from https://github.com/androidx/media/pull/3193.

The [`TPOS` frame][1] can be either a number, or two numbers separated with a '/' similar to how track numbers in the `TRCK` frame:

> The 'Part of a set' frame is a numeric string that describes which
> part of a set the audio came from. This frame is used if the source
> described in the "TALB" frame is divided into several mediums, e.g. a
> double CD. The value may be extended with a "/" character and a
> numeric string containing the total number of parts in the set. E.g.
> "1/2".

[1]: https://id3.org/d3v2.3.0