### PR TITLE
Fix HLS download failure when EXT-X-DEFINE variables are referenced in media playlist segment URLs

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/SegmentDownloader.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/offline/SegmentDownloader.java
@@ -406,6 +406,20 @@ public abstract class SegmentDownloader<M extends FilterableManifest<M>> impleme
         removing);
   }
 
+  protected final M getManifest(DataSource dataSource, DataSpec dataSpec, boolean removing, Parser<M> manifestParser)
+      throws InterruptedException, IOException {
+    return execute(
+        () ->
+            new RunnableFutureTask<M, IOException>() {
+              @Override
+              protected M doWork() throws IOException {
+                return ParsingLoadable.load(
+                    dataSource, manifestParser, dataSpec, C.DATA_TYPE_MANIFEST);
+              }
+            },
+        removing);
+  }
+
   /**
    * Executes the provided {@link RunnableFutureTask}.
    *

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/offline/HlsDownloader.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/offline/HlsDownloader.java
@@ -233,7 +233,7 @@ public final class HlsDownloader extends SegmentDownloader<HlsPlaylist> {
     // When the multivariant playlist defines variables, create a parser that propagates
     // them to child manifests for IMPORT resolution. Otherwise use the default path.
     boolean hasVariables = !multivariantPlaylist.variableDefinitions.isEmpty();
-    @Nullable HlsPlaylistParser childManifestParser = hasVariables
+    @Nullable HlsPlaylistParser mediaPlaylistParser = hasVariables
         ? new HlsPlaylistParser(multivariantPlaylist, /* previousMediaPlaylist= */ null)
         : null;
 
