### PR TITLE
EAC3-JOC MIME type should not be taken as EAC3 on Pixel Device

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
@@ -378,7 +378,9 @@ public final class MediaCodecUtil {
   public static String getAlternativeCodecMimeType(Format format) {
     if (MimeTypes.AUDIO_E_AC3_JOC.equals(format.sampleMimeType)) {
       // E-AC3 decoders can decode JOC streams, but in 2-D rather than 3-D.
-      return MimeTypes.AUDIO_E_AC3;
+      // Some devices (e.g. Pixel) integrate an EAC3 decoder that does not support EAC3-JOC
+      // stream decoding.
+      return supportsEac3JocFallbackDecoding() ? MimeTypes.AUDIO_E_AC3 : null;
     }
     if (MimeTypes.AUDIO_DTS_HD.equals(format.sampleMimeType)
         || MimeTypes.AUDIO_DTS_UHD_P2.equals(format.sampleMimeType)) {
@@ -418,6 +420,25 @@ public final class MediaCodecUtil {
   }
 
   // Internal methods.
+
+  /**
+   * Returns whether the device supports decoding E-AC3 JOC streams using a standard E-AC3 decoder
+   * (in 2-D rather than 3-D).
+   *
+   * <p>Some devices (e.g. Pixel) have an E-AC3 decoder that cannot handle E-AC3 JOC streams at
+   * all, even in degraded 2-D mode.
+   */
+  private static boolean supportsEac3JocFallbackDecoding() {
+    String manufacturer = Build.MANUFACTURER;
+    String brand = Build.BRAND;
+    String model = Build.MODEL;
+
+    boolean isGoogle =
+        "Google".equalsIgnoreCase(manufacturer) && "google".equalsIgnoreCase(brand);
+    boolean isPixelModel = model != null && model.startsWith("Pixel");
+
+    return !(isGoogle && isPixelModel);
+  }
 
   /**
    * Returns {@link MediaCodecInfo}s for the given codec {@link CodecKey} in the order given by


### PR DESCRIPTION
Pixel devices integrate an EAC3 decoder, but it does not support EAC3-JOC stream decoding. If there is a manifest file includes one AAC 2.0 track and one EAC3-JOC track.

- Without this PR, EAC3-JOC track is selected since channel count DD+JOC > AAC. Then playback failed.
- With this PR, AAC is the only MIME type that DUT can support so that AAC track is selected. Playback is OK.

Note: Pixel devices integrate EAC3 decoder but cannot handle EAC3-JOC stream. -- This is a product decision rather than technical limitation. 
