### PR TITLE
fix(dash): ignore presentationTimeOffset for standalone text

### DIFF
--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/DashManifestParser.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/DashManifestParser.java
@@ -977,10 +977,9 @@ public class DashManifestParser extends DefaultHandler
     }
     ArrayList<Descriptor> inbandEventStreams = representationInfo.inbandEventStreams;
     inbandEventStreams.addAll(extraInbandEventStreams);
-    Format format = formatBuilder.build();
     return Representation.newInstance(
         representationInfo.revisionId,
-        format,
+        formatBuilder.build(),
         representationInfo.baseUrls,
         representationInfo.segmentBase,
         inbandEventStreams,

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/DashManifestParser.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/DashManifestParser.java
@@ -862,6 +862,11 @@ public class DashManifestParser extends DefaultHandler
             essentialProperties,
             supplementalProperties);
     segmentBase = segmentBase != null ? segmentBase : new SingleSegmentBase();
+    if (isStandaloneTextRepresentation(format) && segmentBase.presentationTimeOffset != 0) {
+      // DASH-IF IOP "Standalone Text Timing": @presentationTimeOffset SHALL be ignored for
+      // standalone text. See https://dashif.org/Guidelines-TimingModel/#standalone-text-timing
+      segmentBase = segmentBase.copyWithPresentationTimeOffset(0);
+    }
 
     return new RepresentationInfo(
         format,
@@ -973,26 +978,15 @@ public class DashManifestParser extends DefaultHandler
     ArrayList<Descriptor> inbandEventStreams = representationInfo.inbandEventStreams;
     inbandEventStreams.addAll(extraInbandEventStreams);
     Format format = formatBuilder.build();
-    SegmentBase segmentBase = representationInfo.segmentBase;
-    // DASH-IF IOP "Standalone Text Timing": @presentationTimeOffset SHALL NOT be present and SHALL
-    // be ignored by clients if present.
-    // https://dashif.org/Guidelines-TimingModel/#standalone-text-timing
-    if (isStandaloneTextRepresentation(format) && segmentBase.presentationTimeOffset != 0) {
-      segmentBase = segmentBase.copyWithPresentationTimeOffset(0);
-    }
     return Representation.newInstance(
         representationInfo.revisionId,
         format,
         representationInfo.baseUrls,
-        segmentBase,
+        representationInfo.segmentBase,
         inbandEventStreams,
         representationInfo.essentialProperties,
         representationInfo.supplementalProperties,
         /* cacheKey= */ null);
-  }
-
-  private static boolean isStandaloneTextRepresentation(Format format) {
-    return format.containerMimeType != null && MimeTypes.isText(format.containerMimeType);
   }
 
   // SegmentBase, SegmentList and SegmentTemplate parsing.
@@ -2239,6 +2233,10 @@ public class DashManifestParser extends DefaultHandler
       }
     }
     return false;
+  }
+
+  private static boolean isStandaloneTextRepresentation(Format format) {
+    return format.containerMimeType != null && MimeTypes.isText(format.containerMimeType);
   }
 
   /** A parsed Representation element. */

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/DashManifestParser.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/DashManifestParser.java
@@ -972,15 +972,27 @@ public class DashManifestParser extends DefaultHandler
     }
     ArrayList<Descriptor> inbandEventStreams = representationInfo.inbandEventStreams;
     inbandEventStreams.addAll(extraInbandEventStreams);
+    Format format = formatBuilder.build();
+    SegmentBase segmentBase = representationInfo.segmentBase;
+    // DASH-IF IOP "Standalone Text Timing": @presentationTimeOffset SHALL NOT be present and SHALL
+    // be ignored by clients if present.
+    // https://dashif.org/Guidelines-TimingModel/#standalone-text-timing
+    if (isStandaloneTextRepresentation(format) && segmentBase.presentationTimeOffset != 0) {
+      segmentBase = segmentBase.copyWithPresentationTimeOffset(0);
+    }
     return Representation.newInstance(
         representationInfo.revisionId,
-        formatBuilder.build(),
+        format,
         representationInfo.baseUrls,
-        representationInfo.segmentBase,
+        segmentBase,
         inbandEventStreams,
         representationInfo.essentialProperties,
         representationInfo.supplementalProperties,
         /* cacheKey= */ null);
