### PR TITLE
Prevent VSyncSampler recreation

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/VideoFrameReleaseHelper.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/VideoFrameReleaseHelper.java
@@ -69,7 +69,7 @@ public final class VideoFrameReleaseHelper {
 
   private final Context context;
 
-  private boolean vsyncSampleBuilt;
+  private boolean vsyncSamplerBuilt;
   @Nullable private VSyncSampler vsyncSampler;
   private boolean started;
   @Nullable private Surface surface;
@@ -127,10 +127,11 @@ public final class VideoFrameReleaseHelper {
   public void onStarted() {
     started = true;
     resetAdjustment();
-    if (!vsyncSampleBuilt) {
+    if (!vsyncSamplerBuilt) {
       vsyncSampler = VSyncSampler.maybeBuildInstance(context);
     }
     if (vsyncSampler != null) {
+      vsyncSamplerBuilt = true;
       vsyncSampler.register();
     }
     updateSurfacePlaybackFrameRate(/* forceUpdate= */ false);


### PR DESCRIPTION
Prevent VSyncSampler recreation by setting vsyncSamplerBuilt flag when a valid instance has been created.

Rename flag from `vsyncSampleBuilt` to `vsyncSamplerBuilt`