### PR TITLE
Support DTS-HD MA profiles

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/C.java
+++ b/libraries/common/src/main/java/androidx/media3/common/C.java
@@ -185,8 +185,8 @@ public final class C {
    * #ENCODING_PCM_FLOAT_BIG_ENDIAN}, {@link #ENCODING_PCM_DOUBLE}, {@link
    * #ENCODING_PCM_DOUBLE_BIG_ENDIAN}, {@link #ENCODING_MP3}, {@link #ENCODING_AC3}, {@link
    * #ENCODING_E_AC3}, {@link #ENCODING_E_AC3_JOC}, {@link #ENCODING_AC4}, {@link #ENCODING_DTS},
-   * {@link #ENCODING_DTS_HD}, {@link #ENCODING_DOLBY_TRUEHD}, {@link #ENCODING_OPUS} or {@link
-   * #ENCODING_DSD}.
+   * {@link #ENCODING_DTS_HD}, {@link #ENCODING_DTS_HD_MA}, {@link #ENCODING_DOLBY_TRUEHD}, {@link
+   * #ENCODING_OPUS} or {@link #ENCODING_DSD}.
    */
   @Documented
   @Retention(RetentionPolicy.SOURCE)
@@ -218,6 +218,7 @@ public final class C {
     ENCODING_AC4,
     ENCODING_DTS,
     ENCODING_DTS_HD,
+    ENCODING_DTS_HD_MA,
     ENCODING_DOLBY_TRUEHD,
     ENCODING_OPUS,
     ENCODING_DTS_UHD_P2,
@@ -328,6 +329,9 @@ public final class C {
 
   /** See {@link AudioFormat#ENCODING_DTS_HD}. */
   public static final int ENCODING_DTS_HD = AudioFormat.ENCODING_DTS_HD;
+
+  /** See {@link AudioFormat#ENCODING_DTS_HD_MA}. */
+  public static final int ENCODING_DTS_HD_MA = AudioFormat.ENCODING_DTS_HD_MA;
 
   /** See {@link AudioFormat#ENCODING_DTS_UHD_P2}. */
   public static final int ENCODING_DTS_UHD_P2 = AudioFormat.ENCODING_DTS_UHD_P2;

--- a/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
@@ -92,7 +92,19 @@ public final class MimeTypes {
   @UnstableApi public static final String AUDIO_DSD = BASE_TYPE_AUDIO + "/dsd";
   public static final String AUDIO_DTS = BASE_TYPE_AUDIO + "/vnd.dts";
   public static final String AUDIO_DTS_HD = BASE_TYPE_AUDIO + "/vnd.dts.hd";
+  public static final String AUDIO_DTS_HD_MA = BASE_TYPE_AUDIO + "/vnd.dts.hd;profile=dtsma";
   public static final String AUDIO_DTS_EXPRESS = BASE_TYPE_AUDIO + "/vnd.dts.hd;profile=lbr";
+
+  /**
+   * DTS-HD MA can be encoded in a multi-layer setup with a core layer ({@link #AUDIO_DTS_HD_MA}),
+   * where fallback to a DTS core decoder is possible, or in a single-layer setup with only a
+   * lossless layer, where this is not. The same MIME type is normally used for both, but it's
+   * important for ExoPlayer to differentiate this at extractor level to understand whether decoder
+   * fallback is possible or not. Hence, use this dummy MIME type to signal lossless-only DTS-HD MA.
+   */
+  @UnstableApi
+  public static final String AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS =
+      BASE_TYPE_AUDIO + "/x-exoplayer-dtsma-coreless";
 
   @UnstableApi
   public static final String AUDIO_DTS_UHD_P2 = BASE_TYPE_AUDIO + "/vnd.dts.uhd;profile=p2";
@@ -509,8 +521,10 @@ public final class MimeTypes {
       return MimeTypes.AUDIO_DTS;
     } else if (codec.startsWith("dtse")) {
       return MimeTypes.AUDIO_DTS_EXPRESS;
-    } else if (codec.startsWith("dtsh") || codec.startsWith("dtsl")) {
+    } else if (codec.startsWith("dtsh")) {
       return MimeTypes.AUDIO_DTS_HD;
+    } else if (codec.startsWith("dtsl")) {
+      return MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS;
     } else if (codec.startsWith("dtsx")) {
       return MimeTypes.AUDIO_DTS_UHD_P2;
     } else if (codec.startsWith("opus")) {
@@ -716,6 +730,9 @@ public final class MimeTypes {
         return C.ENCODING_DTS;
       case MimeTypes.AUDIO_DTS_HD:
         return C.ENCODING_DTS_HD;
+      case MimeTypes.AUDIO_DTS_HD_MA:
+      case MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS:
+        return C.ENCODING_DTS_HD_MA;
       case MimeTypes.AUDIO_DTS_EXPRESS:
         return C.ENCODING_DTS_HD;
       case MimeTypes.AUDIO_DTS_UHD_P2:

--- a/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
+++ b/libraries/common/src/main/java/androidx/media3/common/MimeTypes.java
@@ -98,12 +98,12 @@ public final class MimeTypes {
   /**
    * DTS-HD MA can be encoded in a multi-layer setup with a core layer ({@link #AUDIO_DTS_HD_MA}),
    * where fallback to a DTS core decoder is possible, or in a single-layer setup with only a
-   * lossless layer, where this is not. The same MIME type is normally used for both, but it's
-   * important for ExoPlayer to differentiate this at extractor level to understand whether decoder
-   * fallback is possible or not. Hence, use this dummy MIME type to signal lossless-only DTS-HD MA.
+   * lossless layer, where this is not. The same MIME type is normally used for both, but it is
+   * important to differentiate this to understand whether decoder fallback is possible. Hence, use
+   * this synthetic MIME type to signal lossless-only DTS-HD MA.
    */
   @UnstableApi
-  public static final String AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS =
+  public static final String AUDIO_MEDIA3_DTS_HD_MA_CORELESS =
       BASE_TYPE_AUDIO + "/x-exoplayer-dtsma-coreless";
 
   @UnstableApi
@@ -524,7 +524,7 @@ public final class MimeTypes {
     } else if (codec.startsWith("dtsh")) {
       return MimeTypes.AUDIO_DTS_HD;
     } else if (codec.startsWith("dtsl")) {
-      return MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS;
+      return MimeTypes.AUDIO_MEDIA3_DTS_HD_MA_CORELESS;
     } else if (codec.startsWith("dtsx")) {
       return MimeTypes.AUDIO_DTS_UHD_P2;
     } else if (codec.startsWith("opus")) {
@@ -731,7 +731,7 @@ public final class MimeTypes {
       case MimeTypes.AUDIO_DTS_HD:
         return C.ENCODING_DTS_HD;
       case MimeTypes.AUDIO_DTS_HD_MA:
-      case MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS:
+      case MimeTypes.AUDIO_MEDIA3_DTS_HD_MA_CORELESS:
         return C.ENCODING_DTS_HD_MA;
       case MimeTypes.AUDIO_DTS_EXPRESS:
         return C.ENCODING_DTS_HD;

--- a/libraries/common/src/main/java/androidx/media3/common/util/Util.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/Util.java
@@ -2711,6 +2711,7 @@ public final class Util {
       case C.ENCODING_PCM_32BIT:
         return 31;
       case C.ENCODING_DTS_UHD_P2:
+      case C.ENCODING_DTS_HD_MA:
       case C.ENCODING_DSD:
         return 34;
       default:

--- a/libraries/common/src/test/java/androidx/media3/common/MimeTypesTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/MimeTypesTest.java
@@ -179,7 +179,8 @@ public final class MimeTypesTest {
     assertThat(MimeTypes.getMediaMimeType("dtsc")).isEqualTo(MimeTypes.AUDIO_DTS);
     assertThat(MimeTypes.getMediaMimeType("dtse")).isEqualTo(MimeTypes.AUDIO_DTS_EXPRESS);
     assertThat(MimeTypes.getMediaMimeType("dtsh")).isEqualTo(MimeTypes.AUDIO_DTS_HD);
-    assertThat(MimeTypes.getMediaMimeType("dtsl")).isEqualTo(MimeTypes.AUDIO_DTS_HD);
+    assertThat(MimeTypes.getMediaMimeType("dtsl"))
+        .isEqualTo(MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS);
     assertThat(MimeTypes.getMediaMimeType("dtsx")).isEqualTo(MimeTypes.AUDIO_DTS_UHD_P2);
     assertThat(MimeTypes.getMediaMimeType("opus")).isEqualTo(MimeTypes.AUDIO_OPUS);
     assertThat(MimeTypes.getMediaMimeType("vorbis")).isEqualTo(MimeTypes.AUDIO_VORBIS);

--- a/libraries/common/src/test/java/androidx/media3/common/MimeTypesTest.java
+++ b/libraries/common/src/test/java/androidx/media3/common/MimeTypesTest.java
@@ -180,7 +180,7 @@ public final class MimeTypesTest {
     assertThat(MimeTypes.getMediaMimeType("dtse")).isEqualTo(MimeTypes.AUDIO_DTS_EXPRESS);
     assertThat(MimeTypes.getMediaMimeType("dtsh")).isEqualTo(MimeTypes.AUDIO_DTS_HD);
     assertThat(MimeTypes.getMediaMimeType("dtsl"))
-        .isEqualTo(MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS);
+        .isEqualTo(MimeTypes.AUDIO_MEDIA3_DTS_HD_MA_CORELESS);
     assertThat(MimeTypes.getMediaMimeType("dtsx")).isEqualTo(MimeTypes.AUDIO_DTS_UHD_P2);
     assertThat(MimeTypes.getMediaMimeType("opus")).isEqualTo(MimeTypes.AUDIO_OPUS);
     assertThat(MimeTypes.getMediaMimeType("vorbis")).isEqualTo(MimeTypes.AUDIO_VORBIS);

--- a/libraries/decoder_ffmpeg/src/main/java/androidx/media3/decoder/ffmpeg/FfmpegLibrary.java
+++ b/libraries/decoder_ffmpeg/src/main/java/androidx/media3/decoder/ffmpeg/FfmpegLibrary.java
@@ -133,6 +133,8 @@ public final class FfmpegLibrary {
       case MimeTypes.AUDIO_DTS:
       case MimeTypes.AUDIO_DTS_EXPRESS:
       case MimeTypes.AUDIO_DTS_HD:
+      case MimeTypes.AUDIO_DTS_HD_MA:
+      case MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS:
         return "dca";
       case MimeTypes.AUDIO_VORBIS:
         return "vorbis";

--- a/libraries/decoder_ffmpeg/src/main/java/androidx/media3/decoder/ffmpeg/FfmpegLibrary.java
+++ b/libraries/decoder_ffmpeg/src/main/java/androidx/media3/decoder/ffmpeg/FfmpegLibrary.java
@@ -134,7 +134,7 @@ public final class FfmpegLibrary {
       case MimeTypes.AUDIO_DTS_EXPRESS:
       case MimeTypes.AUDIO_DTS_HD:
       case MimeTypes.AUDIO_DTS_HD_MA:
-      case MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS:
+      case MimeTypes.AUDIO_MEDIA3_DTS_HD_MA_CORELESS:
         return "dca";
       case MimeTypes.AUDIO_VORBIS:
         return "vorbis";

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -98,6 +98,7 @@ public final class AudioCapabilities {
           .put(C.ENCODING_E_AC3_JOC, 6)
           .put(C.ENCODING_E_AC3, 8)
           .put(C.ENCODING_DTS_HD, 8)
+          .put(C.ENCODING_DTS_HD_MA, 8)
           .put(C.ENCODING_DOLBY_TRUEHD, 8)
           .buildOrThrow();
 
@@ -398,6 +399,23 @@ public final class AudioCapabilities {
         || (encoding == C.ENCODING_DTS_UHD_P2 && !supportsEncoding(C.ENCODING_DTS_UHD_P2))) {
       // DTS receivers support DTS-HD streams (but decode only the core layer).
       encoding = C.ENCODING_DTS;
+    } else if (MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS.equals(format.sampleMimeType)) {
+      // DTS-HD MA without core layer can only be decoded by DTS-HD MA receivers. However, because
+      // the constant for DTS-HD MA was only added in 2022 (https://r.android.com/1992892), we have
+      // to try the older DTS-HD constant for backwards compatibility.
+      if (!supportsEncoding(C.ENCODING_DTS_HD_MA)) {
+        encoding = C.ENCODING_DTS_HD;
+      }
+    } else if (encoding == C.ENCODING_DTS_HD_MA && !supportsEncoding(C.ENCODING_DTS_HD_MA)) {
+      // DTS-HD MA with core layer can be decoded by any DTS or DTS-HD MA receivers. Also, because
+      // the constant for DTS-HD MA was only added in 2022 (https://r.android.com/1992892), we have
+      // to try the older DTS-HD constant for backwards compatibility as well.
+      if (supportsEncoding(C.ENCODING_DTS_HD)) {
+        encoding = C.ENCODING_DTS_HD;
+      } else {
+        // DTS receivers support DTS-HD MA streams (but decode only the core layer).
+        encoding = C.ENCODING_DTS;
+      }
     }
     if (!supportsEncoding(encoding)) {
       return null;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilities.java
@@ -399,7 +399,7 @@ public final class AudioCapabilities {
         || (encoding == C.ENCODING_DTS_UHD_P2 && !supportsEncoding(C.ENCODING_DTS_UHD_P2))) {
       // DTS receivers support DTS-HD streams (but decode only the core layer).
       encoding = C.ENCODING_DTS;
-    } else if (MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS.equals(format.sampleMimeType)) {
+    } else if (MimeTypes.AUDIO_MEDIA3_DTS_HD_MA_CORELESS.equals(format.sampleMimeType)) {
       // DTS-HD MA without core layer can only be decoded by DTS-HD MA receivers. However, because
       // the constant for DTS-HD MA was only added in 2022 (https://r.android.com/1992892), we have
       // to try the older DTS-HD constant for backwards compatibility.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/DefaultAudioSink.java
@@ -1837,6 +1837,7 @@ public final class DefaultAudioSink implements AudioSink {
         return AacUtil.AAC_LD_AUDIO_SAMPLE_COUNT;
       case C.ENCODING_DTS:
       case C.ENCODING_DTS_HD:
+      case C.ENCODING_DTS_HD_MA:
       case C.ENCODING_DTS_UHD_P2:
         return DtsUtil.parseDtsAudioSampleCount(buffer);
       case C.ENCODING_AC3:

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecInfo.java
@@ -312,7 +312,7 @@ public final class MediaCodecInfo {
 
   private boolean isSampleMimeTypeSupported(Format format) {
     return mimeType.equals(format.sampleMimeType)
-        || mimeType.equals(MediaCodecUtil.getAlternativeCodecMimeType(format));
+        || MediaCodecUtil.getAlternativeCodecMimeTypes(format).contains(mimeType);
   }
 
   private boolean isCodecProfileAndLevelSupported(

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
@@ -384,6 +384,18 @@ public final class MediaCodecUtil {
       // E-AC3 decoders can decode JOC streams, but in 2-D rather than 3-D.
       return Collections.singletonList(MimeTypes.AUDIO_E_AC3);
     }
+    if (MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS.equals(format.sampleMimeType)) {
+      // Coreless DTS-HD MA can only be decoded by a DTS-HD MA decoder. However, as DTS-HD MA was
+      // added as separate MIME type in platform in 2022, we need to try the older DTS-HD mime type
+      // for backwards compatibility. (https://r.android.com/2302237)
+      return List.of(MimeTypes.AUDIO_DTS_HD_MA, MimeTypes.AUDIO_DTS_HD);
+    }
+    if (MimeTypes.AUDIO_DTS_HD_MA.equals(format.sampleMimeType)) {
+      // DTS-HD MA was added as separate MIME type in platform in 2022, so we need to try the older
+      // DTS-HD mime type for backwards compatibility. (https://r.android.com/2302237)
+      // And because this is DTS-HD MA with core layer, even a DTS decoder can decode this stream.
+      return List.of(MimeTypes.AUDIO_DTS_HD, MimeTypes.AUDIO_DTS);
+    }
     if (MimeTypes.AUDIO_DTS_HD.equals(format.sampleMimeType)
         || MimeTypes.AUDIO_DTS_UHD_P2.equals(format.sampleMimeType)) {
       // DTS decoders support DTS-HD streams (but decode only the core layer).

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
@@ -193,7 +193,7 @@ public final class MediaCodecUtil {
    * decoders that fully support the format come first.
    *
    * <p>This list is more complete than {@link #getDecoderInfos}, as it also considers alternative
-   * MIME types that are a close match using {@link #getAlternativeCodecMimeType}.
+   * MIME types that are a close match using {@link #getAlternativeCodecMimeTypes}.
    *
    * @param mediaCodecSelector The decoder selector.
    * @param format The {@link Format} for which a decoder is required.
@@ -222,9 +222,9 @@ public final class MediaCodecUtil {
   }
 
   /**
-   * Returns a list of decoders for {@linkplain #getAlternativeCodecMimeType alternative MIME types}
-   * that can decode samples of the provided {@link Format}, in the priority order specified by the
-   * {@link MediaCodecSelector}.
+   * Returns a list of decoders for {@linkplain #getAlternativeCodecMimeTypes alternative MIME
+   * types} that can decode samples of the provided {@link Format}, in the priority order specified
+   * by the {@link MediaCodecSelector}.
    *
    * <p>Since the {@link MediaCodecSelector} only has access to {@link Format#sampleMimeType}, the
    * list is not ordered to account for whether each decoder supports the details of the format
@@ -245,12 +245,17 @@ public final class MediaCodecUtil {
       boolean requiresSecureDecoder,
       boolean requiresTunnelingDecoder)
       throws DecoderQueryException {
-    @Nullable String alternativeMimeType = getAlternativeCodecMimeType(format);
-    if (alternativeMimeType == null) {
+    List<String> alternativeMimeTypes = getAlternativeCodecMimeTypes(format);
+    if (alternativeMimeTypes.isEmpty()) {
       return ImmutableList.of();
     }
-    return mediaCodecSelector.getDecoderInfos(
-        alternativeMimeType, requiresSecureDecoder, requiresTunnelingDecoder);
+    ImmutableList.Builder<MediaCodecInfo> listBuilder = new ImmutableList.Builder<>();
+    for (String alternativeMimeType : alternativeMimeTypes) {
+      listBuilder.addAll(
+          mediaCodecSelector.getDecoderInfos(
+              alternativeMimeType, requiresSecureDecoder, requiresTunnelingDecoder));
+    }
+    return listBuilder.build();
   }
 
   /**
@@ -366,24 +371,23 @@ public final class MediaCodecUtil {
   }
 
   /**
-   * Returns an alternative codec MIME type (besides the default {@link Format#sampleMimeType}) that
-   * can be used to decode samples of the provided {@link Format}.
+   * Returns alternative codec MIME types (besides the default {@link Format#sampleMimeType}) that
+   * can be used to decode samples of the provided {@link Format}, in order of preference.
    *
    * @param format The media format.
-   * @return An alternative MIME type of a codec that be used decode samples of the provided {@code
-   *     Format} (besides the default {@link Format#sampleMimeType}), or null if no such alternative
-   *     exists.
+   * @return Alternative MIME types of a codec that be used decode samples of the provided {@code
+   *     Format} (besides the default {@link Format#sampleMimeType}), or an empty List if no such
+   *     alternative exists.
    */
-  @Nullable
-  public static String getAlternativeCodecMimeType(Format format) {
+  public static List<String> getAlternativeCodecMimeTypes(Format format) {
     if (MimeTypes.AUDIO_E_AC3_JOC.equals(format.sampleMimeType)) {
       // E-AC3 decoders can decode JOC streams, but in 2-D rather than 3-D.
-      return MimeTypes.AUDIO_E_AC3;
+      return Collections.singletonList(MimeTypes.AUDIO_E_AC3);
     }
     if (MimeTypes.AUDIO_DTS_HD.equals(format.sampleMimeType)
         || MimeTypes.AUDIO_DTS_UHD_P2.equals(format.sampleMimeType)) {
       // DTS decoders support DTS-HD streams (but decode only the core layer).
-      return MimeTypes.AUDIO_DTS;
+      return Collections.singletonList(MimeTypes.AUDIO_DTS);
     }
     if (MimeTypes.VIDEO_DOLBY_VISION.equals(format.sampleMimeType)) {
       // H.264/AVC, H.265/HEVC or AV1 decoders can decode the base layer of some DV profiles.
@@ -397,24 +401,24 @@ public final class MediaCodecUtil {
         int profile = codecProfileAndLevel.getProfile();
         if (profile == CodecProfileLevel.DolbyVisionProfileDvheDtr
             || profile == CodecProfileLevel.DolbyVisionProfileDvheSt) {
-          return MimeTypes.VIDEO_H265;
+          return Collections.singletonList(MimeTypes.VIDEO_H265);
         } else if (profile == CodecProfileLevel.DolbyVisionProfileDvavSe) {
-          return MimeTypes.VIDEO_H264;
+          return Collections.singletonList(MimeTypes.VIDEO_H264);
         } else if (profile == CodecProfileLevel.DolbyVisionProfileDvav110) {
           if (format.colorInfo != null
               && format.colorInfo.colorTransfer == C.COLOR_TRANSFER_ST2084
               && format.colorInfo.colorRange == C.COLOR_RANGE_FULL) {
-            return null;
+            return Collections.emptyList();
           }
-          return MimeTypes.VIDEO_AV1;
+          return Collections.singletonList(MimeTypes.VIDEO_AV1);
         }
       }
     }
     if (MimeTypes.VIDEO_MV_HEVC.equals(format.sampleMimeType)) {
       // Single-layer HEVC decoders can decode the base layer of MV-HEVC streams.
-      return MimeTypes.VIDEO_H265;
+      return Collections.singletonList(MimeTypes.VIDEO_H265);
     }
-    return null;
+    return Collections.emptyList();
   }
 
   // Internal methods.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
@@ -384,22 +384,22 @@ public final class MediaCodecUtil {
       // E-AC3 decoders can decode JOC streams, but in 2-D rather than 3-D.
       return Collections.singletonList(MimeTypes.AUDIO_E_AC3);
     }
-    if (MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS.equals(format.sampleMimeType)) {
+    if (MimeTypes.AUDIO_MEDIA3_DTS_HD_MA_CORELESS.equals(format.sampleMimeType)) {
       // Coreless DTS-HD MA can only be decoded by a DTS-HD MA decoder. However, as DTS-HD MA was
       // added as separate MIME type in platform in 2022, we need to try the older DTS-HD mime type
       // for backwards compatibility. (https://r.android.com/2302237)
-      return List.of(MimeTypes.AUDIO_DTS_HD_MA, MimeTypes.AUDIO_DTS_HD);
+      return ImmutableList.of(MimeTypes.AUDIO_DTS_HD_MA, MimeTypes.AUDIO_DTS_HD);
     }
     if (MimeTypes.AUDIO_DTS_HD_MA.equals(format.sampleMimeType)) {
       // DTS-HD MA was added as separate MIME type in platform in 2022, so we need to try the older
       // DTS-HD mime type for backwards compatibility. (https://r.android.com/2302237)
       // And because this is DTS-HD MA with core layer, even a DTS decoder can decode this stream.
-      return List.of(MimeTypes.AUDIO_DTS_HD, MimeTypes.AUDIO_DTS);
+      return ImmutableList.of(MimeTypes.AUDIO_DTS_HD, MimeTypes.AUDIO_DTS);
     }
     if (MimeTypes.AUDIO_DTS_HD.equals(format.sampleMimeType)
         || MimeTypes.AUDIO_DTS_UHD_P2.equals(format.sampleMimeType)) {
       // DTS decoders support DTS-HD streams (but decode only the core layer).
-      return Collections.singletonList(MimeTypes.AUDIO_DTS);
+      return ImmutableList.of(MimeTypes.AUDIO_DTS);
     }
     if (MimeTypes.VIDEO_DOLBY_VISION.equals(format.sampleMimeType)) {
       // H.264/AVC, H.265/HEVC or AV1 decoders can decode the base layer of some DV profiles.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
@@ -3912,9 +3912,9 @@ public class DefaultTrackSelector extends MappingTrackSelector
       @RendererCapabilities.DecoderSupport
       int decoderSupport = RendererCapabilities.getDecoderSupport(formatSupport);
       if (decoderSupport == RendererCapabilities.DECODER_SUPPORT_FALLBACK_MIMETYPE) {
-        String fallbackMimeType = MediaCodecUtil.getAlternativeCodecMimeType(format);
-        if (fallbackMimeType != null) {
-          resolvedMimeType = fallbackMimeType;
+        List<String> fallbackMimeType = MediaCodecUtil.getAlternativeCodecMimeTypes(format);
+        if (!fallbackMimeType.isEmpty()) {
+          resolvedMimeType = fallbackMimeType.get(0);
         }
       }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/EventLogger.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/util/EventLogger.java
@@ -805,6 +805,8 @@ public class EventLogger implements AnalyticsListener {
         return "dts";
       case C.ENCODING_DTS_HD:
         return "dts-hd";
+      case C.ENCODING_DTS_HD_MA:
+        return "dts-hd-ma";
       case C.ENCODING_DTS_UHD_P2:
         return "dts-uhd-p2";
       case C.ENCODING_DSD:

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtilTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtilTest.java
@@ -25,6 +25,7 @@ import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.CodecSpecificDataUtil.MediaCodecProfileAndLevel;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.collect.ImmutableList;
+import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -228,7 +229,7 @@ public final class MediaCodecUtilTest {
   }
 
   @Test
-  public void getAlternativeCodecMimeType_withNonFallbackCompatibleFormat_returnsNull() {
+  public void getAlternativeCodecMimeType_withNonFallbackCompatibleFormat_returnsEmpty() {
     // Profile 10.0 (Full Range PQ) which does NOT allow fallback.
     Format formatDav1NoFallbackPossible =
         new Format.Builder()
@@ -254,9 +255,9 @@ public final class MediaCodecUtilTest {
                     .build())
             .build();
 
-    assertThat(MediaCodecUtil.getAlternativeCodecMimeType(formatDav1NoFallbackPossible)).isNull();
-    assertThat(MediaCodecUtil.getAlternativeCodecMimeType(formatDav1FallbackToAv1))
-        .isEqualTo(MimeTypes.VIDEO_AV1);
+    assertThat(MediaCodecUtil.getAlternativeCodecMimeTypes(formatDav1NoFallbackPossible)).isEmpty();
+    assertThat(MediaCodecUtil.getAlternativeCodecMimeTypes(formatDav1FallbackToAv1))
+        .isEqualTo(Collections.singletonList(MimeTypes.VIDEO_AV1));
   }
 
   private static void assertHevcBaseLayerCodecProfileAndLevelForFormat(

--- a/libraries/exoplayer_smoothstreaming/src/main/java/androidx/media3/exoplayer/smoothstreaming/manifest/SsManifestParser.java
+++ b/libraries/exoplayer_smoothstreaming/src/main/java/androidx/media3/exoplayer/smoothstreaming/manifest/SsManifestParser.java
@@ -795,8 +795,10 @@ public class SsManifestParser implements ParsingLoadable.Parser<SsManifest> {
         return MimeTypes.AUDIO_E_AC3;
       } else if (fourCC.equalsIgnoreCase("dtsc")) {
         return MimeTypes.AUDIO_DTS;
-      } else if (fourCC.equalsIgnoreCase("dtsh") || fourCC.equalsIgnoreCase("dtsl")) {
+      } else if (fourCC.equalsIgnoreCase("dtsh")) {
         return MimeTypes.AUDIO_DTS_HD;
+      } else if (fourCC.equalsIgnoreCase("dtsl")) {
+        return MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS;
       } else if (fourCC.equalsIgnoreCase("dtse")) {
         return MimeTypes.AUDIO_DTS_EXPRESS;
       } else if (fourCC.equalsIgnoreCase("opus")) {

--- a/libraries/exoplayer_smoothstreaming/src/main/java/androidx/media3/exoplayer/smoothstreaming/manifest/SsManifestParser.java
+++ b/libraries/exoplayer_smoothstreaming/src/main/java/androidx/media3/exoplayer/smoothstreaming/manifest/SsManifestParser.java
@@ -798,7 +798,7 @@ public class SsManifestParser implements ParsingLoadable.Parser<SsManifest> {
       } else if (fourCC.equalsIgnoreCase("dtsh")) {
         return MimeTypes.AUDIO_DTS_HD;
       } else if (fourCC.equalsIgnoreCase("dtsl")) {
-        return MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS;
+        return MimeTypes.AUDIO_MEDIA3_DTS_HD_MA_CORELESS;
       } else if (fourCC.equalsIgnoreCase("dtse")) {
         return MimeTypes.AUDIO_DTS_EXPRESS;
       } else if (fourCC.equalsIgnoreCase("opus")) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
@@ -90,7 +90,7 @@ public final class DtsUtil {
    *   <li>{@link MimeTypes#AUDIO_DTS_EXPRESS}
    *   <li>{@link MimeTypes#AUDIO_DTS_HD}
    *   <li>{@link MimeTypes#AUDIO_DTS_HD_MA}
-   *   <li>{@link MimeTypes#AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS}
+   *   <li>{@link MimeTypes#AUDIO_MEDIA3_DTS_HD_MA_CORELESS}
    *   <li>{@link MimeTypes#AUDIO_DTS_UHD_P2}
    * </ul>
    */
@@ -102,7 +102,7 @@ public final class DtsUtil {
     MimeTypes.AUDIO_DTS_EXPRESS,
     MimeTypes.AUDIO_DTS_HD,
     MimeTypes.AUDIO_DTS_HD_MA,
-    MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS,
+    MimeTypes.AUDIO_MEDIA3_DTS_HD_MA_CORELESS,
     MimeTypes.AUDIO_DTS_UHD_P2
   })
   public @interface DtsAudioMimeType {}
@@ -664,13 +664,13 @@ public final class DtsUtil {
           if ((extensionMask & 0x001) != 0) { // Core component within the core substream
             return MimeTypes.AUDIO_DTS_HD_MA;
           } else {
-            return MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS;
+            return MimeTypes.AUDIO_MEDIA3_DTS_HD_MA_CORELESS;
           }
         } else {
           return MimeTypes.AUDIO_DTS_HD;
         }
       case 1: // DTS-HD Loss-less coding mode without CBR component
-        return MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS;
+        return MimeTypes.AUDIO_MEDIA3_DTS_HD_MA_CORELESS;
       case 2: // DTS-HD Low bit-rate mode
         return MimeTypes.AUDIO_DTS_EXPRESS;
       case 3: // The auxiliary coding mode is reserved for future applications.

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/DtsUtil.java
@@ -89,6 +89,8 @@ public final class DtsUtil {
    *   <li>{@link MimeTypes#AUDIO_DTS}
    *   <li>{@link MimeTypes#AUDIO_DTS_EXPRESS}
    *   <li>{@link MimeTypes#AUDIO_DTS_HD}
+   *   <li>{@link MimeTypes#AUDIO_DTS_HD_MA}
+   *   <li>{@link MimeTypes#AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS}
    *   <li>{@link MimeTypes#AUDIO_DTS_UHD_P2}
    * </ul>
    */
@@ -99,6 +101,8 @@ public final class DtsUtil {
     MimeTypes.AUDIO_DTS,
     MimeTypes.AUDIO_DTS_EXPRESS,
     MimeTypes.AUDIO_DTS_HD,
+    MimeTypes.AUDIO_DTS_HD_MA,
+    MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS,
     MimeTypes.AUDIO_DTS_UHD_P2
   })
   public @interface DtsAudioMimeType {}
@@ -656,11 +660,17 @@ public final class DtsUtil {
         int extensionMask = headerBits.readBits(12);
         if ((extensionMask & 0x100) != 0) { // Low bit rate component
           return MimeTypes.AUDIO_DTS_EXPRESS;
+        } else if ((extensionMask & 0x200) != 0) { // Lossless extension
+          if ((extensionMask & 0x001) != 0) { // Core component within the core substream
+            return MimeTypes.AUDIO_DTS_HD_MA;
+          } else {
+            return MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS;
+          }
         } else {
           return MimeTypes.AUDIO_DTS_HD;
         }
       case 1: // DTS-HD Loss-less coding mode without CBR component
-        return MimeTypes.AUDIO_DTS_HD;
+        return MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS;
       case 2: // DTS-HD Low bit-rate mode
         return MimeTypes.AUDIO_DTS_EXPRESS;
       case 3: // The auxiliary coding mode is reserved for future applications.

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/ExtractorUtil.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/ExtractorUtil.java
@@ -155,6 +155,7 @@ public final class ExtractorUtil {
       case C.ENCODING_DTS:
         return DtsUtil.DTS_MAX_RATE_BYTES_PER_SECOND;
       case C.ENCODING_DTS_HD:
+      case C.ENCODING_DTS_HD_MA:
       case C.ENCODING_DTS_UHD_P2:
         return DtsUtil.DTS_HD_MAX_RATE_BYTES_PER_SECOND;
       case C.ENCODING_DOLBY_TRUEHD:

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
@@ -2549,7 +2549,7 @@ public class MatroskaExtractor implements Extractor {
           mimeType = MimeTypes.AUDIO_DTS_EXPRESS;
           break;
         case CODEC_ID_DTS_LOSSLESS:
-          mimeType = MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS;
+          mimeType = MimeTypes.AUDIO_MEDIA3_DTS_HD_MA_CORELESS;
           break;
         case CODEC_ID_FLAC:
           mimeType = MimeTypes.AUDIO_FLAC;

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mkv/MatroskaExtractor.java
@@ -2549,7 +2549,7 @@ public class MatroskaExtractor implements Extractor {
           mimeType = MimeTypes.AUDIO_DTS_EXPRESS;
           break;
         case CODEC_ID_DTS_LOSSLESS:
-          mimeType = MimeTypes.AUDIO_DTS_HD;
+          mimeType = MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS;
           break;
         case CODEC_ID_FLAC:
           mimeType = MimeTypes.AUDIO_FLAC;

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
@@ -2128,7 +2128,7 @@ public final class BoxParser {
     } else if (atomType == Mp4Box.TYPE_dtsh) {
       mimeType = MimeTypes.AUDIO_DTS_HD;
     } else if (atomType == Mp4Box.TYPE_dtsl) {
-      mimeType = MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS;
+      mimeType = MimeTypes.AUDIO_MEDIA3_DTS_HD_MA_CORELESS;
     } else if (atomType == Mp4Box.TYPE_dtse) {
       mimeType = MimeTypes.AUDIO_DTS_EXPRESS;
     } else if (atomType == Mp4Box.TYPE_dtsx) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
@@ -2125,8 +2125,10 @@ public final class BoxParser {
       mimeType = MimeTypes.AUDIO_AC4;
     } else if (atomType == Mp4Box.TYPE_dtsc) {
       mimeType = MimeTypes.AUDIO_DTS;
-    } else if (atomType == Mp4Box.TYPE_dtsh || atomType == Mp4Box.TYPE_dtsl) {
+    } else if (atomType == Mp4Box.TYPE_dtsh) {
       mimeType = MimeTypes.AUDIO_DTS_HD;
+    } else if (atomType == Mp4Box.TYPE_dtsl) {
+      mimeType = MimeTypes.AUDIO_EXOPLAYER_DTS_HD_MA_CORELESS;
     } else if (atomType == Mp4Box.TYPE_dtse) {
       mimeType = MimeTypes.AUDIO_DTS_EXPRESS;
     } else if (atomType == Mp4Box.TYPE_dtsx) {

--- a/libraries/inspector/src/main/java/androidx/media3/inspector/MediaExtractorCompatInternal.java
+++ b/libraries/inspector/src/main/java/androidx/media3/inspector/MediaExtractorCompatInternal.java
@@ -72,14 +72,17 @@ import androidx.media3.extractor.SeekPoint;
 import androidx.media3.extractor.TrackAwareSeekMap;
 import androidx.media3.extractor.TrackOutput;
 import androidx.media3.extractor.mp4.PsshAtomUtil;
+import com.google.common.collect.ImmutableSet;
 import java.io.FileDescriptor;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -825,17 +828,19 @@ import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
             mediaExtractorSampleQueue,
             /* isCompatibilityTrack= */ false,
             /* compatibilityTrackMimeType= */ null));
-    @Nullable
-    String compatibilityTrackMimeType =
-        MediaCodecUtil.getAlternativeCodecMimeType(newUpstreamFormat);
-    if (compatibilityTrackMimeType != null) {
-      mediaExtractorSampleQueue.setCompatibilityTrackIndex(tracks.size());
+    List<String> compatibilityTrackMimeTypes =
+        MediaCodecUtil.getAlternativeCodecMimeTypes(newUpstreamFormat);
+    ImmutableSet.Builder<Integer> compatibilityTrackIndicesBuilder = new ImmutableSet.Builder<>();
+    for (String compatibilityTrackMimeType : compatibilityTrackMimeTypes) {
+      compatibilityTrackIndicesBuilder.add(tracks.size());
       tracks.add(
           new MediaExtractorTrack(
               mediaExtractorSampleQueue,
               /* isCompatibilityTrack= */ true,
               compatibilityTrackMimeType));
     }
+    mediaExtractorSampleQueue.setCompatibilityTrackIndices(
+        compatibilityTrackIndicesBuilder.build());
   }
 
   private void maybeResolvePendingSeek() throws IOException {
@@ -969,7 +974,7 @@ import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
     private final int trackId;
     private long trackDurationUs;
     private int mainTrackIndex;
-    private int compatibilityTrackIndex;
+    private Set<Integer> compatibilityTrackIndices;
 
     private MediaExtractorSampleQueue(Allocator allocator, int trackId) {
       // We do not need the sample queue to acquire keys for encrypted samples, so we pass null
@@ -978,15 +983,15 @@ import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
       this.trackId = trackId;
       trackDurationUs = C.TIME_UNSET;
       mainTrackIndex = C.INDEX_UNSET;
-      compatibilityTrackIndex = C.INDEX_UNSET;
+      compatibilityTrackIndices = Collections.emptySet();
     }
 
     private void setMainTrackIndex(int mainTrackIndex) {
       this.mainTrackIndex = mainTrackIndex;
     }
 
-    private void setCompatibilityTrackIndex(int compatibilityTrackIndex) {
-      this.compatibilityTrackIndex = compatibilityTrackIndex;
+    private void setCompatibilityTrackIndices(Set<Integer> compatibilityTrackIndices) {
+      this.compatibilityTrackIndices = compatibilityTrackIndices;
     }
 
     // SampleQueue implementation.
@@ -1028,7 +1033,7 @@ import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
     public String toString() {
       return String.format(
           "trackId: %s, mainTrackIndex: %s, compatibilityTrackIndex: %s",
-          trackId, mainTrackIndex, compatibilityTrackIndex);
+          trackId, mainTrackIndex, compatibilityTrackIndices);
     }
 
     private void queueSampleMetadata(long timeUs, @C.BufferFlags int flags) {
@@ -1038,7 +1043,7 @@ import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
       mediaExtractorFlags |=
           (flags & C.BUFFER_FLAG_KEY_FRAME) != 0 ? MediaExtractor.SAMPLE_FLAG_SYNC : 0;
 
-      if (compatibilityTrackIndex != C.INDEX_UNSET) {
+      for (Integer compatibilityTrackIndex : compatibilityTrackIndices) {
         sampleMetadataQueue.addLast(
             timeUs, /* flags= */ mediaExtractorFlags, compatibilityTrackIndex);
       }

--- a/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_hd_ma.mkv.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_hd_ma.mkv.0.dump
@@ -12,7 +12,7 @@ track 1:
   format 0:
     id = 1
     containerMimeType = video/x-matroska
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     selectionFlags = [default]

--- a/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_hd_ma.mkv.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_hd_ma.mkv.1.dump
@@ -12,7 +12,7 @@ track 1:
   format 0:
     id = 1
     containerMimeType = video/x-matroska
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     selectionFlags = [default]

--- a/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_hd_ma.mkv.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_hd_ma.mkv.2.dump
@@ -12,7 +12,7 @@ track 1:
   format 0:
     id = 1
     containerMimeType = video/x-matroska
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     selectionFlags = [default]

--- a/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_hd_ma.mkv.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_hd_ma.mkv.3.dump
@@ -12,7 +12,7 @@ track 1:
   format 0:
     id = 1
     containerMimeType = video/x-matroska
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     selectionFlags = [default]

--- a/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_hd_ma.mkv.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_hd_ma.mkv.unknown_length.dump
@@ -12,7 +12,7 @@ track 1:
   format 0:
     id = 1
     containerMimeType = video/x-matroska
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     selectionFlags = [default]

--- a/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_x.mkv.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_x.mkv.0.dump
@@ -12,7 +12,7 @@ track 1:
   format 0:
     id = 1
     containerMimeType = video/x-matroska
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     selectionFlags = [default]

--- a/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_x.mkv.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_x.mkv.1.dump
@@ -12,7 +12,7 @@ track 1:
   format 0:
     id = 1
     containerMimeType = video/x-matroska
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     selectionFlags = [default]

--- a/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_x.mkv.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_x.mkv.2.dump
@@ -12,7 +12,7 @@ track 1:
   format 0:
     id = 1
     containerMimeType = video/x-matroska
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     selectionFlags = [default]

--- a/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_x.mkv.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_x.mkv.3.dump
@@ -12,7 +12,7 @@ track 1:
   format 0:
     id = 1
     containerMimeType = video/x-matroska
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     selectionFlags = [default]

--- a/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_x.mkv.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mkv/sample_with_dts_x.mkv.unknown_length.dump
@@ -12,7 +12,7 @@ track 1:
   format 0:
     id = 1
     containerMimeType = video/x-matroska
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     selectionFlags = [default]

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_dts_hd_ma.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_dts_hd_ma.mp4.0.dump
@@ -14,7 +14,7 @@ track 0:
     averageBitrate = 1595470
     id = 1
     containerMimeType = audio/mp4
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     maxInputSize = 2158
     channelCount = 8
     sampleRate = 48000

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_dts_hd_ma.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_dts_hd_ma.mp4.1.dump
@@ -14,7 +14,7 @@ track 0:
     averageBitrate = 1595470
     id = 1
     containerMimeType = audio/mp4
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     maxInputSize = 2158
     channelCount = 8
     sampleRate = 48000

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_dts_hd_ma.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_dts_hd_ma.mp4.2.dump
@@ -14,7 +14,7 @@ track 0:
     averageBitrate = 1595470
     id = 1
     containerMimeType = audio/mp4
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     maxInputSize = 2158
     channelCount = 8
     sampleRate = 48000

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_dts_hd_ma.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_dts_hd_ma.mp4.3.dump
@@ -14,7 +14,7 @@ track 0:
     averageBitrate = 1595470
     id = 1
     containerMimeType = audio/mp4
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     maxInputSize = 2158
     channelCount = 8
     sampleRate = 48000

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_dts_hd_ma.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_dts_hd_ma.mp4.unknown_length.dump
@@ -14,7 +14,7 @@ track 0:
     averageBitrate = 1595470
     id = 1
     containerMimeType = audio/mp4
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     maxInputSize = 2158
     channelCount = 8
     sampleRate = 48000

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_dts_hd_ma.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_dts_hd_ma.mp4.0.dump
@@ -10,7 +10,7 @@ track 0:
   format 0:
     id = 1
     containerMimeType = audio/mp4
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     language = en

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_dts_hd_ma.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_fragmented_dts_hd_ma.mp4.unknown_length.dump
@@ -9,7 +9,7 @@ track 0:
   format 0:
     id = 1
     containerMimeType = audio/mp4
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     language = en

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_across_pes.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_across_pes.ts.0.dump
@@ -10,7 +10,7 @@ track 256:
     averageBitrate = 1536000
     id = 1/256
     containerMimeType = video/mp2t
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     language = en

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_across_pes.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_across_pes.ts.unknown_length.dump
@@ -10,7 +10,7 @@ track 256:
     averageBitrate = 1536000
     id = 1/256
     containerMimeType = video/mp2t
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     language = en

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_ma.ts.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_ma.ts.0.dump
@@ -13,7 +13,7 @@ track 256:
     averageBitrate = 1536000
     id = 1/256
     containerMimeType = video/mp2t
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     language = en

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_ma.ts.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_ma.ts.1.dump
@@ -13,7 +13,7 @@ track 256:
     averageBitrate = 1536000
     id = 1/256
     containerMimeType = video/mp2t
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     language = en

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_ma.ts.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_ma.ts.2.dump
@@ -13,7 +13,7 @@ track 256:
     averageBitrate = 1536000
     id = 1/256
     containerMimeType = video/mp2t
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     language = en

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_ma.ts.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_ma.ts.3.dump
@@ -13,7 +13,7 @@ track 256:
     averageBitrate = 1536000
     id = 1/256
     containerMimeType = video/mp2t
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     language = en

--- a/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_ma.ts.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/ts/sample_dts_hd_ma.ts.unknown_length.dump
@@ -10,7 +10,7 @@ track 256:
     averageBitrate = 1536000
     id = 1/256
     containerMimeType = video/mp2t
-    sampleMimeType = audio/vnd.dts.hd
+    sampleMimeType = audio/vnd.dts.hd;profile=dtsma
     channelCount = 8
     sampleRate = 48000
     language = en

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/SampleExporter.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/SampleExporter.java
@@ -17,7 +17,7 @@
 package androidx.media3.transformer;
 
 import static androidx.media3.common.ColorInfo.isTransferHdr;
-import static androidx.media3.exoplayer.mediacodec.MediaCodecUtil.getAlternativeCodecMimeType;
+import static androidx.media3.exoplayer.mediacodec.MediaCodecUtil.getAlternativeCodecMimeTypes;
 import static androidx.media3.transformer.EncoderUtil.getSupportedEncoders;
 import static androidx.media3.transformer.EncoderUtil.getSupportedEncodersForHdrEditing;
 import static androidx.media3.transformer.TransformerUtil.getProcessedTrackType;
@@ -110,10 +110,12 @@ import java.util.List;
         inputFormat = inputFormat.buildUpon().setMetadata(metadata).build();
       }
       if (!muxerWrapper.supportsSampleMimeType(inputFormat.sampleMimeType)) {
-        String alternativeSampleMimeType = getAlternativeCodecMimeType(inputFormat);
-        if (muxerWrapper.supportsSampleMimeType(alternativeSampleMimeType)) {
-          inputFormat =
-              inputFormat.buildUpon().setSampleMimeType(alternativeSampleMimeType).build();
+        for (String alternativeSampleMimeType : getAlternativeCodecMimeTypes(inputFormat)) {
+          if (muxerWrapper.supportsSampleMimeType(alternativeSampleMimeType)) {
+            inputFormat =
+                inputFormat.buildUpon().setSampleMimeType(alternativeSampleMimeType).build();
+            break;
+          }
         }
       }
       try {

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/TransformerUtil.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/TransformerUtil.java
@@ -18,7 +18,7 @@ package androidx.media3.transformer;
 
 import static androidx.media3.common.ColorInfo.SDR_BT709_LIMITED;
 import static androidx.media3.common.ColorInfo.isTransferHdr;
-import static androidx.media3.exoplayer.mediacodec.MediaCodecUtil.getAlternativeCodecMimeType;
+import static androidx.media3.exoplayer.mediacodec.MediaCodecUtil.getAlternativeCodecMimeTypes;
 import static androidx.media3.transformer.Composition.HDR_MODE_KEEP_HDR;
 import static androidx.media3.transformer.Composition.HDR_MODE_TONE_MAP_HDR_TO_SDR_USING_OPEN_GL;
 import static androidx.media3.transformer.EncoderUtil.getSupportedEncodersForHdrEditing;
@@ -159,15 +159,23 @@ public final class TransformerUtil {
     if (requestedMimeType != null) {
       boolean requestedMimeTypeEqualsPrimaryOrAlternativeMimeType =
           requestedMimeType.equals(inputFormat.sampleMimeType)
-              || requestedMimeType.equals(getAlternativeCodecMimeType(inputFormat));
+              || getAlternativeCodecMimeTypes(inputFormat).contains(requestedMimeType);
       if (!requestedMimeTypeEqualsPrimaryOrAlternativeMimeType) {
         return true;
       }
     }
     if (requestedMimeType == null
-        && !muxerWrapper.supportsSampleMimeType(inputFormat.sampleMimeType)
-        && !muxerWrapper.supportsSampleMimeType(getAlternativeCodecMimeType(inputFormat))) {
-      return true;
+        && !muxerWrapper.supportsSampleMimeType(inputFormat.sampleMimeType)) {
+      boolean supported = false;
+      for (String mimeType : getAlternativeCodecMimeTypes(inputFormat)) {
+        supported = muxerWrapper.supportsSampleMimeType(mimeType);
+        if (supported) {
+          break;
+        }
+      }
+      if (!supported) {
+        return true;
+      }
     }
     if (inputFormat.pixelWidthHeightRatio != 1f) {
       return true;


### PR DESCRIPTION
Android supports a seperate AudioFormat.ENCODING_DTS_HD_MA and a MediaCodec
mime type with ;profile=dtsma since SDK 34, but ExoPlayer wasn't using this
even though the platform docs explicitly say to use the new encoding for
DTS-HD MA. Implement detection of DTS-HD MA and add plumbing to use this
constant where available, and fall back to previous behavior of using
ENCODING_DTS_HD otherwise for backwards compatibility with devices that
weren't updated to support the new constant/MIME type.

DTS-HD MA exists in two versions, in multi-layer version where fallback to
DTS decoders is valid and in a single-layer version where it is not. Add
detection for this and change fallbacks accordingly.

Issue: https://github.com/androidx/media/issues/2487