+  }
+
+  private static boolean isStandaloneTextRepresentation(Format format) {
+    return format.containerMimeType != null && MimeTypes.isText(format.containerMimeType);
   }
 
   // SegmentBase, SegmentList and SegmentTemplate parsing.

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/SegmentBase.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/SegmentBase.java
@@ -72,6 +72,12 @@ public abstract class SegmentBase {
     return Util.scaleLargeTimestamp(presentationTimeOffset, C.MICROS_PER_SECOND, timescale);
   }
 
+  /**
+   * Returns a copy of this {@link SegmentBase} with its presentation time offset replaced by {@code
+   * newPresentationTimeOffset}.
+   */
+  public abstract SegmentBase copyWithPresentationTimeOffset(long newPresentationTimeOffset);
+
   /** A {@link SegmentBase} that defines a single segment. */
   public static class SingleSegmentBase extends SegmentBase {
 
@@ -113,6 +119,12 @@ public abstract class SegmentBase {
           ? null
           : new RangedUri(/* referenceUri= */ null, indexStart, indexLength);
     }
+
+    @Override
+    public SingleSegmentBase copyWithPresentationTimeOffset(long newPresentationTimeOffset) {
+      return new SingleSegmentBase(
+          initialization, timescale, newPresentationTimeOffset, indexStart, indexLength);
+    }
   }
 
   /** A {@link SegmentBase} that consists of multiple segments. */
@@ -121,8 +133,8 @@ public abstract class SegmentBase {
     /* package */ final long startNumber;
     /* package */ final long duration;
     @Nullable /* package */ final List<SegmentTimelineElement> segmentTimeline;
-    private final long timeShiftBufferDepthUs;
-    private final long periodStartUnixTimeUs;
+    /* package */ final long timeShiftBufferDepthUs;
+    /* package */ final long periodStartUnixTimeUs;
 
     /**
      * Offset to the current realtime at which segments become available, in microseconds, or {@link
@@ -363,6 +375,21 @@ public abstract class SegmentBase {
     public boolean isExplicit() {
       return true;
     }
+
+    @Override
+    public SegmentList copyWithPresentationTimeOffset(long newPresentationTimeOffset) {
+      return new SegmentList(
+          initialization,
+          timescale,
+          newPresentationTimeOffset,
+          startNumber,
+          duration,
+          segmentTimeline,
+          availabilityTimeOffsetUs,
+          mediaSegments,
+          timeShiftBufferDepthUs,
+          periodStartUnixTimeUs);
+    }
   }
 
   /** A {@link MultiSegmentBase} that uses a SegmentTemplate to define its segments. */
@@ -469,6 +496,23 @@ public abstract class SegmentBase {
       } else {
         return INDEX_UNBOUNDED;
       }
+    }
+
+    @Override
+    public SegmentTemplate copyWithPresentationTimeOffset(long newPresentationTimeOffset) {
+      return new SegmentTemplate(
+          initialization,
+          timescale,
+          newPresentationTimeOffset,
+          startNumber,
+          endNumber,
+          duration,
+          segmentTimeline,
+          availabilityTimeOffsetUs,
+          initializationTemplate,
+          mediaTemplate,
+          timeShiftBufferDepthUs,
+          periodStartUnixTimeUs);
     }
   }
 

--- a/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/manifest/DashManifestParserTest.java
+++ b/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/manifest/DashManifestParserTest.java
@@ -29,6 +29,7 @@ import androidx.media3.common.ParserException;
 import androidx.media3.common.util.Util;
 import androidx.media3.datasource.DataSourceInputStream;
 import androidx.media3.datasource.DataSpec;
+import androidx.media3.exoplayer.dash.DashSegmentIndex;
 import androidx.media3.exoplayer.dash.manifest.Representation.MultiSegmentRepresentation;
 import androidx.media3.exoplayer.dash.manifest.Representation.SingleSegmentRepresentation;
 import androidx.media3.exoplayer.dash.manifest.SegmentBase.SegmentTimelineElement;