@@ -243,11 +243,9 @@ public final class HlsDownloader extends SegmentDownloader<HlsPlaylist> {
       segments.add(new Segment(/* startTimeUs= */ 0, mediaPlaylistDataSpec));
       HlsMediaPlaylist mediaPlaylist;
       try {
-        if (childManifestParser != null) {
-          mediaPlaylist =
-              (HlsMediaPlaylist)
-                  ParsingLoadable.load(
-                      dataSource, childManifestParser, mediaPlaylistDataSpec, C.DATA_TYPE_MANIFEST);
+        if (mediaPlaylistParser != null) {
+          mediaPlaylist = (HlsMediaPlaylist) getManifest(dataSource, mediaPlaylistDataSpec,
+              removing, mediaPlaylistParser);
         } else {
           mediaPlaylist = (HlsMediaPlaylist) getManifest(dataSource, mediaPlaylistDataSpec,
               removing);

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/offline/HlsDownloader.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/offline/HlsDownloader.java
@@ -29,7 +29,6 @@ import androidx.media3.exoplayer.hls.playlist.HlsMultivariantPlaylist;
 import androidx.media3.exoplayer.hls.playlist.HlsPlaylist;
 import androidx.media3.exoplayer.hls.playlist.HlsPlaylistParser;
 import androidx.media3.exoplayer.offline.SegmentDownloader;
-import androidx.media3.exoplayer.upstream.ParsingLoadable;
 import androidx.media3.exoplayer.upstream.ParsingLoadable.Parser;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/offline/HlsDownloader.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/offline/HlsDownloader.java
@@ -29,6 +29,7 @@ import androidx.media3.exoplayer.hls.playlist.HlsMultivariantPlaylist;
 import androidx.media3.exoplayer.hls.playlist.HlsPlaylist;
 import androidx.media3.exoplayer.hls.playlist.HlsPlaylistParser;
 import androidx.media3.exoplayer.offline.SegmentDownloader;
+import androidx.media3.exoplayer.upstream.ParsingLoadable;
 import androidx.media3.exoplayer.upstream.ParsingLoadable.Parser;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
@@ -220,13 +221,21 @@ public final class HlsDownloader extends SegmentDownloader<HlsPlaylist> {
   protected List<Segment> getSegments(DataSource dataSource, HlsPlaylist manifest, boolean removing)
       throws IOException, InterruptedException {
     ArrayList<DataSpec> mediaPlaylistDataSpecs = new ArrayList<>();
+    HlsMultivariantPlaylist multivariantPlaylist = HlsMultivariantPlaylist.EMPTY;
     if (manifest instanceof HlsMultivariantPlaylist) {
-      HlsMultivariantPlaylist multivariantPlaylist = (HlsMultivariantPlaylist) manifest;
+      multivariantPlaylist = (HlsMultivariantPlaylist) manifest;
       addMediaPlaylistDataSpecs(multivariantPlaylist.mediaPlaylistUrls, mediaPlaylistDataSpecs);
     } else {
       mediaPlaylistDataSpecs.add(
           SegmentDownloader.getCompressibleDataSpec(Uri.parse(manifest.baseUri)));
     }
+
+    // When the multivariant playlist defines variables, create a parser that propagates
+    // them to child manifests for IMPORT resolution. Otherwise use the default path.
+    boolean hasVariables = !multivariantPlaylist.variableDefinitions.isEmpty();
+    @Nullable HlsPlaylistParser childManifestParser = hasVariables
+        ? new HlsPlaylistParser(multivariantPlaylist, /* previousMediaPlaylist= */ null)
+        : null;
 
     ArrayList<Segment> segments = new ArrayList<>();
     HashSet<Uri> seenEncryptionKeyUris = new HashSet<>();
@@ -234,7 +243,15 @@ public final class HlsDownloader extends SegmentDownloader<HlsPlaylist> {
       segments.add(new Segment(/* startTimeUs= */ 0, mediaPlaylistDataSpec));
       HlsMediaPlaylist mediaPlaylist;
       try {
-        mediaPlaylist = (HlsMediaPlaylist) getManifest(dataSource, mediaPlaylistDataSpec, removing);
+        if (childManifestParser != null) {
+          mediaPlaylist =
+              (HlsMediaPlaylist)
+                  ParsingLoadable.load(
+                      dataSource, childManifestParser, mediaPlaylistDataSpec, C.DATA_TYPE_MANIFEST);
+        } else {
+          mediaPlaylist = (HlsMediaPlaylist) getManifest(dataSource, mediaPlaylistDataSpec,
+              removing);
+        }
       } catch (IOException e) {
         if (!removing) {
           throw e;

--- a/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/offline/HlsDownloaderTest.java
+++ b/libraries/exoplayer_hls/src/test/java/androidx/media3/exoplayer/hls/offline/HlsDownloaderTest.java
@@ -290,6 +290,128 @@ public class HlsDownloaderTest {
     assertCachedData(cache, fakeDataSet);
   }
 
+  @Test
+  public void download_withVariableSubstitutionInSegmentUrls_resolvesVariables() throws Exception {
+    // Multivariant playlist defines a variable via EXT-X-DEFINE NAME/VALUE
+    byte[] multivariantPlaylistData =
+        ("#EXTM3U\n"
+                + "#EXT-X-DEFINE:NAME=\"cdnPrefix\",VALUE=\"https://cdn.example.com/\"\n"
+                + "#EXT-X-STREAM-INF:BANDWIDTH=232370,CODECS=\"mp4a.40.2, avc1.4d4015\"\n"
+                + "media_with_vars.m3u8\n")
+            .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+    // Media playlist uses the variable in segment URLs with IMPORT
+    byte[] mediaPlaylistData =
+        ("#EXTM3U\n"
+                + "#EXT-X-TARGETDURATION:10\n"
+                + "#EXT-X-VERSION:8\n"
+                + "#EXT-X-MEDIA-SEQUENCE:0\n"
+                + "#EXT-X-PLAYLIST-TYPE:VOD\n"
+                + "#EXT-X-DEFINE:IMPORT=\"cdnPrefix\"\n"
+                + "#EXTINF:9.97667,\n"
+                + "{$cdnPrefix}segment0.ts\n"
+                + "#EXTINF:9.97667,\n"
+                + "{$cdnPrefix}segment1.ts\n"
+                + "#EXT-X-ENDLIST")
+            .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+    fakeDataSet =
+        new FakeDataSet()
+            .setData("master_vars.m3u8", multivariantPlaylistData)
+            .setData("media_with_vars.m3u8", mediaPlaylistData)
+            .setRandomData("https://cdn.example.com/segment0.ts", 10)
+            .setRandomData("https://cdn.example.com/segment1.ts", 11);
+
+    HlsDownloader downloader = getHlsDownloader("master_vars.m3u8", getKeys(0));
+    downloader.download(progressListener);
+
+    // Verify segments were downloaded with resolved URLs
+    assertCachedData(cache, fakeDataSet);
+  }
+
+  @Test
+  public void download_withMultipleVariablesInSegmentUrls_resolvesAllVariables() throws Exception {
+    // Multivariant playlist defines multiple variables
+    byte[] multivariantPlaylistData =
+        ("#EXTM3U\n"
+                + "#EXT-X-DEFINE:NAME=\"contentPrefix\",VALUE=\"https://media.example.com/\"\n"
+                + "#EXT-X-DEFINE:NAME=\"sessionId\",VALUE=\"abc123\"\n"
+                + "#EXT-X-STREAM-INF:BANDWIDTH=500000,CODECS=\"avc1.4d401f,mp4a.40.2\"\n"
+                + "{$contentPrefix}video/720p.m3u8?sid={$sessionId}\n")
+            .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+    // Media playlist imports and uses both variables
+    byte[] mediaPlaylistData =
+        ("#EXTM3U\n"
+                + "#EXT-X-TARGETDURATION:6\n"
+                + "#EXT-X-VERSION:8\n"
+                + "#EXT-X-MEDIA-SEQUENCE:0\n"
+                + "#EXT-X-PLAYLIST-TYPE:VOD\n"
+                + "#EXT-X-DEFINE:IMPORT=\"contentPrefix\"\n"
+                + "#EXT-X-DEFINE:IMPORT=\"sessionId\"\n"
+                + "#EXTINF:6.0,\n"
+                + "{$contentPrefix}seg/s0.ts?sid={$sessionId}\n"
+                + "#EXTINF:6.0,\n"
+                + "{$contentPrefix}seg/s1.ts?sid={$sessionId}\n"
+                + "#EXT-X-ENDLIST")
+            .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+    fakeDataSet =
+        new FakeDataSet()
+            .setData("master_multi_vars.m3u8", multivariantPlaylistData)
+            .setData(
+                "https://media.example.com/video/720p.m3u8?sid=abc123", mediaPlaylistData)
+            .setRandomData(
+                "https://media.example.com/seg/s0.ts?sid=abc123", 10)
+            .setRandomData(
+                "https://media.example.com/seg/s1.ts?sid=abc123", 11);
+
+    HlsDownloader downloader = getHlsDownloader("master_multi_vars.m3u8", getKeys(0));
+    downloader.download(progressListener);
+
+    assertCachedData(cache, fakeDataSet);
+  }
+
+  @Test
+  public void download_withVariableInChildManifestUri_resolvesVariables() throws Exception {
+    // Multivariant playlist uses variable in the child manifest URI itself
+    byte[] multivariantPlaylistData =
+        ("#EXTM3U\n"
+                + "#EXT-X-DEFINE:NAME=\"manifestBase\",VALUE=\"https://manifest.example.com/\"\n"
+                + "#EXT-X-DEFINE:NAME=\"segmentBase\",VALUE=\"https://segments.example.com/\"\n"
+                + "#EXT-X-STREAM-INF:BANDWIDTH=128000,CODECS=\"mp4a.40.2\"\n"
+                + "{$manifestBase}audio/playlist.m3u8\n")
+            .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+    // Media playlist uses a different variable for segment URLs
+    byte[] mediaPlaylistData =
+        ("#EXTM3U\n"
+                + "#EXT-X-TARGETDURATION:10\n"
+                + "#EXT-X-VERSION:8\n"
+                + "#EXT-X-MEDIA-SEQUENCE:0\n"
+                + "#EXT-X-PLAYLIST-TYPE:VOD\n"
+                + "#EXT-X-DEFINE:IMPORT=\"segmentBase\"\n"
+                + "#EXTINF:10.0,\n"
+                + "{$segmentBase}audio/chunk_0.ts\n"
+                + "#EXTINF:10.0,\n"
+                + "{$segmentBase}audio/chunk_1.ts\n"
+                + "#EXT-X-ENDLIST")
+            .getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+    fakeDataSet =
+        new FakeDataSet()
+            .setData("master_child_var.m3u8", multivariantPlaylistData)
+            .setData(
+                "https://manifest.example.com/audio/playlist.m3u8", mediaPlaylistData)
+            .setRandomData("https://segments.example.com/audio/chunk_0.ts", 10)
+            .setRandomData("https://segments.example.com/audio/chunk_1.ts", 11);
+
+    HlsDownloader downloader = getHlsDownloader("master_child_var.m3u8", getKeys(0));
+    downloader.download(progressListener);
+
+    assertCachedData(cache, fakeDataSet);
+  }
+
   private HlsDownloader getHlsDownloader(String mediaPlaylistUri, List<StreamKey> keys) {
     CacheDataSource.Factory cacheDataSourceFactory =
         new CacheDataSource.Factory()


### PR DESCRIPTION
PR Description:
  
  ## Summary
  
  Fixes HLS download failures for streams where the multivariant playlist defines
  variables via `#EXT-X-DEFINE:NAME=...,VALUE=...` and media playlists reference
  them in segment URLs without an explicit `#EXT-X-DEFINE:IMPORT=...` tag.
  
  Fixes #3258
  
  ## Problem
  
  `HlsDownloader` (via `SegmentDownloader`) uses a single `HlsPlaylistParser()`
  instance constructed with `HlsMultivariantPlaylist.EMPTY`. This instance first
  parses the multivariant playlist, then parses each media playlist. However, the
  parsed multivariant playlist was never stored back into the parser instance.
  
  When media playlists are subsequently parsed, `multivariantPlaylist` is still
  `EMPTY`, so:
  - `variableDefinitions` is unavailable during `replaceVariableReferences()`
  - `{$variable}` references in segment URLs pass through unsubstituted
  - Downloads fail with HTTP errors on malformed URLs
  - `HlsMediaPeriod.getStreamKeys()` crashes with `IndexOutOfBoundsException`
  
  During **playback** this works correctly because `HlsPlaylistTracker` constructs
  the parser with the real multivariant playlist.
  
  ## Fix
  
  **`HlsPlaylistParser.java`:**
  - Make `multivariantPlaylist` field non-final
  - After parsing a multivariant playlist in `parse()`, store it in the instance
  - Subsequent `parseMediaPlaylist()` calls on the same instance now have access
    to the correct `variableDefinitions` for variable substitution
  
  **`HlsMediaPeriod.java`:**
  - Add bounds checks in `getStreamKeys()` to prevent `IndexOutOfBoundsException`
    when `redundantGroupIndicesPerWrapper` has an empty array or when
    `renditionRedundantGroupIndex` exceeds the redundant groups list size
  
  ## Testing
  
  Tested with an HLS stream using:
  
  #EXT-X-DEFINE:NAME="awsContentSegmentPrefix",VALUE="https://cdn.example.com/"
  
  in the multivariant playlist, with media playlist segment URLs referencing
  `{$awsContentSegmentPrefix}` directly. Download completes successfully with
  variables resolved. Existing playback behavior is unchanged