### PR TITLE
Add selection priority parsing for DASH

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/Format.java
+++ b/libraries/common/src/main/java/androidx/media3/common/Format.java
@@ -1013,6 +1013,9 @@ public final class Format {
    *   <li>HLS variants: The {@code SCORE} attribute defined on the corresponding {@code
    *       EXT-X-STREAM-INF} and {@code EXT-X-I-FRAME-STREAM-INF} tags in the multivariant playlist,
    *       or {@link #NO_VALUE} if not present.
+   *   <li>DASH representations: The {@code selectionPriority} attribute defined on the
+   *       corresponding {@code Representation}, inherited from the parent {@code AdaptationSet}, or
+   *       {@code 1} if not present.
    *   <li>All the other types of media: Always {@link #NO_VALUE}.
    * </ul>
    */

--- a/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/DashManifestParser.java
+++ b/libraries/exoplayer_dash/src/main/java/androidx/media3/exoplayer/dash/manifest/DashManifestParser.java
@@ -472,6 +472,7 @@ public class DashManifestParser extends DefaultHandler
     float frameRate = parseFrameRate(xpp, Format.NO_VALUE);
     int audioChannels = Format.NO_VALUE;
     int audioSamplingRate = parseInt(xpp, "audioSamplingRate", Format.NO_VALUE);
+    int selectionPriority = parseInt(xpp, "selectionPriority", /* defaultValue= */ 1);
     String language = xpp.getAttributeValue(null, "lang");
     String label = xpp.getAttributeValue(null, "label");
     List<Label> labels = new ArrayList<>();
@@ -530,6 +531,7 @@ public class DashManifestParser extends DefaultHandler
                 frameRate,
                 audioChannels,
                 audioSamplingRate,
+                selectionPriority,
                 language,
                 roleDescriptors,
                 accessibilityDescriptors,
@@ -750,6 +752,7 @@ public class DashManifestParser extends DefaultHandler
       float adaptationSetFrameRate,
       int adaptationSetAudioChannels,
       int adaptationSetAudioSamplingRate,
+      int adaptationSetSelectionPriority,
       @Nullable String adaptationSetLanguage,
       List<Descriptor> adaptationSetRoleDescriptors,
       List<Descriptor> adaptationSetAccessibilityDescriptors,
@@ -777,6 +780,7 @@ public class DashManifestParser extends DefaultHandler
     float frameRate = parseFrameRate(xpp, adaptationSetFrameRate);
     int audioChannels = adaptationSetAudioChannels;
     int audioSamplingRate = parseInt(xpp, "audioSamplingRate", adaptationSetAudioSamplingRate);
+    int selectionPriority = parseInt(xpp, "selectionPriority", adaptationSetSelectionPriority);
     String drmSchemeType = null;
     ArrayList<SchemeData> drmSchemeDatas = new ArrayList<>();
     ArrayList<Descriptor> inbandEventStreams = new ArrayList<>();
@@ -853,6 +857,7 @@ public class DashManifestParser extends DefaultHandler
             audioChannels,
             audioSamplingRate,
             bandwidth,
+            selectionPriority,
             adaptationSetLanguage,
             adaptationSetRoleDescriptors,
             adaptationSetAccessibilityDescriptors,
@@ -889,6 +894,7 @@ public class DashManifestParser extends DefaultHandler
       int audioChannels,
       int audioSamplingRate,
       int bitrate,
+      float selectionPriority,
       @Nullable String language,
       List<Descriptor> roleDescriptors,
       List<Descriptor> accessibilityDescriptors,
@@ -925,6 +931,7 @@ public class DashManifestParser extends DefaultHandler
             .setSampleMimeType(sampleMimeType)
             .setCodecs(codecs)
             .setPeakBitrate(bitrate)
+            .setSelectionPriority(selectionPriority)
             .setSelectionFlags(selectionFlags)
             .setRoleFlags(roleFlags)
             .setColorInfo(colorInfo)

--- a/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/manifest/DashManifestParserTest.java
+++ b/libraries/exoplayer_dash/src/test/java/androidx/media3/exoplayer/dash/manifest/DashManifestParserTest.java
@@ -65,6 +65,8 @@ public class DashManifestParserTest {
   private static final String SAMPLE_MPD_SEGMENT_TEMPLATE = "media/mpd/sample_mpd_segment_template";
   private static final String SAMPLE_MPD_EVENT_STREAM = "media/mpd/sample_mpd_event_stream";
   private static final String SAMPLE_MPD_IMAGES = "media/mpd/sample_mpd_images";
+  private static final String SAMPLE_MPD_SELECTION_PRIORITY =
+      "media/mpd/sample_mpd_selection_priority";
   private static final String SAMPLE_MPD_LABELS = "media/mpd/sample_mpd_labels";
   private static final String SAMPLE_MPD_ASSET_IDENTIFIER = "media/mpd/sample_mpd_asset_identifier";
   private static final String SAMPLE_MPD_TEXT = "media/mpd/sample_mpd_text";
@@ -320,6 +322,24 @@ public class DashManifestParserTest {
     assertThat(format1.height).isEqualTo(360);
     assertThat(format1.tileCountHorizontal).isEqualTo(2);
     assertThat(format1.tileCountVertical).isEqualTo(4);
+  }
+
+  @Test
+  public void parseMediaPresentationDescription_selectionPriority() throws IOException {
+    DashManifestParser parser = new DashManifestParser();
+    DashManifest manifest =
+        parser.parse(
+            Uri.parse("https://example.com/test.mpd"),
+            TestUtil.getInputStream(
+                ApplicationProvider.getApplicationContext(), SAMPLE_MPD_SELECTION_PRIORITY));
+
+    AdaptationSet adaptationSet = manifest.getPeriod(0).adaptationSets.get(0);
+    assertThat(adaptationSet.representations.get(0).format.selectionPriority).isEqualTo(3f);
+    assertThat(adaptationSet.representations.get(1).format.selectionPriority).isEqualTo(5f);
+
+    AdaptationSet defaultedAdaptationSet = manifest.getPeriod(0).adaptationSets.get(1);
+    assertThat(defaultedAdaptationSet.representations.get(0).format.selectionPriority)
+        .isEqualTo(1f);
   }
 
   @Test

--- a/libraries/test_data/src/test/assets/media/mpd/sample_mpd_selection_priority
+++ b/libraries/test_data/src/test/assets/media/mpd/sample_mpd_selection_priority
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD type="static" duration="1s" mediaPresentationDuration="PT1S">
+ <Period>
+  <AdaptationSet
+      id="0"
+      mimeType="video/mp4"
+      codecs="avc1.4d401f"
+      contentType="video"
+      selectionPriority="3">
+   <Representation id="video-360p" bandwidth="1000000" width="640" height="360"/>
+   <Representation
+       id="video-720p"
+       bandwidth="2000000"
+       width="1280"
+       height="720"
+       selectionPriority="5"/>
+  </AdaptationSet>
+  <AdaptationSet id="1" mimeType="audio/mp4" codecs="mp4a.40.2" contentType="audio">
+   <Representation id="audio" bandwidth="128000" audioSamplingRate="48000">
+    <AudioChannelConfiguration
+        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
+        value="2"/>
+   </Representation>
+  </AdaptationSet>
+ </Period>
+</MPD>


### PR DESCRIPTION
## Summary
- Parse DASH `selectionPriority` on `AdaptationSet` and `Representation` into `Format.selectionPriority`.
- Preserve DASH inheritance semantics: representations inherit from their parent adaptation set, defaulting to `1` when absent.
- Add DASH parser coverage with a small MPD fixture.

This follows the merged HLS `SCORE` extraction in https://github.com/androidx/media/pull/3236 .

Official public ISO DASH MPD schema: https://standards.iso.org/iso-iec/23009/-1/ed-3/en/DASH-MPD.xsd

## Testing
- `./gradlew :lib-common:assemble :lib-exoplayer-dash:assemble`
- `git diff --check`