### PR TITLE
Fix ProgressiveMediaPeriod hang

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ProgressiveMediaPeriod.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/source/ProgressiveMediaPeriod.java
@@ -236,14 +236,15 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     this.progressiveMediaExtractor = progressiveMediaExtractor;
     this.singleSampleDurationUs = singleSampleDurationUs;
     loadCondition = new ConditionVariable();
+    handler = Util.createHandlerForCurrentLooper();
     maybeFinishPrepareRunnable = this::maybeFinishPrepare;
     onContinueLoadingRequestedRunnable =
         () -> {
           if (!released) {
+            handler.post(maybeFinishPrepareRunnable);
             checkNotNull(callback).onContinueLoadingRequested(ProgressiveMediaPeriod.this);
           }
         };
-    handler = Util.createHandlerForCurrentLooper();
     sampleQueueTrackIds = new TrackId[0];
     sampleQueues = new SampleQueue[0];
     controlledTrackOutputs = new ControlledTrackOutput[0];
@@ -725,6 +726,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
         /* mediaStartTimeUs= */ loadable.seekTimeUs,
         durationUs);
     loadingFinished = true;
+    handler.post(maybeFinishPrepareRunnable);
     checkNotNull(callback).onContinueLoadingRequested(this);
   }
 
@@ -907,7 +909,35 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     }
     for (SampleQueue sampleQueue : sampleQueues) {
       if (sampleQueue.getUpstreamFormat() == null) {
-        return;
+        if (loadingFinished) {
+          // File fully exhausted; this track never produced any data.
+        } else if (!loadCondition.isOpen()) {
+          // Loading is paused (e.g. DefaultLoadControl byte budget full). Only assign a
+          // placeholder if at least one real video and one real audio track have already
+          // been seen, confirming this is an extra PMT-declared stream that carries no data
+          // rather than a legitimate track whose format packet hasn't arrived yet.
+          boolean haveVideo = false;
+          boolean haveAudio = false;
+          for (SampleQueue q : sampleQueues) {
+            Format f = q.getUpstreamFormat();
+            if (f == null) {
+              continue;
+            }
+            if (MimeTypes.isVideo(f.sampleMimeType)) {
+              haveVideo = true;
+            } else if (MimeTypes.isAudio(f.sampleMimeType)) {
+              haveAudio = true;
+            }
+          }
+          if (!haveVideo || !haveAudio) {
+            return;
+          }
+        } else {
+          // Actively loading; a format may still arrive from the loading thread.
+          return;
+        }
+        Log.i(TAG, "Empty declared track — assigning placeholder (loadingFinished=" + loadingFinished + "). PATCHED_BUILD_OK");
+        sampleQueue.format(new Format.Builder().build());
       }
     }
     loadCondition.close();


### PR DESCRIPTION
Fix ProgressiveMediaPeriod hang when MPEG-TS PMT declares a track that carries no PES data

  When an MPEG-TS file declares an elementary stream in the PMT but that stream carries zero PES packets (e.g. a "visual impaired commentary" audio service that is listed in the PMT but not actually broadcast), ProgressiveMediaPeriod.maybeFinishPrepare() loops returning early indefinitely because sampleQueue.getUpstreamFormat() == null for that queue. The player times out with StuckPlayerException: Player
  stuck buffering and not loading after 4 seconds. This is a real-world problem with DVB-T2 and ATSC recordings.

  This was previously reported as ExoPlayer#7873 and addressed by ExoPlayer PR#8063 (closed without merge). The bug is unchanged in media3 1.10.1.

  Fix (single file: ProgressiveMediaPeriod.java):

  1. Move handler initialization before the onContinueLoadingRequestedRunnable lambda in the constructor (required by Java's definite-assignment rule for the final field).
  2. In onContinueLoadingRequestedRunnable, post maybeFinishPrepareRunnable before calling callback.onContinueLoadingRequested(). This runnable is posted by the loading thread every 1 MB (the DEFAULT_LOADING_CHECK_INTERVAL_BYTES pacing loop); posting our check first means it runs while loadCondition is still closed and the loading thread is blocked.
  3. In onLoadCompleted(), post maybeFinishPrepareRunnable after setting loadingFinished = true, covering files that reach EOF before the buffer fills.
  4. In maybeFinishPrepare(), replace the unconditional return for a null-format queue with a three-branch guard: (a) if loadingFinished — loading is done, no format will ever arrive; (b) if !loadCondition.isOpen() and at least one real video and one real audio track have reported formats — loading is paused at a checkpoint and the null-format queue is provably an empty PMT-declared track; (c) otherwise —
  still loading, wait. In cases (a) and (b), assign an empty Format.Builder().build() placeholder so preparation can complete on the tracks that do carry data.

  The placeholder has a null sampleMimeType, which DefaultTrackSelector leaves unselected and which trackIsAudioVideoFlags marks false (excluded from buffering calculations). No renderer claims it. The happy path (all queues have formats) is unchanged — maybeFinishPrepare() returns immediately at the prepared guard on any extra invocation.

