### PR TITLE
Fix segmented webvtt parser status after seek

### DIFF
--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/e2etest/WebvttPlaybackTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/e2etest/WebvttPlaybackTest.java
@@ -288,7 +288,8 @@ public class WebvttPlaybackTest {
     surface.release();
 
     DumpFileAsserts.assertOutput(
-        applicationContext, playbackOutput, "playbackdumps/webvtt/" + inputFile + ".seek.dump");
+        applicationContext, playbackOutput,
+            "playbackdumps/webvtt/" + inputFile + ".legacy.seek.dump");
   }
 
   // Deliberately configuring legacy subtitle handling to check unconfigured TextRenderer fails.

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/LegacySubtitleUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/LegacySubtitleUtil.java
@@ -41,14 +41,16 @@ public class LegacySubtitleUtil {
     boolean startedInMiddleOfCue = false;
     if (outputOptions.startTimeUs != C.TIME_UNSET && startIndex < subtitle.getEventTimeCount()) {
       List<Cue> cuesAtStartTime = subtitle.getCues(outputOptions.startTimeUs);
-      long firstEventTimeUs = subtitle.getEventTime(startIndex);
-      if (!cuesAtStartTime.isEmpty() && outputOptions.startTimeUs < firstEventTimeUs) {
-        output.accept(
-            new CuesWithTiming(
-                cuesAtStartTime,
-                outputOptions.startTimeUs,
-                firstEventTimeUs - outputOptions.startTimeUs));
-        startedInMiddleOfCue = true;
+      if (!cuesAtStartTime.isEmpty() && startIndex < subtitle.getEventTimeCount()) {
+        long firstEventTimeUs = subtitle.getEventTime(startIndex);
+        if (!cuesAtStartTime.isEmpty() && outputOptions.startTimeUs < firstEventTimeUs) {
+          output.accept(
+              new CuesWithTiming(
+                  cuesAtStartTime,
+                  outputOptions.startTimeUs,
+                  firstEventTimeUs - outputOptions.startTimeUs));
+          startedInMiddleOfCue = true;
+        }
       }
     }
     for (int i = startIndex; i < subtitle.getEventTimeCount(); i++) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/SubtitleExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/SubtitleExtractor.java
@@ -201,7 +201,14 @@ public class SubtitleExtractor implements Extractor {
       state = STATE_INITIALIZED;
     }
     if (state == STATE_FINISHED) {
-      state = STATE_SEEKING;
+      // Some parsers require to reparse the cues as the input can be different. For those
+      // parsers just force a reinitialization, which will force a reprocess of the new input.
+      state = subtitleParser.requiresInitializationAfterSeeking()
+          ? STATE_INITIALIZED : STATE_SEEKING;
+      if (state == STATE_INITIALIZED) {
+        samples.clear();
+        timestamps = Util.EMPTY_LONG_ARRAY;
+      }
     }
   }
 
@@ -251,7 +258,9 @@ public class SubtitleExtractor implements Extractor {
     try {
       SubtitleParser.OutputOptions outputOptions =
           seekTimeUs != C.TIME_UNSET
-              ? SubtitleParser.OutputOptions.cuesAfterThenRemainingCuesBefore(seekTimeUs)
+              ? subtitleParser.requiresInitializationAfterSeeking()
+                  ? SubtitleParser.OutputOptions.onlyCuesAfter(seekTimeUs)
+                  : SubtitleParser.OutputOptions.cuesAfterThenRemainingCuesBefore(seekTimeUs)
               : SubtitleParser.OutputOptions.allCues();
       AtomicLong maxEndTimeUs = new AtomicLong(C.TIME_UNSET);
       subtitleParser.parse(

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/SubtitleParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/SubtitleParser.java
@@ -215,6 +215,14 @@ public interface SubtitleParser {
   default void reset() {}
 
   /**
+   * Returns whether the subtitle parser requires to be reinitialized after seeking, so
+   * input is reprocessed before cues being written to the output.
+   *
+   * <p>The default implementation is {@code false}.
+   */
+  default boolean requiresInitializationAfterSeeking() { return false; }
+
+  /**
    * Returns the {@link CueReplacementBehavior} for consecutive {@link CuesWithTiming} emitted by
    * this implementation.
    *

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/webvtt/WebvttParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/webvtt/WebvttParser.java
@@ -108,6 +108,13 @@ public final class WebvttParser implements SubtitleParser {
     LegacySubtitleUtil.toCuesWithTiming(subtitle, outputOptions, output);
   }
 
+  @Override
+  public boolean requiresInitializationAfterSeeking() {
+    // Cues of segmented webvtt need to be reprocessed, as the extractor could be reused, but
+    // can fetch different inputs on seeking.
+    return true;
+  }
+
   /**
    * Positions the input right before the next event, and returns the kind of event found. Does not
    * consume any data from such event, if any.

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/text/SubtitleExtractorTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/text/SubtitleExtractorTest.java
@@ -114,6 +114,7 @@ public class SubtitleExtractorTest {
 
   @Test
   public void extractor_seekAfterExtracting_outputsCues() throws Exception {
+    SubtitleParser parser = new WebvttParser();
     FakeExtractorOutput output = new FakeExtractorOutput();
     FakeExtractorInput input =
         new FakeExtractorInput.Builder()
@@ -122,7 +123,7 @@ public class SubtitleExtractorTest {
             .build();
     SubtitleExtractor extractor =
         new SubtitleExtractor(
-            new WebvttParser(), new Format.Builder().setSampleMimeType(MimeTypes.TEXT_VTT).build());
+            parser, new Format.Builder().setSampleMimeType(MimeTypes.TEXT_VTT).build());
     extractor.init(output);
     FakeTrackOutput trackOutput = output.trackOutputs.get(0);
 
@@ -136,8 +137,9 @@ public class SubtitleExtractorTest {
     assertThat(trackOutput.lastFormat.codecs).isEqualTo(MimeTypes.TEXT_VTT);
     assertThat(trackOutput.getSampleCount()).isEqualTo(3);
     CuesWithTiming cues0 = decodeSample(trackOutput, 0);
-    assertThat(cues0.startTimeUs).isEqualTo(2_345_000L);
-    assertThat(cues0.durationUs).isEqualTo(2_600_000 - 2_345_000L);
+    long startTimeUs = parser.requiresInitializationAfterSeeking() ? 2_445_000L : 2_345_000L;
+    assertThat(cues0.startTimeUs).isEqualTo(startTimeUs);
+    assertThat(cues0.durationUs).isEqualTo(2_600_000 - startTimeUs);
     assertThat(cues0.endTimeUs).isEqualTo(2_600_000);
     assertThat(cues0.cues).hasSize(1);
     assertThat(cues0.cues.get(0).text.toString()).isEqualTo("This is the second subtitle.");

--- a/libraries/test_data/src/test/assets/playbackdumps/webvtt/typical.legacy.seek.dump
+++ b/libraries/test_data/src/test/assets/playbackdumps/webvtt/typical.legacy.seek.dump
@@ -5632,7 +5632,7 @@ TextOutput:
     presentationTimeUs = 1000000
     Cues = []
   Subtitle[6]:
-    presentationTimeUs = 1000000
+    presentationTimeUs = 0
     Cue[0]:
       text = This is the first subtitle.
       textAlignment = ALIGN_CENTER


### PR DESCRIPTION
When playing a stream with segmented webvtt, no subtitles are displayed after seeking. This PR tries to reset the status to allow to reinitialized the webvtt parser state, so it can display segmented webvtt after seeking.

See https://github.com/androidx/media/issues/3219