### PR TITLE
fix(ttml): TTML/IMSC subtitles not shown when cue timing is on a <div> wrapping the <p>

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -144,6 +144,8 @@
 *   Text:
     *   TTML: Fallback to `displayAlign` from `style` for regions
         ([#2559](https://github.com/androidx/media/issues/2559)).
+    *   TTML: Inherit cue start time from parent of `<p>` elements
+        ([#3246](https://github.com/androidx/media/issues/3246)).
 *   Metadata:
     *   Add `MediaMetadata.discSubtitle` field and parse it from ID3v2.4 `TSST`
         and Vorbis `DISCSUBTITLE` data.

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/ttml/TtmlParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/ttml/TtmlParser.java
@@ -738,6 +738,13 @@ public final class TtmlParser implements SubtitleParser {
     if (parent != null && parent.startTimeUs != C.TIME_UNSET) {
       if (startTime != C.TIME_UNSET) {
         startTime += parent.startTimeUs;
+      } else {
+        // Per TTML2 §12.2.1 and SMIL 3.0 §5.4.3, when `begin` is absent on a timed element
+        // inside a parallel or sequential time container, the implicit value is 0s, which
+        // resolves to the parent's start time. Without this, an element whose timing is
+        // carried by a wrapping ancestor (e.g. a `<p>` inside a `<div begin="…">`) would
+        // keep an unset startTimeUs and never be emitted as a cue.
+        startTime = parent.startTimeUs;
       }
       if (endTime != C.TIME_UNSET) {
         endTime += parent.startTimeUs;

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/text/ttml/TtmlParserTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/text/ttml/TtmlParserTest.java
@@ -44,6 +44,8 @@ public final class TtmlParserTest {
 
   private static final String SIMPLE_TTML_FILE = "media/ttml/simple.xml";
   private static final String OVERLAPPING_TIMES_TTML_FILE = "media/ttml/overlapping_times.xml";
+  private static final String INHERIT_BEGIN_FROM_DIV_TTML_FILE =
+      "media/ttml/inherit_begin_from_div.xml";
   private static final String INLINE_ATTRIBUTES_TTML_FILE =
       "media/ttml/inline_style_attributes.xml";
   private static final String INHERIT_STYLE_TTML_FILE = "media/ttml/inherit_style.xml";
@@ -147,6 +149,49 @@ public final class TtmlParserTest {
     assertThat(fourthCue.startTimeUs).isEqualTo(10_000_000);
     assertThat(fourthCue.endTimeUs).isEqualTo(11_000_000);
     assertThat(fourthCue.cues.stream().map(c -> c.text.toString())).containsExactly("cue 1");
+  }
+
+  @Test
+  public void inheritBeginFromDiv_allCues() throws Exception {
+    // Validates TTML2 §12.2.1 default-`begin`-0s rule: a <p> with no `begin`
+    // inside a timed <div> (a parallel time container) inherits the <div>'s start; previously
+    // such cues were silently dropped (0 cues emitted) by the extraction-time path.
+    //
+    // The single fixture exercises every in-scope <div begin/end>-wraps-<p> variant; expected
+    // cues in time order.
+    ImmutableList<CuesWithTiming> allCues = getAllCues(INHERIT_BEGIN_FROM_DIV_TTML_FILE);
+
+    assertThat(allCues).hasSize(6);
+
+    CuesWithTiming lara = allCues.get(0);
+    assertThat(lara.startTimeUs).isEqualTo(69_583_000);
+    assertThat(lara.endTimeUs).isEqualTo(71_125_000);
+    assertThat(lara.cues.stream().map(c -> c.text.toString())).containsExactly("Lara.");
+
+    CuesWithTiming stil = allCues.get(1);
+    assertThat(stil.startTimeUs).isEqualTo(72_000_000);
+    assertThat(stil.endTimeUs).isEqualTo(74_500_000);
+    assertThat(stil.cues.stream().map(c -> c.text.toString())).containsExactly("Stil.");
+
+    CuesWithTiming offset = allCues.get(2);
+    assertThat(offset.startTimeUs).isEqualTo(122_000_000);
+    assertThat(offset.endTimeUs).isEqualTo(125_000_000);
+    assertThat(offset.cues.stream().map(c -> c.text.toString())).containsExactly("offset");
+
+    CuesWithTiming dur = allCues.get(3);
+    assertThat(dur.startTimeUs).isEqualTo(180_000_000);
+    assertThat(dur.endTimeUs).isEqualTo(184_000_000);
+    assertThat(dur.cues.stream().map(c -> c.text.toString())).containsExactly("dur");
+
+    CuesWithTiming nested = allCues.get(4);
+    assertThat(nested.startTimeUs).isEqualTo(242_000_000);
+    assertThat(nested.endTimeUs).isEqualTo(245_000_000);
+    assertThat(nested.cues.stream().map(c -> c.text.toString())).containsExactly("nested");
+
+    CuesWithTiming bare = allCues.get(5);
+    assertThat(bare.startTimeUs).isEqualTo(300_000_000);
+    assertThat(bare.endTimeUs).isEqualTo(302_000_000);
+    assertThat(bare.cues.stream().map(c -> c.text.toString())).containsExactly("bare");
   }
 
   @Test

--- a/libraries/test_data/src/test/assets/media/ttml/inherit_begin_from_div.xml
+++ b/libraries/test_data/src/test/assets/media/ttml/inherit_begin_from_div.xml
@@ -1,0 +1,44 @@
+<tt xmlns="http://www.w3.org/ns/ttml"
+    xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    ttp:contentProfiles="http://www.w3.org/ns/ttml/profile/imsc1.1/text"
+    xml:lang="en">
+  <head>
+    <styling>
+      <style xml:id="style.center" tts:color="white" tts:textAlign="center"/>
+    </styling>
+    <layout>
+      <region xml:id="region.bottomCenter" tts:origin="10% 80%" tts:extent="80% 15%"/>
+    </layout>
+  </head>
+  <body>
+    <div>
+      <!-- <p> with no timing of its own inside a timed <div>: it uses the div's begin/end -->
+      <div xml:id="d0" style="style.center" begin="00:01:09.583" end="00:01:11.125">
+        <p region="region.bottomCenter">Lara.</p>
+      </div>
+      <div xml:id="d1" style="style.center" begin="00:01:12.000" end="00:01:14.500">
+        <p region="region.bottomCenter">Stil.</p>
+      </div>
+      <!-- <p> with its own begin/end inside a timed <div>: its times are relative to the div -->
+      <div begin="00:02:00.000" end="00:02:30.000">
+        <p begin="00:00:02.000" end="00:00:05.000">offset</p>
+      </div>
+      <!-- <p> with only dur inside a timed <div>: end = the div's start + dur -->
+      <div begin="00:03:00.000" end="00:03:30.000">
+        <p dur="00:00:04.000">dur</p>
+      </div>
+    </div>
+    <!-- nested timed <div>s: the begin offsets add up -->
+    <div begin="00:04:00.000">
+      <div begin="00:00:02.000" end="00:00:05.000">
+        <p>nested</p>
+      </div>
+    </div>
+    <!-- <p> with its own begin/end under an untimed <div>: timed directly, nothing to inherit -->
+    <div>
+      <p begin="00:05:00.000" end="00:05:02.000">bare</p>
+    </div>
+  </body>
+</tt>


### PR DESCRIPTION
Inherit `begin` from a timed parent in TtmlParser

Fixes #3246

## Summary

TTML/IMSC subtitles are not shown when the cue timing is carried on a `<div>` that wraps the
`<p>` (the `<p>` itself has no `begin`/`end`). `TtmlParser.parseNode` inherits `end` from a
timed parent but not `begin`, so the `<p>`'s `startTimeUs` is left unset and the cue is dropped
(extraction-time path) or rendered from t=0 (legacy decoder path).

This change inherits the parent's resolved start time when the child's own `begin` is absent,
matching the TTML2 default-`begin`-of-0s rule.

## Why this is a bug (spec)

* `<div>` is a parallel time container by default (TTML2 §8.1.4).
* A child element with no `begin` defaults to `begin = 0s` relative to its nearest time
  container (TTML2 §12.2.1, citing SMIL 3.0 §5.4.3) — i.e. it inherits the container's start.
* Nested `<div>` is valid in the IMSC1.1 Text profile (IMSC1.1 §6 feature table, `#nested-div`).

So a `<p>` inside `<div begin="..." end="...">` must present at the `<div>`'s interval. This
shape is produced by real authoring tools (e.g. AWS MediaConvert IMSC output).

## Root cause

In `TtmlParser.parseNode`, after the parent-offset block:

* `end` is inherited from `parent.endTimeUs` when unset, but
* `start` is **not** inherited from `parent.startTimeUs` when unset.

Consequences with `startTimeUs` left unset:

* `LegacySubtitleUtil#toCuesWithTiming` (extraction-time path) registers no start event for the
  cue → **0 cues emitted**.
* `TtmlNode#isActive` returns `true` for an unset start → cue is **active from t=0** (out of
  sync) on the legacy `TtmlDecoder` path.

## The change

`libraries/extractor/.../ttml/TtmlParser.java` — add, after the parent-offset block and before
the `dur`→`end` computation:

```java
if (startTime == C.TIME_UNSET && parent != null && parent.startTimeUs != C.TIME_UNSET) {
  startTime = parent.startTimeUs;
}
```

Placement matters: resolving `start` before the `dur`→`end` step means a `<p dur="...">` inside
a timed `<div>` still computes `end = start + dur` correctly. Nested timed `<div>`s continue to
compound additively, and a plain `<p begin/end>` is unaffected.

## Testing

`libraries/extractor/.../ttml/TtmlParserTest.java` + one new fixture
`libraries/test_data/.../media/ttml/inherit_begin_from_div.xml`.

A single fixture exercises every in-scope `<div begin/end>`-wraps-`<p>` variant; the test
`inheritBeginFromDiv_allCues` asserts the full ordered cue list:

| Cue | Interval | Variant |
|---|---|---|
| `Lara.` | [69.583s, 71.125s) | timed div wraps untimed p |
| `Stil.` | [72.000s, 74.500s) | sibling timed div wraps untimed p |
| `offset` | [122.000s, 125.000s) | p own begin/end as offsets within the timed div |
| `dur` | [180.000s, 184.000s) | p with only dur inherits div start, end = start + dur |
| `nested` | [242.000s, 245.000s) | nested timed divs compound additively |
| `bare` | [300.000s, 302.000s) | plain `<p begin/end>` (regression guard) |

Full `androidx.media3.extractor.text.ttml.*` unit tests pass (TtmlParserTest, TextEmphasisTest,
TtmlRenderUtilTest, TtmlStyleTest) — 0 failures.

```shell
./gradlew :lib-extractor:testDebugUnitTest --tests "androidx.media3.extractor.text.ttml.*"
```

## Out of scope (noted for maintainers)

* `timeContainer="seq"` resolution is not implemented (still treated as `par`). Out of scope
  for this fix; EBU-TT-D — of which IMSC Text is a syntactic superset — forbids `seq`.
* A `<p dur="...">` with no `begin` on any ancestor remains a pre-existing edge case (unset
  start). Not addressed here to keep the change focused on the reported `<div>`-wraps-`<p>` case.

## Checklist

- [x] CLA signed
- [x] "Allow edits from maintainers" enabled on the PR
- [x] `google-java-format` applied to the diff