@@ -67,6 +68,8 @@ public class DashManifestParserTest {
   private static final String SAMPLE_MPD_LABELS = "media/mpd/sample_mpd_labels";
   private static final String SAMPLE_MPD_ASSET_IDENTIFIER = "media/mpd/sample_mpd_asset_identifier";
   private static final String SAMPLE_MPD_TEXT = "media/mpd/sample_mpd_text";
+  private static final String SAMPLE_MPD_TEXT_PRESENTATION_TIME_OFFSET =
+      "media/mpd/sample_mpd_text_presentation_time_offset";
   private static final String SAMPLE_MPD_TRICK_PLAY = "media/mpd/sample_mpd_trick_play";
   private static final String SAMPLE_MPD_ESSENTIAL_SUPPLEMENTAL_PROPERTIES =
       "media/mpd/sample_mpd_essential_supplemental_properties";
@@ -370,6 +373,44 @@ public class DashManifestParserTest {
     assertThat(format.codecs).isNull();
     assertThat(format.roleFlags).isEqualTo(0);
     assertThat(adaptationSets.get(2).type).isEqualTo(C.TRACK_TYPE_TEXT);
+  }
+
+  // DASH-IF "Standalone Text Timing": @presentationTimeOffset SHALL NOT be present and SHALL be
+  // ignored by clients if present.
+  // https://dashif.org/Guidelines-TimingModel/#standalone-text-timing
+  @Test
+  public void parseMediaPresentationDescription_standaloneTextIgnoresPresentationTimeOffset()
+      throws IOException {
+    DashManifestParser parser = new DashManifestParser();
+    DashManifest manifest =
+        parser.parse(
+            Uri.parse("https://example.com/test.mpd"),
+            TestUtil.getInputStream(
+                ApplicationProvider.getApplicationContext(),
+                SAMPLE_MPD_TEXT_PRESENTATION_TIME_OFFSET));
+
+    List<AdaptationSet> adaptationSets = manifest.getPeriod(0).adaptationSets;
+
+    // Standalone TTML - @presentationTimeOffset must be ignored.
+    Representation ttmlRepresentation = adaptationSets.get(0).representations.get(0);
+    assertThat(ttmlRepresentation.format.containerMimeType).isEqualTo(MimeTypes.APPLICATION_TTML);
+    assertThat(ttmlRepresentation.presentationTimeOffsetUs).isEqualTo(0);
+    DashSegmentIndex ttmlIndex = ((MultiSegmentRepresentation) ttmlRepresentation);
+    assertThat(ttmlIndex.getTimeUs(ttmlIndex.getFirstSegmentNum())).isEqualTo(2_000_000);
+
+    // Standalone WebVTT - @presentationTimeOffset must be ignored.
+    Representation vttRepresentation = adaptationSets.get(1).representations.get(0);
+    assertThat(vttRepresentation.format.containerMimeType).isEqualTo(MimeTypes.TEXT_VTT);
+    assertThat(vttRepresentation.presentationTimeOffsetUs).isEqualTo(0);
+    DashSegmentIndex vttIndex = ((MultiSegmentRepresentation) vttRepresentation);
+    assertThat(vttIndex.getTimeUs(vttIndex.getFirstSegmentNum())).isEqualTo(3_000_000);
+
+    // Muxed text in mp4 - @presentationTimeOffset must be honored.
+    Representation mp4Representation = adaptationSets.get(2).representations.get(0);
+    assertThat(mp4Representation.format.containerMimeType).isEqualTo(MimeTypes.APPLICATION_MP4);
+    assertThat(mp4Representation.presentationTimeOffsetUs).isEqualTo(5_000_000);
+    DashSegmentIndex mp4Index = ((MultiSegmentRepresentation) mp4Representation);
+    assertThat(mp4Index.getTimeUs(mp4Index.getFirstSegmentNum())).isEqualTo(0);
   }
 
   @Test

--- a/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/manifest/DashManifestParserTest.java
+++ b/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/manifest/DashManifestParserTest.java
@@ -375,12 +375,12 @@ public class DashManifestParserTest {
     assertThat(adaptationSets.get(2).type).isEqualTo(C.TRACK_TYPE_TEXT);
   }
 
-  // DASH-IF "Standalone Text Timing": @presentationTimeOffset SHALL NOT be present and SHALL be
-  // ignored by clients if present.
-  // https://dashif.org/Guidelines-TimingModel/#standalone-text-timing
   @Test
   public void parseMediaPresentationDescription_standaloneTextIgnoresPresentationTimeOffset()
       throws IOException {
+    // DASH-IF "Standalone Text Timing": @presentationTimeOffset SHALL NOT be present and SHALL be
+    // ignored by clients if present.
+    // https://dashif.org/Guidelines-TimingModel/#standalone-text-timing
     DashManifestParser parser = new DashManifestParser();
     DashManifest manifest =
         parser.parse(

--- a/libraries/test_data/src/test/assets/media/mpd/sample_mpd_text_presentation_time_offset
+++ b/libraries/test_data/src/test/assets/media/mpd/sample_mpd_text_presentation_time_offset
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD type="static" mediaPresentationDuration="PT10S">
+ <Period>
+  <!-- Standalone TTML with @presentationTimeOffset. Per DASH-IF Standalone Text Timing
+       (https://dashif.org/Guidelines-TimingModel/#standalone-text-timing), the offset SHALL be
+       ignored by clients. -->
+  <AdaptationSet id="0" mimeType="application/ttml+xml" subsegmentAlignment="true">
+   <SegmentTemplate timescale="1000" presentationTimeOffset="2000" startNumber="0" media="ttml/$Number$">
+    <SegmentTimeline>
+     <S t="2000" d="10000"/>
+    </SegmentTimeline>
+   </SegmentTemplate>
+   <Representation id="0" bandwidth="16">
+    <BaseURL>https://test.com/0</BaseURL>
+   </Representation>
+  </AdaptationSet>
+  <!-- Standalone WebVTT with @presentationTimeOffset. Must also be ignored. -->
+  <AdaptationSet id="1" mimeType="text/vtt" subsegmentAlignment="true">
+   <SegmentTemplate timescale="1000" presentationTimeOffset="3000" startNumber="0" media="vtt/$Number$">
+    <SegmentTimeline>
+     <S t="3000" d="10000"/>
+    </SegmentTimeline>
+   </SegmentTemplate>
+   <Representation id="1" bandwidth="16">
+    <BaseURL>https://test.com/1</BaseURL>
+   </Representation>
+  </AdaptationSet>
+  <!-- TTML muxed inside mp4. This is NOT standalone text and @presentationTimeOffset must be
+       honored. -->
+  <AdaptationSet id="2" mimeType="application/mp4" subsegmentAlignment="true">
+   <SegmentTemplate timescale="1000" presentationTimeOffset="5000" startNumber="0" media="mp4/$Number$">
+    <SegmentTimeline>
+     <S t="5000" d="10000"/>
+    </SegmentTimeline>
+   </SegmentTemplate>
+   <Representation id="2" codecs="stpp.ttml.im1t" bandwidth="16">
+    <BaseURL>https://test.com/2</BaseURL>
+   </Representation>
+  </AdaptationSet>
+ </Period>
+</MPD>


### PR DESCRIPTION
## Summary

Standalone text Representations (TTML / WebVTT / SubRip etc. that are not muxed into MP4) currently apply the manifest's `@presentationTimeOffset`, causing subtitle timings to be shifted by the offset.

[DASH-IF IOP Guidelines, "Standalone Text Timing"](https://dashif.org/Guidelines-TimingModel/#standalone-text-timing) state:

> @presentationTimeOffset SHALL NOT be present and SHALL be ignored by clients if present.

This PR makes the parser ignore `@presentationTimeOffset` for standalone text Representations, while continuing to apply it to muxed text (in `application/mp4`) and other media types.

## Changes

- `SegmentBase`: add abstract `copyWithPresentationTimeOffset(long)` and implement it in `SingleSegmentBase` / `SegmentList` / `SegmentTemplate`. Two `MultiSegmentBase` fields needed to be lowered from `private` to package-private so subclass copies can pass them through.
- `DashManifestParser.buildRepresentation`: when the Representation's `containerMimeType` is a text type (i.e. not `application/mp4`), replace its `SegmentBase` with one whose `presentationTimeOffset` is `0`. This zeros out both `Representation.presentationTimeOffsetUs` and the PTO subtraction in `SegmentBase.getSegmentTimeUs`, making the behavior compliant.
- Muxed text in MP4 and other media types are unaffected.

## Test plan

Added `DashManifestParserTest.parseMediaPresentationDescription_standaloneTextIgnoresPresentationTimeOffset` with a manifest containing three Representations sharing the same period and non-zero `@presentationTimeOffset`:

- [x] Standalone TTML (`application/ttml+xml`, PTO=2000/1000s) → `presentationTimeOffsetUs == 0`, first segment time = `@t` directly (2,000,000us).
- [x] Standalone WebVTT (`text/vtt`, PTO=3000/1000s) → `presentationTimeOffsetUs == 0`, first segment time = 3,000,000us.
- [x] Muxed TTML in MP4 (`application/mp4` + `stpp.ttml.im1t`, PTO=5000/1000s) → `presentationTimeOffsetUs == 5,000,000us`, first segment time = `@t - PTO = 0`.
- [x] Full `:lib-exoplayer-dash:testDebugUnitTest` suite passes with no regressions.