### PR TITLE
Fix some dodgy math

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -69,6 +69,12 @@
         `MetadataRetriever`.
 *   Inspector Frame:
 *   Audio:
+    *   Fix buffer size calculation in `SilenceSkippingAudioProcessor` so that
+        the minimum silence duration is not incorrectly scaled down by the frame
+        size ([#3271](https://github.com/androidx/media/pull/3271)).
+    *   Fix 8-bit PCM handling in `PcmAudioUtil` to treat samples as unsigned as
+        defined by Android
+        ([#3271](https://github.com/androidx/media/pull/3271)).
     *   Fix offload issue in which playback could stall during pre-roll or
         gapless transitions due to limited hardware buffer sizes.
     *   Fix bug in `DefaultAudioSink` where release count doesn't decrease when

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/PcmAudioUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/PcmAudioUtil.java
@@ -71,7 +71,7 @@ public final class PcmAudioUtil {
   public static int readAs32BitIntPcm(ByteBuffer buffer, @C.Encoding int pcmEncoding) {
     switch (pcmEncoding) {
       case C.ENCODING_PCM_8BIT:
-        return (buffer.get() & 0xFF) << 24;
+        return ((buffer.get() & 0xFF) - 128) << 24;
       case C.ENCODING_PCM_16BIT:
         return ((buffer.get() & 0xFF) << 16) | ((buffer.get() & 0xFF) << 24);
       case C.ENCODING_PCM_16BIT_BIG_ENDIAN:
@@ -161,7 +161,7 @@ public final class PcmAudioUtil {
         buffer.put((byte) (pcm32bit >> 24));
         return;
       case C.ENCODING_PCM_8BIT:
-        buffer.put((byte) (pcm32bit >> 24));
+        buffer.put((byte) ((pcm32bit >> 24) + 128));
         return;
       case C.ENCODING_PCM_32BIT_BIG_ENDIAN:
         buffer.put((byte) (pcm32bit >> 24));

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/SilenceSkippingAudioProcessor.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/SilenceSkippingAudioProcessor.java
@@ -62,7 +62,7 @@ public final class SilenceSkippingAudioProcessor extends BaseAudioProcessor {
    * Default minimum duration of audio that must be below {@code silenceThresholdLevel} before
    * silence starts being trimmed. Specified in microseconds.
    */
-  public static final long DEFAULT_MINIMUM_SILENCE_DURATION_US = 100_000;
+  public static final long DEFAULT_MINIMUM_SILENCE_DURATION_US = 25_000;
 
   /**
    * Default maximum silence to keep in microseconds. This maximum is applied after {@code
@@ -309,7 +309,9 @@ public final class SilenceSkippingAudioProcessor extends BaseAudioProcessor {
       bytesPerFrame = inputAudioFormat.channelCount * 2;
       // Divide by 2 to allow the buffer to be split into two bytesPerFrame aligned parts.
       int maybeSilenceBufferSize =
-          alignToBytePerFrameBoundary(durationUsToFrames(minimumSilenceDurationUs) / 2) * 2;
+          alignToBytePerFrameBoundary(
+                  durationUsToFrames(minimumSilenceDurationUs) * bytesPerFrame / 2)
+              * 2;
       if (maybeSilenceBuffer.length != maybeSilenceBufferSize) {
         maybeSilenceBuffer = new byte[maybeSilenceBufferSize];
         contiguousOutputBuffer = new byte[maybeSilenceBufferSize];
@@ -647,6 +649,7 @@ public final class SilenceSkippingAudioProcessor extends BaseAudioProcessor {
       return;
     }
 
+    int lastFrameIdx = (size / bytesPerFrame) - 1;
     for (int idx = 0; idx < size; idx += 2) {
       byte mostSignificantByte = sampleBuffer[idx + 1];
       byte leastSignificantByte = sampleBuffer[idx];
@@ -655,10 +658,10 @@ public final class SilenceSkippingAudioProcessor extends BaseAudioProcessor {
       int volumeModificationPercentage;
       if (volumeChangeType == FADE_OUT) {
         volumeModificationPercentage =
-            calculateFadeOutPercentage(/* value= */ idx, /* max= */ size - 1);
+            calculateFadeOutPercentage(/* value= */ idx / bytesPerFrame, /* max= */ lastFrameIdx);
       } else if (volumeChangeType == FADE_IN) {
         volumeModificationPercentage =
-            calculateFadeInPercentage(/* value= */ idx, /* max= */ size - 1);
+            calculateFadeInPercentage(/* value= */ idx / bytesPerFrame, /* max= */ lastFrameIdx);
       } else {
         volumeModificationPercentage = minVolumeToKeepPercentageWhenMuting;
       }
@@ -669,12 +672,18 @@ public final class SilenceSkippingAudioProcessor extends BaseAudioProcessor {
   }
 
   private int calculateFadeOutPercentage(int value, int max) {
+    if (max == 0) {
+      return 0;
+    }
     return ((minVolumeToKeepPercentageWhenMuting - 100) * ((AVOID_TRUNCATION_FACTOR * value) / max))
             / AVOID_TRUNCATION_FACTOR
         + 100;
   }
 
   private int calculateFadeInPercentage(int value, int max) {
+    if (max == 0) {
+      return 0;
+    }
     return (minVolumeToKeepPercentageWhenMuting
         + ((100 - minVolumeToKeepPercentageWhenMuting) * (AVOID_TRUNCATION_FACTOR * value) / max)
             / AVOID_TRUNCATION_FACTOR);

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/SilenceSkippingAudioProcessor.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/SilenceSkippingAudioProcessor.java
@@ -62,7 +62,7 @@ public final class SilenceSkippingAudioProcessor extends BaseAudioProcessor {
    * Default minimum duration of audio that must be below {@code silenceThresholdLevel} before
    * silence starts being trimmed. Specified in microseconds.
    */
-  public static final long DEFAULT_MINIMUM_SILENCE_DURATION_US = 25_000;
+  public static final long DEFAULT_MINIMUM_SILENCE_DURATION_US = 100_000;
 
   /**
    * Default maximum silence to keep in microseconds. This maximum is applied after {@code
@@ -673,7 +673,7 @@ public final class SilenceSkippingAudioProcessor extends BaseAudioProcessor {
 
   private int calculateFadeOutPercentage(int value, int max) {
     if (max == 0) {
-      return 0;
+      return minVolumeToKeepPercentageWhenMuting;
     }
     return ((minVolumeToKeepPercentageWhenMuting - 100) * ((AVOID_TRUNCATION_FACTOR * value) / max))
             / AVOID_TRUNCATION_FACTOR
@@ -682,7 +682,7 @@ public final class SilenceSkippingAudioProcessor extends BaseAudioProcessor {
 
   private int calculateFadeInPercentage(int value, int max) {
     if (max == 0) {
-      return 0;
+      return 100;
     }
     return (minVolumeToKeepPercentageWhenMuting
         + ((100 - minVolumeToKeepPercentageWhenMuting) * (AVOID_TRUNCATION_FACTOR * value) / max)

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/PcmAudioUtilTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/PcmAudioUtilTest.java
@@ -33,7 +33,7 @@ public final class PcmAudioUtilTest {
   @Test
   public void readAs32BitIntPcm_read8Bit_returnsExpectedValues() {
     ByteBuffer buffer = ByteBuffer.allocate(5);
-    buffer.put(hexToBytes("80" + "AB" + "00" + "12" + "7F"));
+    buffer.put(hexToBytes("00" + "2B" + "80" + "92" + "FF"));
     buffer.flip();
 
     assertThat(PcmAudioUtil.readAs32BitIntPcm(buffer, C.ENCODING_PCM_8BIT))
@@ -197,7 +197,7 @@ public final class PcmAudioUtilTest {
     PcmAudioUtil.write32BitIntPcm(buffer, Integer.MAX_VALUE, C.ENCODING_PCM_8BIT);
     buffer.flip();
 
-    assertThat(byteBufferToHex(buffer)).isEqualTo("80" + "AB" + "00" + "12" + "7F");
+    assertThat(byteBufferToHex(buffer)).isEqualTo("00" + "2B" + "80" + "92" + "FF");
   }
 
   @Test

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/SilenceSkippingAudioProcessorTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/SilenceSkippingAudioProcessorTest.java
@@ -133,8 +133,8 @@ public final class SilenceSkippingAudioProcessorTest {
     // Given a signal with only noise.
     InputBufferProvider inputBufferProvider =
         getInputBufferProviderForAlternatingSilenceAndNoise(
-            /* silenceDurationMs= */ 30,
-            TEST_SIGNAL_NOISE_DURATION_MS - 30,
+            /* silenceDurationMs= */ 24,
+            TEST_SIGNAL_NOISE_DURATION_MS - 24,
             TEST_SIGNAL_FRAME_COUNT);
 
     // When processing the entire signal.
@@ -172,7 +172,7 @@ public final class SilenceSkippingAudioProcessorTest {
         process(silenceSkippingAudioProcessor, inputBufferProvider, INPUT_BUFFER_SIZE);
 
     // The output has 50000 frames of noise, plus 50 * 0.2 * 1000 padding (plus rounding errors).
-    assertThat(totalOutputFrames).isIn(Range.closed(60000L - 500L, 60000L + 500L));
+    assertThat(totalOutputFrames).isIn(Range.closed(60000L - 1500L, 60000L + 1500L));
     assertThat(silenceSkippingAudioProcessor.getSkippedFrames())
         .isEqualTo(TEST_SIGNAL_FRAME_COUNT - totalOutputFrames);
   }
@@ -201,7 +201,7 @@ public final class SilenceSkippingAudioProcessorTest {
         process(silenceSkippingAudioProcessor, inputBufferProvider, INPUT_BUFFER_SIZE);
 
     // The output has 50000 frames of noise, plus 50 * 0.2 * 1000 padding (plus rounding errors).
-    assertThat(totalOutputFrames).isIn(Range.closed(60000L - 500L, 60000L + 500L));
+    assertThat(totalOutputFrames).isIn(Range.closed(60000L - 1500L, 60000L + 1500L));
     assertThat(silenceSkippingAudioProcessor.getSkippedFrames())
         .isEqualTo(TEST_SIGNAL_FRAME_COUNT - totalOutputFrames);
   }
@@ -227,7 +227,7 @@ public final class SilenceSkippingAudioProcessorTest {
         process(silenceSkippingAudioProcessor, inputBufferProvider, /* inputBufferSize= */ 80);
 
     // The output has 50000 frames of noise, plus 50 * 0.2 * 1000 padding (plus rounding errors).
-    assertThat(totalOutputFrames).isIn(Range.closed(60000L - 500L, 60000L + 500L));
+    assertThat(totalOutputFrames).isIn(Range.closed(60000L - 1500L, 60000L + 1500L));
     assertThat(silenceSkippingAudioProcessor.getSkippedFrames())
         .isEqualTo(TEST_SIGNAL_FRAME_COUNT - totalOutputFrames);
   }
@@ -253,7 +253,7 @@ public final class SilenceSkippingAudioProcessorTest {
         process(silenceSkippingAudioProcessor, inputBufferProvider, /* inputBufferSize= */ 120);
 
     // The output has 50000 frames of noise, plus 50 * 0.2 * 1000 padding (plus rounding errors).
-    assertThat(totalOutputFrames).isIn(Range.closed(60000L - 500L, 60000L + 500L));
+    assertThat(totalOutputFrames).isIn(Range.closed(60000L - 1500L, 60000L + 1500L));
     assertThat(silenceSkippingAudioProcessor.getSkippedFrames())
         .isEqualTo(TEST_SIGNAL_FRAME_COUNT - totalOutputFrames);
   }
@@ -283,7 +283,7 @@ public final class SilenceSkippingAudioProcessorTest {
         process(silenceSkippingAudioProcessor, inputBufferProvider, /* inputBufferSize= */ 120);
 
     // The output has 50000 frames of noise, plus 50 * 0.05 * 1000 padding (plus rounding errors).
-    assertThat(totalOutputFrames).isIn(Range.closed(52500L - 500L, 52500L + 500L));
+    assertThat(totalOutputFrames).isIn(Range.closed(52500L - 1500L, 52500L + 1500L));
     assertThat(silenceSkippingAudioProcessor.getSkippedFrames())
         .isEqualTo(TEST_SIGNAL_FRAME_COUNT - totalOutputFrames);
   }
@@ -347,16 +347,21 @@ public final class SilenceSkippingAudioProcessorTest {
       int silenceDurationMs, int noiseDurationMs, int totalFrameCount) {
     int sampleRate = AUDIO_FORMAT.sampleRate;
     int channelCount = AUDIO_FORMAT.channelCount;
+    int lastSize = 0;
     Pcm16BitAudioBuilder audioBuilder = new Pcm16BitAudioBuilder(channelCount, totalFrameCount);
     while (!audioBuilder.isFull()) {
       int silenceDurationFrames = (silenceDurationMs * sampleRate) / 1000;
       // Append stereo silence.
       audioBuilder.appendFrames(
           /* count= */ silenceDurationFrames, /* channelLevels...= */ (short) 0, (short) 0);
+      lastSize += silenceDurationFrames * channelCount * 2;
+      assertThat(audioBuilder.getSize()).isEqualTo(lastSize);
       int noiseDurationFrames = (noiseDurationMs * sampleRate) / 1000;
       // Append stereo noise.
       audioBuilder.appendFrames(
           /* count= */ noiseDurationFrames, /* channelLevels...= */ MAX_VALUE, MAX_VALUE);
+      lastSize += noiseDurationFrames * channelCount * 2;
+      assertThat(audioBuilder.getSize()).isEqualTo(lastSize);
     }
     return new InputBufferProvider(audioBuilder.build());
   }
@@ -410,11 +415,17 @@ public final class SilenceSkippingAudioProcessorTest {
     public void appendFrames(int count, short... channelLevels) {
       checkState(!built);
       checkState(channelLevels.length == channelCount);
-      for (int i = 0; i < count; i += channelCount) {
+      for (int i = 0; i < count; i++) {
         for (short channelLevel : channelLevels) {
           buffer.put(channelLevel);
         }
       }
+    }
+
+    /** Returns how many bytes the buffer contains so far. */
+    public int getSize() {
+      checkState(!built);
+      return buffer.position() * 2;
     }
 
     /** Returns whether the buffer is full. */

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/SilenceSkippingAudioProcessorTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/SilenceSkippingAudioProcessorTest.java
@@ -22,8 +22,10 @@ import static java.lang.Short.MAX_VALUE;
 
 import androidx.media3.common.C;
 import androidx.media3.common.audio.AudioProcessor.AudioFormat;
+import androidx.media3.common.audio.AudioProcessor.StreamMetadata;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.collect.Range;
+import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ShortBuffer;
@@ -95,7 +97,7 @@ public final class SilenceSkippingAudioProcessorTest {
     // When processing the entire signal.
     silenceSkippingAudioProcessor.setEnabled(true);
     silenceSkippingAudioProcessor.configure(AUDIO_FORMAT);
-    silenceSkippingAudioProcessor.flush();
+    silenceSkippingAudioProcessor.flush(StreamMetadata.DEFAULT);
     assertThat(silenceSkippingAudioProcessor.isActive()).isTrue();
     long totalOutputFrames =
         process(silenceSkippingAudioProcessor, inputBufferProvider, INPUT_BUFFER_SIZE);
@@ -118,7 +120,7 @@ public final class SilenceSkippingAudioProcessorTest {
         new SilenceSkippingAudioProcessor();
     silenceSkippingAudioProcessor.setEnabled(true);
     silenceSkippingAudioProcessor.configure(AUDIO_FORMAT);
-    silenceSkippingAudioProcessor.flush();
+    silenceSkippingAudioProcessor.flush(StreamMetadata.DEFAULT);
     assertThat(silenceSkippingAudioProcessor.isActive()).isTrue();
     long totalOutputFrames =
         process(silenceSkippingAudioProcessor, inputBufferProvider, INPUT_BUFFER_SIZE);
@@ -133,8 +135,8 @@ public final class SilenceSkippingAudioProcessorTest {
     // Given a signal with only noise.
     InputBufferProvider inputBufferProvider =
         getInputBufferProviderForAlternatingSilenceAndNoise(
-            /* silenceDurationMs= */ 24,
-            TEST_SIGNAL_NOISE_DURATION_MS - 24,
+            /* silenceDurationMs= */ 30,
+            TEST_SIGNAL_NOISE_DURATION_MS - 30,
             TEST_SIGNAL_FRAME_COUNT);
 
     // When processing the entire signal.
@@ -142,7 +144,7 @@ public final class SilenceSkippingAudioProcessorTest {
         new SilenceSkippingAudioProcessor();
     silenceSkippingAudioProcessor.setEnabled(true);
     silenceSkippingAudioProcessor.configure(AUDIO_FORMAT);
-    silenceSkippingAudioProcessor.flush();
+    silenceSkippingAudioProcessor.flush(StreamMetadata.DEFAULT);
     assertThat(silenceSkippingAudioProcessor.isActive()).isTrue();
     long totalOutputFrames =
         process(silenceSkippingAudioProcessor, inputBufferProvider, INPUT_BUFFER_SIZE);
@@ -166,13 +168,14 @@ public final class SilenceSkippingAudioProcessorTest {
         new SilenceSkippingAudioProcessor();
     silenceSkippingAudioProcessor.setEnabled(true);
     silenceSkippingAudioProcessor.configure(AUDIO_FORMAT);
-    silenceSkippingAudioProcessor.flush();
+    silenceSkippingAudioProcessor.flush(StreamMetadata.DEFAULT);
     assertThat(silenceSkippingAudioProcessor.isActive()).isTrue();
     long totalOutputFrames =
         process(silenceSkippingAudioProcessor, inputBufferProvider, INPUT_BUFFER_SIZE);
 
-    // The output has 50000 frames of noise, plus 50 * 0.2 * 1000 padding (plus rounding errors).
-    assertThat(totalOutputFrames).isIn(Range.closed(60000L - 1500L, 60000L + 1500L));
+    // The output has 50000 frames of noise, plus 50 * (100 + 0.2 * 900) frames of silence (plus
+    // rounding errors).
+    assertThat(totalOutputFrames).isIn(Range.closed(64000L - 1500L, 64000L + 1500L));
     assertThat(silenceSkippingAudioProcessor.getSkippedFrames())
         .isEqualTo(TEST_SIGNAL_FRAME_COUNT - totalOutputFrames);
   }
@@ -191,7 +194,7 @@ public final class SilenceSkippingAudioProcessorTest {
         new SilenceSkippingAudioProcessor();
     silenceSkippingAudioProcessor.setEnabled(true);
     silenceSkippingAudioProcessor.configure(AUDIO_FORMAT);
-    silenceSkippingAudioProcessor.flush();
+    silenceSkippingAudioProcessor.flush(StreamMetadata.DEFAULT);
 
     // Early configure the next format without flushing yet (this format should be ignored).
     silenceSkippingAudioProcessor.configure(
@@ -200,8 +203,9 @@ public final class SilenceSkippingAudioProcessorTest {
     long totalOutputFrames =
         process(silenceSkippingAudioProcessor, inputBufferProvider, INPUT_BUFFER_SIZE);
 
-    // The output has 50000 frames of noise, plus 50 * 0.2 * 1000 padding (plus rounding errors).
-    assertThat(totalOutputFrames).isIn(Range.closed(60000L - 1500L, 60000L + 1500L));
+    // The output has 50000 frames of noise, plus 50 * (100 + 0.2 * 900) frames of silence (plus
+    // rounding errors).
+    assertThat(totalOutputFrames).isIn(Range.closed(64000L - 1500L, 64000L + 1500L));
     assertThat(silenceSkippingAudioProcessor.getSkippedFrames())
         .isEqualTo(TEST_SIGNAL_FRAME_COUNT - totalOutputFrames);
   }
@@ -221,13 +225,14 @@ public final class SilenceSkippingAudioProcessorTest {
         new SilenceSkippingAudioProcessor();
     silenceSkippingAudioProcessor.setEnabled(true);
     silenceSkippingAudioProcessor.configure(AUDIO_FORMAT);
-    silenceSkippingAudioProcessor.flush();
+    silenceSkippingAudioProcessor.flush(StreamMetadata.DEFAULT);
     assertThat(silenceSkippingAudioProcessor.isActive()).isTrue();
     long totalOutputFrames =
         process(silenceSkippingAudioProcessor, inputBufferProvider, /* inputBufferSize= */ 80);
 
-    // The output has 50000 frames of noise, plus 50 * 0.2 * 1000 padding (plus rounding errors).
-    assertThat(totalOutputFrames).isIn(Range.closed(60000L - 1500L, 60000L + 1500L));
+    // The output has 50000 frames of noise, plus 50 * (100 + 0.2 * 900) frames of silence (plus
+    // rounding errors).
+    assertThat(totalOutputFrames).isIn(Range.closed(64000L - 1500L, 64000L + 1500L));
     assertThat(silenceSkippingAudioProcessor.getSkippedFrames())
         .isEqualTo(TEST_SIGNAL_FRAME_COUNT - totalOutputFrames);
   }
@@ -247,13 +252,14 @@ public final class SilenceSkippingAudioProcessorTest {
         new SilenceSkippingAudioProcessor();
     silenceSkippingAudioProcessor.setEnabled(true);
     silenceSkippingAudioProcessor.configure(AUDIO_FORMAT);
-    silenceSkippingAudioProcessor.flush();
+    silenceSkippingAudioProcessor.flush(StreamMetadata.DEFAULT);
     assertThat(silenceSkippingAudioProcessor.isActive()).isTrue();
     long totalOutputFrames =
         process(silenceSkippingAudioProcessor, inputBufferProvider, /* inputBufferSize= */ 120);
 
-    // The output has 50000 frames of noise, plus 50 * 0.2 * 1000 padding (plus rounding errors).
-    assertThat(totalOutputFrames).isIn(Range.closed(60000L - 1500L, 60000L + 1500L));
+    // The output has 50000 frames of noise, plus 50 * (100 + 0.2 * 900) frames of silence (plus
+    // rounding errors).
+    assertThat(totalOutputFrames).isIn(Range.closed(64000L - 1500L, 64000L + 1500L));
     assertThat(silenceSkippingAudioProcessor.getSkippedFrames())
         .isEqualTo(TEST_SIGNAL_FRAME_COUNT - totalOutputFrames);
   }
@@ -277,13 +283,14 @@ public final class SilenceSkippingAudioProcessorTest {
             SilenceSkippingAudioProcessor.DEFAULT_SILENCE_THRESHOLD_LEVEL);
     silenceSkippingAudioProcessor.setEnabled(true);
     silenceSkippingAudioProcessor.configure(AUDIO_FORMAT);
-    silenceSkippingAudioProcessor.flush();
+    silenceSkippingAudioProcessor.flush(StreamMetadata.DEFAULT);
     assertThat(silenceSkippingAudioProcessor.isActive()).isTrue();
     long totalOutputFrames =
         process(silenceSkippingAudioProcessor, inputBufferProvider, /* inputBufferSize= */ 120);
 
-    // The output has 50000 frames of noise, plus 50 * 0.05 * 1000 padding (plus rounding errors).
-    assertThat(totalOutputFrames).isIn(Range.closed(52500L - 1500L, 52500L + 1500L));
+    // The output has 50000 frames of noise, plus 50 * (100 + 0.05 * 900) frames of silence (plus
+    // rounding errors).
+    assertThat(totalOutputFrames).isIn(Range.closed(56800L - 1500L, 56800L + 1500L));
     assertThat(silenceSkippingAudioProcessor.getSkippedFrames())
         .isEqualTo(TEST_SIGNAL_FRAME_COUNT - totalOutputFrames);
   }
@@ -302,13 +309,111 @@ public final class SilenceSkippingAudioProcessorTest {
         new SilenceSkippingAudioProcessor();
     silenceSkippingAudioProcessor.setEnabled(true);
     silenceSkippingAudioProcessor.configure(AUDIO_FORMAT);
-    silenceSkippingAudioProcessor.flush();
+    silenceSkippingAudioProcessor.flush(StreamMetadata.DEFAULT);
     assertThat(silenceSkippingAudioProcessor.isActive()).isTrue();
     process(silenceSkippingAudioProcessor, inputBufferProvider, INPUT_BUFFER_SIZE);
-    silenceSkippingAudioProcessor.flush();
+    silenceSkippingAudioProcessor.flush(StreamMetadata.DEFAULT);
 
     // The skipped frame count is zero.
     assertThat(silenceSkippingAudioProcessor.getSkippedFrames()).isEqualTo(0);
+  }
+
+  @Test
+  public void process_withSingleFrameFadeBuffer_processesWithoutError() throws Exception {
+    // 2ms at 1000Hz results in a 2-frame buffer (1-frame fade out/in, max == 0).
+    SilenceSkippingAudioProcessor silenceSkippingAudioProcessor =
+        new SilenceSkippingAudioProcessor(
+            /* minimumSilenceDurationUs= */ 2_000,
+            SilenceSkippingAudioProcessor.DEFAULT_SILENCE_RETENTION_RATIO,
+            SilenceSkippingAudioProcessor.DEFAULT_MAX_SILENCE_TO_KEEP_DURATION_US,
+            SilenceSkippingAudioProcessor.DEFAULT_MIN_VOLUME_TO_KEEP_PERCENTAGE,
+            SilenceSkippingAudioProcessor.DEFAULT_SILENCE_THRESHOLD_LEVEL);
+    silenceSkippingAudioProcessor.setEnabled(true);
+    silenceSkippingAudioProcessor.configure(AUDIO_FORMAT);
+    silenceSkippingAudioProcessor.flush(StreamMetadata.DEFAULT);
+
+    // Provide 1 frame of noise (20000), 2 frames of silence (1000), and 1 frame of noise (20000).
+    ByteBuffer inputBuffer =
+        ByteBuffer.allocate(4 * AUDIO_FORMAT.bytesPerFrame).order(ByteOrder.nativeOrder());
+    inputBuffer.putShort((short) 20000);
+    inputBuffer.putShort((short) 20000);
+    inputBuffer.putShort((short) 1000);
+    inputBuffer.putShort((short) 1000);
+    inputBuffer.putShort((short) 1000);
+    inputBuffer.putShort((short) 1000);
+    inputBuffer.putShort((short) 20000);
+    inputBuffer.putShort((short) 20000);
+    inputBuffer.flip();
+
+    ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+    while (inputBuffer.hasRemaining()) {
+      silenceSkippingAudioProcessor.queueInput(inputBuffer);
+      ByteBuffer outputBuffer = silenceSkippingAudioProcessor.getOutput();
+      byte[] bytes = new byte[outputBuffer.remaining()];
+      outputBuffer.get(bytes);
+      outStream.write(bytes);
+    }
+    silenceSkippingAudioProcessor.queueEndOfStream();
+    while (!silenceSkippingAudioProcessor.isEnded()) {
+      ByteBuffer outputBuffer = silenceSkippingAudioProcessor.getOutput();
+      byte[] bytes = new byte[outputBuffer.remaining()];
+      outputBuffer.get(bytes);
+      outStream.write(bytes);
+    }
+
+    ShortBuffer outputShortBuffer =
+        ByteBuffer.wrap(outStream.toByteArray()).order(ByteOrder.nativeOrder()).asShortBuffer();
+
+    // 1st frame: Noise (20000)
+    assertThat(outputShortBuffer.get()).isEqualTo((short) 20000);
+    assertThat(outputShortBuffer.get()).isEqualTo((short) 20000);
+
+    // 2nd frame: 1-frame Fade-Out with max == 0 (scaled to 10% of 1000 = 100)
+    assertThat(outputShortBuffer.get()).isEqualTo((short) 100);
+    assertThat(outputShortBuffer.get()).isEqualTo((short) 100);
+
+    // 3rd frame: 1-frame Fade-In with max == 0 (scaled to 100% of 1000 = 1000)
+    assertThat(outputShortBuffer.get()).isEqualTo((short) 1000);
+    assertThat(outputShortBuffer.get()).isEqualTo((short) 1000);
+
+    // 4th frame: Noise (20000)
+    assertThat(outputShortBuffer.get()).isEqualTo((short) 20000);
+    assertThat(outputShortBuffer.get()).isEqualTo((short) 20000);
+  }
+
+  @Test
+  public void queueInput_stereoFadedSilence_scalesBothChannelsEqually() throws Exception {
+    SilenceSkippingAudioProcessor silenceSkippingAudioProcessor =
+        new SilenceSkippingAudioProcessor();
+    silenceSkippingAudioProcessor.setEnabled(true);
+    silenceSkippingAudioProcessor.configure(AUDIO_FORMAT);
+    silenceSkippingAudioProcessor.flush(StreamMetadata.DEFAULT);
+
+    // Create a buffer with noise followed by silence (with non-zero sub-threshold level 500 on both
+    // L and R).
+    int frameCount = 2000;
+    ByteBuffer inputBuffer =
+        ByteBuffer.allocate(frameCount * AUDIO_FORMAT.bytesPerFrame).order(ByteOrder.nativeOrder());
+    for (int i = 0; i < 500; i++) {
+      inputBuffer.putShort(MAX_VALUE);
+      inputBuffer.putShort(MAX_VALUE);
+    }
+    for (int i = 0; i < 1500; i++) {
+      inputBuffer.putShort((short) 500);
+      inputBuffer.putShort((short) 500);
+    }
+    inputBuffer.flip();
+
+    silenceSkippingAudioProcessor.queueInput(inputBuffer);
+    silenceSkippingAudioProcessor.queueEndOfStream();
+
+    ByteBuffer outputBuffer = silenceSkippingAudioProcessor.getOutput();
+    ShortBuffer outputShortBuffer = outputBuffer.asShortBuffer();
+    while (outputShortBuffer.hasRemaining()) {
+      short leftChannel = outputShortBuffer.get();
+      short rightChannel = outputShortBuffer.get();
+      assertThat(leftChannel).isEqualTo(rightChannel);
+    }
   }
 
   /**
@@ -347,21 +452,16 @@ public final class SilenceSkippingAudioProcessorTest {
       int silenceDurationMs, int noiseDurationMs, int totalFrameCount) {
     int sampleRate = AUDIO_FORMAT.sampleRate;
     int channelCount = AUDIO_FORMAT.channelCount;
-    int lastSize = 0;
     Pcm16BitAudioBuilder audioBuilder = new Pcm16BitAudioBuilder(channelCount, totalFrameCount);
     while (!audioBuilder.isFull()) {
       int silenceDurationFrames = (silenceDurationMs * sampleRate) / 1000;
       // Append stereo silence.
       audioBuilder.appendFrames(
           /* count= */ silenceDurationFrames, /* channelLevels...= */ (short) 0, (short) 0);
-      lastSize += silenceDurationFrames * channelCount * 2;
-      assertThat(audioBuilder.getSize()).isEqualTo(lastSize);
       int noiseDurationFrames = (noiseDurationMs * sampleRate) / 1000;
       // Append stereo noise.
       audioBuilder.appendFrames(
           /* count= */ noiseDurationFrames, /* channelLevels...= */ MAX_VALUE, MAX_VALUE);
-      lastSize += noiseDurationFrames * channelCount * 2;
-      assertThat(audioBuilder.getSize()).isEqualTo(lastSize);
     }
     return new InputBufferProvider(audioBuilder.build());
   }
@@ -420,12 +520,6 @@ public final class SilenceSkippingAudioProcessorTest {
           buffer.put(channelLevel);
         }
       }
-    }
-
-    /** Returns how many bytes the buffer contains so far. */
-    public int getSize() {
-      checkState(!built);
-      return buffer.position() * 2;
     }
 
     /** Returns whether the buffer is full. */


### PR DESCRIPTION
I was expanding SilenceSkippingAudioProcessor to cover different sample formats and noticed a couple instances of dodgy math.

- SilenceSkippingAudioProcessor was not considering `bytesPerFrame` when calculating `maybeSilenceBufferSize` which in practice led to `minimumSilenceDurationUs` being divided by 4 (channel count 2 and sample format 2). The test `skipInNoisySignalWithShortSilences_skipsNothing` should've caught this but didn't, due to a bug in the test:
- In `Pcm16BitAudioBuilder`, `appendFrames` was only generating half of the supposed millisecond amounts (but due to the loop in the caller, this wasn't noticed as the output was still correct size, just with wrong amount of silence/noise between each change). This is because the loop was accepting a frame count but did `i += channelCount`, that is, treating it as sample count. Thus, `skipInNoisySignalWithShortSilences_skipsNothing` only generated 15ms of silence and noise, which is below the threshold of 25ms (which is the intended default 100ms but divided by 4 due to aforementioned bug), and thus passed.
- In `modifyVolume`, the volume percentage was calculated from the byte index, which could lead to the left and right channel having a different percentage or prevent reaching 100% of volume in edge cases.
- In PcmAudioUtil, 8-bit PCM is treated as signed, but Android defines 8-bit PCM to be unsigned.