### PR TITLE
Fix issue where end of stream wasn't signaled if last pes had length field set

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -80,6 +80,9 @@
     *   MP4: Prevent infinite loops and out-of-bounds reads when parsing empty
         `ilst` metadata tag items
         ([#3191](https://github.com/androidx/media/pull/3191)).
+    *   MPEG-TS: Ensure the last frame is rendered for streams where the last
+        PES packet has a known length
+        ([#3206](https://github.com/androidx/media/pull/3206)).
 *   Inspector:
 *   Audio:
     *   Update `MediaCodecAudioRenderer` to extract the spatial channelMask from

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/Ac3Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/Ac3Reader.java
@@ -167,11 +167,6 @@ public final class Ac3Reader implements ElementaryStreamReader {
     }
   }
 
-  @Override
-  public void packetFinished(boolean isEndOfInput) {
-    // Do nothing.
-  }
-
   /**
    * Continues a read from the provided {@code source} into a given {@code target}. It's assumed
    * that the data should be written into {@code target} starting from an offset of zero.

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/Ac4Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/Ac4Reader.java
@@ -169,11 +169,6 @@ public final class Ac4Reader implements ElementaryStreamReader {
     }
   }
 
-  @Override
-  public void packetFinished(boolean isEndOfInput) {
-    // Do nothing.
-  }
-
   /**
    * Continues a read from the provided {@code source} into a given {@code target}. It's assumed
    * that the data should be written into {@code target} starting from an offset of zero.

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/AdtsReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/AdtsReader.java
@@ -202,11 +202,6 @@ public final class AdtsReader implements ElementaryStreamReader {
     }
   }
 
-  @Override
-  public void packetFinished(boolean isEndOfInput) {
-    // Do nothing.
-  }
-
   /**
    * Returns the duration in microseconds per sample, or {@link C#TIME_UNSET} if the sample duration
    * is not available.

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/DtsReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/DtsReader.java
@@ -293,7 +293,7 @@ public final class DtsReader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished(boolean isEndOfInput) {
+  public void packetFinished() {
     if (state == STATE_CHECKING_FOR_EXTSS_AFTER_CORE) {
       checkNotNull(output);
       if (coreFormatPendingEmit) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/DvbSubtitleReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/DvbSubtitleReader.java
@@ -90,7 +90,7 @@ public final class DvbSubtitleReader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished(boolean isEndOfInput) {
+  public void packetFinished() {
     if (writingSample) {
       // packetStarted method must be called before reading sample.
       checkState(sampleTimeUs != C.TIME_UNSET);

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/ElementaryStreamReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/ElementaryStreamReader.java
@@ -67,5 +67,14 @@ public interface ElementaryStreamReader {
   void consume(ParsableByteArray data) throws ParserException;
 
   /** Called when a packet ends. */
-  void packetFinished(boolean isEndOfInput);
+  default void packetFinished() {
+    // Do nothing.
+  }
+
+  /**
+   * Called when there will be no further packets (unless a seek occurs) because the stream ended.
+   */
+  default void endOfInputReached() {
+    // Do nothing.
+  }
 }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/ElementaryStreamReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/ElementaryStreamReader.java
@@ -31,8 +31,9 @@ import androidx.media3.extractor.TrackOutput;
  *   <li>{@link #seek()} (optional, to reset the state)
  *   <li>{@link #packetStarted(long, int)} (to signal the start of a new packet)
  *   <li>{@link #consume(ParsableByteArray)} (zero or more times, to provide packet data)
- *   <li>{@link #packetFinished(boolean)} (to signal the end of the current packet)
+ *   <li>{@link #packetFinished()} (to signal the end of the current PES packet)
  *   <li>Repeat steps 3-5 for subsequent packets
+ *   <li>{@link #endOfInputReached()} (called when there are no more packets)
  * </ol>
  */
 @UnstableApi
@@ -66,7 +67,10 @@ public interface ElementaryStreamReader {
    */
   void consume(ParsableByteArray data) throws ParserException;
 
-  /** Called when a packet ends. */
+  /**
+   * Called when a PES packet ends. For PES packets with an unset length, this is called when the
+   * next packet starts or the stream ends.
+   */
   default void packetFinished() {
     // Do nothing.
   }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H262Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H262Reader.java
@@ -220,10 +220,14 @@ public final class H262Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished(boolean isEndOfInput) {
+  public void packetFinished() {
     // Asserts that createTracks has been called.
     checkNotNull(output);
-    if (isEndOfInput) {
+  }
+
+  @Override
+  public void endOfInputReached() {
+    if (sampleTimeUs != C.TIME_UNSET) {
       @C.BufferFlags int flags = sampleIsKeyframe ? C.BUFFER_FLAG_KEY_FRAME : 0;
       int size = (int) (totalBytesWritten - samplePosition);
       output.sampleMetadata(sampleTimeUs, flags, size, /* offset= */ 0, /* cryptoData= */ null);

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H262Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H262Reader.java
@@ -220,13 +220,9 @@ public final class H262Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
+  public void endOfInputReached() {
     // Asserts that createTracks has been called.
     checkNotNull(output);
-  }
-
-  @Override
-  public void endOfInputReached() {
     if (sampleTimeUs != C.TIME_UNSET) {
       @C.BufferFlags int flags = sampleIsKeyframe ? C.BUFFER_FLAG_KEY_FRAME : 0;
       int size = (int) (totalBytesWritten - samplePosition);

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H263Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H263Reader.java
@@ -221,13 +221,15 @@ public final class H263Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished(boolean isEndOfInput) {
+  public void packetFinished() {
     // Assert that createTracks has been called.
     checkNotNull(sampleReader);
-    if (isEndOfInput) {
-      sampleReader.onDataEnd(totalBytesWritten, /* bytesWrittenPastPosition= */ 0, hasOutputFormat);
-      sampleReader.reset();
-    }
+  }
+
+  @Override
+  public void endOfInputReached() {
+    sampleReader.onDataEnd(totalBytesWritten, /* bytesWrittenPastPosition= */ 0, hasOutputFormat);
+    sampleReader.reset();
   }
 
   /**

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H263Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H263Reader.java
@@ -221,13 +221,9 @@ public final class H263Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
+  public void endOfInputReached() {
     // Assert that createTracks has been called.
     checkNotNull(sampleReader);
-  }
-
-  @Override
-  public void endOfInputReached() {
     sampleReader.onDataEnd(totalBytesWritten, /* bytesWrittenPastPosition= */ 0, hasOutputFormat);
     sampleReader.reset();
   }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
@@ -183,15 +183,17 @@ public final class H264Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished(boolean isEndOfInput) {
+  public void packetFinished() {
     assertTracksCreated();
-    if (isEndOfInput) {
-      seiReader.flush();
-      // Simulate end of current NAL unit and start an AUD one to trigger output of current sample
-      endNalUnit(totalBytesWritten, 0, 0, pesTimeUs);
-      startNalUnit(totalBytesWritten, NalUnitUtil.H264_NAL_UNIT_TYPE_AUD, pesTimeUs);
-      endNalUnit(totalBytesWritten, 0, 0, pesTimeUs);
-    }
+  }
+
+  @Override
+  public void endOfInputReached() {
+    seiReader.flush();
+    // Simulate end of current NAL unit and start an AUD one to trigger output of current sample
+    endNalUnit(totalBytesWritten, 0, 0, pesTimeUs);
+    startNalUnit(totalBytesWritten, NalUnitUtil.H264_NAL_UNIT_TYPE_AUD, pesTimeUs);
+    endNalUnit(totalBytesWritten, 0, 0, pesTimeUs);
   }
 
   @RequiresNonNull("sampleReader")

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H264Reader.java
@@ -183,12 +183,8 @@ public final class H264Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
-    assertTracksCreated();
-  }
-
-  @Override
   public void endOfInputReached() {
+    assertTracksCreated();
     seiReader.flush();
     // Simulate end of current NAL unit and start an AUD one to trigger output of current sample
     endNalUnit(totalBytesWritten, 0, 0, pesTimeUs);

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
@@ -173,15 +173,17 @@ public final class H265Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished(boolean isEndOfInput) {
+  public void packetFinished() {
     assertTracksCreated();
-    if (isEndOfInput) {
-      seiReader.flush();
-      // Simulate end of current NAL unit and start an unspecified one to trigger output of current
-      // sample
-      endNalUnit(totalBytesWritten, 0, 0, pesTimeUs);
-      startNalUnit(totalBytesWritten, 0, NalUnitUtil.H265_NAL_UNIT_TYPE_UNSPECIFIED, pesTimeUs);
-    }
+  }
+
+  @Override
+  public void endOfInputReached() {
+    seiReader.flush();
+    // Simulate end of current NAL unit and start an unspecified one to trigger output of current
+    // sample
+    endNalUnit(totalBytesWritten, 0, 0, pesTimeUs);
+    startNalUnit(totalBytesWritten, 0, NalUnitUtil.H265_NAL_UNIT_TYPE_UNSPECIFIED, pesTimeUs);
   }
 
   @RequiresNonNull("sampleReader")

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/H265Reader.java
@@ -173,12 +173,8 @@ public final class H265Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished() {
-    assertTracksCreated();
-  }
-
-  @Override
   public void endOfInputReached() {
+    assertTracksCreated();
     seiReader.flush();
     // Simulate end of current NAL unit and start an unspecified one to trigger output of current
     // sample

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/Id3Reader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/Id3Reader.java
@@ -124,7 +124,7 @@ public final class Id3Reader implements ElementaryStreamReader {
   }
 
   @Override
-  public void packetFinished(boolean isEndOfInput) {
+  public void packetFinished() {
     // Asserts that createTracks has been called.
     checkNotNull(output);
     if (!writingSample || sampleSize == 0 || sampleBytesRead != sampleSize) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/LatmReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/LatmReader.java
@@ -157,11 +157,6 @@ public final class LatmReader implements ElementaryStreamReader {
     }
   }
 
-  @Override
-  public void packetFinished(boolean isEndOfInput) {
-    // Do nothing.
-  }
-
   /**
    * Parses an AudioMuxElement as defined in 14496-3:2009, Section 1.7.3.1, Table 1.41.
    *

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/MpegAudioReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/MpegAudioReader.java
@@ -122,11 +122,6 @@ public final class MpegAudioReader implements ElementaryStreamReader {
     }
   }
 
-  @Override
-  public void packetFinished(boolean isEndOfInput) {
-    // Do nothing.
-  }
-
   /**
    * Attempts to locate the start of the next frame header.
    *

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/MpeghReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/MpeghReader.java
@@ -220,11 +220,6 @@ public final class MpeghReader implements ElementaryStreamReader {
     }
   }
 
-  @Override
-  public void packetFinished(boolean isEndOfInput) {
-    // Do nothing.
-  }
-
   /**
    * Copies data from the provided {@code source} into a given {@code target}, attempting to fill
    * the target buffer up to its limit.

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PesReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PesReader.java
@@ -108,11 +108,13 @@ public final class PesReader implements TsPayloadReader {
             Log.w(TAG, "Unexpected start indicator: expected " + payloadSize + " more bytes");
           }
           // Either way, notify the reader that it has now finished.
-          boolean isEndOfInput = (data.limit() == 0);
-          reader.packetFinished(isEndOfInput);
+          reader.packetFinished();
           break;
         default:
           throw new IllegalStateException();
+      }
+      if (data.limit() == 0) {
+        reader.endOfInputReached();
       }
       setState(STATE_READING_HEADER);
     }
@@ -149,8 +151,7 @@ public final class PesReader implements TsPayloadReader {
           if (payloadSize != C.LENGTH_UNSET) {
             payloadSize -= readLength;
             if (payloadSize == 0) {
-              // There are bytes left in data, see above, so this is not the end of input
-              reader.packetFinished(/* isEndOfInput= */ false);
+              reader.packetFinished();
               setState(STATE_READING_HEADER);
             }
           }
@@ -168,16 +169,17 @@ public final class PesReader implements TsPayloadReader {
    *     otherwise.
    */
   public boolean canConsumeSynthesizedEmptyPusi(boolean isModeHls) {
-    // Pusi only payload to trigger end of sample data is only applicable if
-    // pes does not have a length field and body is being read, another exclusion
-    // is due to H262 streams possibly having, in HLS mode, a pes across more than one segment
-    // which would trigger committing an unfinished sample in the middle of the access unit
-
     // Only call parseHeader if isModeHls is true and can parse header as some HLS streams may
     // contain packages.
     boolean headerParsed = !isModeHls || parseHeader();
-    return state == STATE_READING_BODY
-        && payloadSize == C.LENGTH_UNSET
+    // Either pes does not have length field and body is being read, where end of stream also
+    // signals end of body, or we are waiting for next pes to start and end of stream means there
+    // won't be any more
+    return ((state == STATE_READING_BODY && payloadSize == C.LENGTH_UNSET)
+            || (state == STATE_READING_HEADER))
+        // Pusi only payload to trigger end of sample data is not applicable for H262 streams
+        // possibly having, in HLS mode, a pes across more than one segment which would trigger
+        // committing an unfinished sample in the middle of the access unit
         && !(isModeHls && reader instanceof H262Reader)
         && headerParsed;
   }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PesReader.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PesReader.java
@@ -172,14 +172,15 @@ public final class PesReader implements TsPayloadReader {
     // Only call parseHeader if isModeHls is true and can parse header as some HLS streams may
     // contain packages.
     boolean headerParsed = !isModeHls || parseHeader();
-    // Either pes does not have length field and body is being read, where end of stream also
-    // signals end of body, or we are waiting for next pes to start and end of stream means there
-    // won't be any more
+    // Either the PES packet does not have a length field and the body is being read (where the end
+    // of the stream also signals the end of the body), or we are waiting for the next PES packet to
+    // start and the end of the stream means there won't be any more data.
     return ((state == STATE_READING_BODY && payloadSize == C.LENGTH_UNSET)
             || (state == STATE_READING_HEADER))
-        // Pusi only payload to trigger end of sample data is not applicable for H262 streams
-        // possibly having, in HLS mode, a pes across more than one segment which would trigger
-        // committing an unfinished sample in the middle of the access unit
+        // An empty PES packet with only the PUSI (Payload Unit Start Indicator) flag set, used to
+        // trigger the end of the sample data, is not applicable for H262 streams. These streams
+        // may, in HLS mode, have a PES packet spanning across more than one segment, which would
+        // incorrectly trigger committing an unfinished sample in the middle of the access unit.
         && !(isModeHls && reader instanceof H262Reader)
         && headerParsed;
   }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PsExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PsExtractor.java
@@ -191,25 +191,19 @@ public final class PsExtractor implements Extractor {
     long peekBytesLeft =
         inputLength != C.LENGTH_UNSET ? inputLength - input.getPeekPosition() : C.LENGTH_UNSET;
     if (peekBytesLeft != C.LENGTH_UNSET && peekBytesLeft < 4) {
-      for (int i = 0; i < psPayloadReaders.size(); i++) {
-        psPayloadReaders.valueAt(i).consumeEndOfInput();
-      }
+      onEndOfInput();
       return RESULT_END_OF_INPUT;
     }
     // First peek and check what type of start code is next.
     if (!input.peekFully(psPacketBuffer.getData(), 0, 4, true)) {
-      for (int i = 0; i < psPayloadReaders.size(); i++) {
-        psPayloadReaders.valueAt(i).consumeEndOfInput();
-      }
+      onEndOfInput();
       return RESULT_END_OF_INPUT;
     }
 
     psPacketBuffer.setPosition(0);
     int nextStartCode = psPacketBuffer.readInt();
     if (nextStartCode == MPEG_PROGRAM_END_CODE) {
-      for (int i = 0; i < psPayloadReaders.size(); i++) {
-        psPayloadReaders.valueAt(i).consumeEndOfInput();
-      }
+      onEndOfInput();
       return RESULT_END_OF_INPUT;
     } else if (nextStartCode == PACK_START_CODE) {
       // Now peek the rest of the pack_header.
@@ -303,6 +297,12 @@ public final class PsExtractor implements Extractor {
 
   // Internals.
 
+  private void onEndOfInput() {
+    for (int i = 0; i < psPayloadReaders.size(); i++) {
+      psPayloadReaders.valueAt(i).consumeEndOfInput();
+    }
+  }
+
   @RequiresNonNull("output")
   private void maybeOutputSeekMap(long inputLength) {
     if (!hasOutputSeekMap) {
@@ -372,7 +372,7 @@ public final class PsExtractor implements Extractor {
       pesPayloadReader.packetFinished();
     }
 
-    public void consumeEndOfInput() {
+    private void consumeEndOfInput() {
       pesPayloadReader.endOfInputReached();
     }
 

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PsExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ts/PsExtractor.java
@@ -191,16 +191,25 @@ public final class PsExtractor implements Extractor {
     long peekBytesLeft =
         inputLength != C.LENGTH_UNSET ? inputLength - input.getPeekPosition() : C.LENGTH_UNSET;
     if (peekBytesLeft != C.LENGTH_UNSET && peekBytesLeft < 4) {
+      for (int i = 0; i < psPayloadReaders.size(); i++) {
+        psPayloadReaders.valueAt(i).consumeEndOfInput();
+      }
       return RESULT_END_OF_INPUT;
     }
     // First peek and check what type of start code is next.
     if (!input.peekFully(psPacketBuffer.getData(), 0, 4, true)) {
+      for (int i = 0; i < psPayloadReaders.size(); i++) {
+        psPayloadReaders.valueAt(i).consumeEndOfInput();
+      }
       return RESULT_END_OF_INPUT;
     }
 
     psPacketBuffer.setPosition(0);
     int nextStartCode = psPacketBuffer.readInt();
     if (nextStartCode == MPEG_PROGRAM_END_CODE) {
+      for (int i = 0; i < psPayloadReaders.size(); i++) {
+        psPayloadReaders.valueAt(i).consumeEndOfInput();
+      }
       return RESULT_END_OF_INPUT;
     } else if (nextStartCode == PACK_START_CODE) {
       // Now peek the rest of the pack_header.
@@ -360,7 +369,11 @@ public final class PsExtractor implements Extractor {
       pesPayloadReader.packetStarted(timeUs, TsPayloadReader.FLAG_DATA_ALIGNMENT_INDICATOR);
       pesPayloadReader.consume(data);
       // We always have complete PES packets with program stream.
-      pesPayloadReader.packetFinished(/* isEndOfInput= */ false);
+      pesPayloadReader.packetFinished();
+    }
+
+    public void consumeEndOfInput() {
+      pesPayloadReader.endOfInputReached();
     }
 
     private void parseHeader() {

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/ts/TsExtractorTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/ts/TsExtractorTest.java
@@ -559,7 +559,7 @@ public final class TsExtractorTest {
     public void consume(ParsableByteArray data) {}
 
     @Override
-    public void packetFinished(boolean isEndOfInput) {
+    public void packetFinished() {
       packetsRead++;
     }
 

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ps.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ps.0.dump
@@ -34,7 +34,7 @@ track 192:
     data = length 418, hash 79CF71F8
 track 224:
   total output bytes = 44056
-  sample count = 2
+  sample count = 3
   format 0:
     id = 224
     containerMimeType = video/mp2p
@@ -51,4 +51,8 @@ track 224:
     time = 80000
     flags = 0
     data = length 17831, hash 5C5A57F5
+  sample 2:
+    time = 120000
+    flags = 0
+    data = length 5579, hash 72A6C31F
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ps.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ps.1.dump
@@ -18,7 +18,7 @@ track 192:
     sampleRate = 44100
 track 224:
   total output bytes = 33949
-  sample count = 1
+  sample count = 2
   format 0:
     id = 224
     containerMimeType = video/mp2p
@@ -31,4 +31,8 @@ track 224:
     time = 80000
     flags = 0
     data = length 17831, hash 5C5A57F5
+  sample 1:
+    time = 120000
+    flags = 0
+    data = length 5579, hash 72A6C31F
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ps.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ps.2.dump
@@ -18,7 +18,7 @@ track 192:
     sampleRate = 44100
 track 224:
   total output bytes = 19791
-  sample count = 0
+  sample count = 1
   format 0:
     id = 224
     containerMimeType = video/mp2p
@@ -27,4 +27,8 @@ track 224:
     height = 426
     initializationData:
       data = length 22, hash 743CC6F8
+  sample 0:
+    time = 120000
+    flags = 0
+    data = length 5579, hash 72A6C31F
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ps.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ps.unknown_length.dump
@@ -31,7 +31,7 @@ track 192:
     data = length 418, hash 79CF71F8
 track 224:
   total output bytes = 44056
-  sample count = 2
+  sample count = 3
   format 0:
     id = 224
     containerMimeType = video/mp2p
@@ -48,4 +48,8 @@ track 224:
     time = 80000
     flags = 0
     data = length 17831, hash 5C5A57F5
+  sample 2:
+    time = 120000
+    flags = 0
+    data = length 5579, hash 72A6C31F
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ts.0.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 45026
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     containerMimeType = video/mp2t
@@ -25,6 +25,10 @@ track 256:
     time = 66733
     flags = 0
     data = length 18112, hash EC44B35B
+  sample 2:
+    time = 100100
+    flags = 0
+    data = length 6203, hash 6D666BC7
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ts.1.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 45026
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     containerMimeType = video/mp2t
@@ -25,6 +25,10 @@ track 256:
     time = 66733
     flags = 0
     data = length 18112, hash EC44B35B
+  sample 2:
+    time = 100100
+    flags = 0
+    data = length 6203, hash 6D666BC7
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ts.2.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 45026
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     containerMimeType = video/mp2t
@@ -25,6 +25,10 @@ track 256:
     time = 66733
     flags = 0
     data = length 18112, hash EC44B35B
+  sample 2:
+    time = 100100
+    flags = 0
+    data = length 6203, hash 6D666BC7
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_h262_mpeg_audio.ts.unknown_length.dump
@@ -5,7 +5,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 45026
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     containerMimeType = video/mp2t
@@ -22,6 +22,10 @@ track 256:
     time = 66733
     flags = 0
     data = length 18112, hash EC44B35B
+  sample 2:
+    time = 100100
+    flags = 0
+    data = length 6203, hash 6D666BC7
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_scte35.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_scte35.ts.0.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 3
 track 256:
   total output bytes = 45026
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     containerMimeType = video/mp2t
@@ -25,6 +25,10 @@ track 256:
     time = 66733
     flags = 0
     data = length 18112, hash EC44B35B
+  sample 2:
+    time = 100100
+    flags = 0
+    data = length 6203, hash 6D666BC7
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_scte35.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_scte35.ts.1.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 3
 track 256:
   total output bytes = 45026
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     containerMimeType = video/mp2t
@@ -25,6 +25,10 @@ track 256:
     time = 66733
     flags = 0
     data = length 18112, hash EC44B35B
+  sample 2:
+    time = 100100
+    flags = 0
+    data = length 6203, hash 6D666BC7
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_scte35.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_scte35.ts.2.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 3
 track 256:
   total output bytes = 45026
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     containerMimeType = video/mp2t
@@ -25,6 +25,10 @@ track 256:
     time = 66733
     flags = 0
     data = length 18112, hash EC44B35B
+  sample 2:
+    time = 100100
+    flags = 0
+    data = length 6203, hash 6D666BC7
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_scte35.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_scte35.ts.unknown_length.dump
@@ -5,7 +5,7 @@ seekMap:
 numberOfTracks = 3
 track 256:
   total output bytes = 45026
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     containerMimeType = video/mp2t
@@ -22,6 +22,10 @@ track 256:
     time = 66733
     flags = 0
     data = length 18112, hash EC44B35B
+  sample 2:
+    time = 100100
+    flags = 0
+    data = length 6203, hash 6D666BC7
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_with_junk.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_with_junk.0.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 45026
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     containerMimeType = video/mp2t
@@ -25,6 +25,10 @@ track 256:
     time = 66733
     flags = 0
     data = length 18112, hash EC44B35B
+  sample 2:
+    time = 100100
+    flags = 0
+    data = length 6203, hash 6D666BC7
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_with_junk.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_with_junk.1.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 45026
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     containerMimeType = video/mp2t
@@ -25,6 +25,10 @@ track 256:
     time = 66733
     flags = 0
     data = length 18112, hash EC44B35B
+  sample 2:
+    time = 100100
+    flags = 0
+    data = length 6203, hash 6D666BC7
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_with_junk.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_with_junk.2.dump
@@ -8,7 +8,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 45026
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     containerMimeType = video/mp2t
@@ -25,6 +25,10 @@ track 256:
     time = 66733
     flags = 0
     data = length 18112, hash EC44B35B
+  sample 2:
+    time = 100100
+    flags = 0
+    data = length 6203, hash 6D666BC7
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_with_junk.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_with_junk.unknown_length.dump
@@ -5,7 +5,7 @@ seekMap:
 numberOfTracks = 2
 track 256:
   total output bytes = 45026
-  sample count = 2
+  sample count = 3
   format 0:
     id = 1/256
     containerMimeType = video/mp2t
@@ -22,6 +22,10 @@ track 256:
     time = 66733
     flags = 0
     data = length 18112, hash EC44B35B
+  sample 2:
+    time = 100100
+    flags = 0
+    data = length 6203, hash 6D666BC7
 track 257:
   total output bytes = 5015
   sample count = 4

--- a/libraries/test_data/src/test/assets/playbackdumps/ts/sample_h262_mpeg_audio.ps.dump
+++ b/libraries/test_data/src/test/assets/playbackdumps/ts/sample_h262_mpeg_audio.ps.dump
@@ -37,7 +37,7 @@ MediaCodecAdapter (media3.audio.mpegl2):
       rendered = false
 MediaCodecAdapter (media3.video.mpeg2):
   inputBuffers:
-    count = 3
+    count = 4
     input buffer #0:
       timeUs = 1000000040000
       contents = length 20646, hash 576390B
@@ -45,11 +45,14 @@ MediaCodecAdapter (media3.video.mpeg2):
       timeUs = 1000000080000
       contents = length 17831, hash 5C5A57F5
     input buffer #2:
+      timeUs = 1000000120000
+      contents = length 5579, hash 72A6C31F
+    input buffer #3:
       timeUs = 0
       flags = 4
       contents = length 0, hash 1
   outputBuffers:
-    count = 2
+    count = 3
     output buffer #0:
       timeUs = 1000000040000
       size = 20646
@@ -57,6 +60,10 @@ MediaCodecAdapter (media3.video.mpeg2):
     output buffer #1:
       timeUs = 1000000080000
       size = 17831
+      rendered = true
+    output buffer #2:
+      timeUs = 1000000120000
+      size = 5579
       rendered = true
 AudioSink:
   buffer count = 4

--- a/libraries/test_data/src/test/assets/playbackdumps/ts/sample_h262_mpeg_audio.ts.dump
+++ b/libraries/test_data/src/test/assets/playbackdumps/ts/sample_h262_mpeg_audio.ts.dump
@@ -37,7 +37,7 @@ MediaCodecAdapter (media3.audio.mpegl2):
       rendered = false
 MediaCodecAdapter (media3.video.mpeg2):
   inputBuffers:
-    count = 3
+    count = 4
     input buffer #0:
       timeUs = 1000000033366
       contents = length 20711, hash 34341E8
@@ -45,11 +45,14 @@ MediaCodecAdapter (media3.video.mpeg2):
       timeUs = 1000000066733
       contents = length 18112, hash EC44B35B
     input buffer #2:
+      timeUs = 1000000100100
+      contents = length 6203, hash 6D666BC7
+    input buffer #3:
       timeUs = 0
       flags = 4
       contents = length 0, hash 1
   outputBuffers:
-    count = 2
+    count = 3
     output buffer #0:
       timeUs = 1000000033366
       size = 20711
@@ -57,6 +60,10 @@ MediaCodecAdapter (media3.video.mpeg2):
     output buffer #1:
       timeUs = 1000000066733
       size = 18112
+      rendered = true
+    output buffer #2:
+      timeUs = 1000000100100
+      size = 6203
       rendered = true
 AudioSink:
   buffer count = 4

--- a/libraries/test_data/src/test/assets/playbackdumps/ts/sample_scte35.ts.dump
+++ b/libraries/test_data/src/test/assets/playbackdumps/ts/sample_scte35.ts.dump
@@ -37,7 +37,7 @@ MediaCodecAdapter (media3.audio.mpegl2):
       rendered = false
 MediaCodecAdapter (media3.video.mpeg2):
   inputBuffers:
-    count = 3
+    count = 4
     input buffer #0:
       timeUs = 1000000033366
       contents = length 20711, hash 34341E8
@@ -45,11 +45,14 @@ MediaCodecAdapter (media3.video.mpeg2):
       timeUs = 1000000066733
       contents = length 18112, hash EC44B35B
     input buffer #2:
+      timeUs = 1000000100100
+      contents = length 6203, hash 6D666BC7
+    input buffer #3:
       timeUs = 0
       flags = 4
       contents = length 0, hash 1
   outputBuffers:
-    count = 2
+    count = 3
     output buffer #0:
       timeUs = 1000000033366
       size = 20711
@@ -57,6 +60,10 @@ MediaCodecAdapter (media3.video.mpeg2):
     output buffer #1:
       timeUs = 1000000066733
       size = 18112
+      rendered = true
+    output buffer #2:
+      timeUs = 1000000100100
+      size = 6203
       rendered = true
 AudioSink:
   buffer count = 4

--- a/libraries/test_data/src/test/assets/playbackdumps/ts/sample_with_junk.dump
+++ b/libraries/test_data/src/test/assets/playbackdumps/ts/sample_with_junk.dump
@@ -37,7 +37,7 @@ MediaCodecAdapter (media3.audio.mpegl2):
       rendered = false
 MediaCodecAdapter (media3.video.mpeg2):
   inputBuffers:
-    count = 3
+    count = 4
     input buffer #0:
       timeUs = 1000000033366
       contents = length 20711, hash 34341E8
@@ -45,11 +45,14 @@ MediaCodecAdapter (media3.video.mpeg2):
       timeUs = 1000000066733
       contents = length 18112, hash EC44B35B
     input buffer #2:
+      timeUs = 1000000100100
+      contents = length 6203, hash 6D666BC7
+    input buffer #3:
       timeUs = 0
       flags = 4
       contents = length 0, hash 1
   outputBuffers:
-    count = 2
+    count = 3
     output buffer #0:
       timeUs = 1000000033366
       size = 20711
@@ -57,6 +60,10 @@ MediaCodecAdapter (media3.video.mpeg2):
     output buffer #1:
       timeUs = 1000000066733
       size = 18112
+      rendered = true
+    output buffer #2:
+      timeUs = 1000000100100
+      size = 6203
       rendered = true
 AudioSink:
   buffer count = 4


### PR DESCRIPTION
In PesReader, endOfInput wasn't set to true if last pes had length field set. Originally, ExoPlayer was always dropping last frame in pes, it was fixed in https://github.com/androidx/media/pull/419 for pes without length and this fixes it for pes with length set. Thus, the dumps changed because last sample is now correctly parsed by ExoPlayer for both TsExtractor and PsExtractor.

Split packetFinished(boolean) into two methods because:
- If pes length is unset, we only know packet is finished once next one starts or stream ends, so we know packet end and stream end at the same time. (This is what was handled so far)
- If pes length is set, we may know packet end far before stream ends. Waiting for next pes to know whether to set isEndOfInput would introduce latency issues for ID3 or SCTE-35, but when we don't wait we can't deliver end of stream event later.

Thus split off a endOfInputReached() method to deliver end of stream event later, and every codec can override the method that best fits without latency issues.