### PR TITLE
Refactor audio sample calculation for EAC3

### DIFF
--- a/libraries/extractor/src/main/java/androidx/media3/extractor/Ac3Util.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/Ac3Util.java
@@ -537,10 +537,10 @@ public final class Ac3Util {
     // Parse the bitstream ID for AC-3 and E-AC-3 (see subsections 4.3, E.1.2 and E.1.3.1.6).
     boolean isEac3 = ((buffer.get(buffer.position() + 5) & 0xF8) >> 3) > 10;
     if (isEac3) {
-      // An EC-3 access unit may contain multiple syncframes. Per ETSI TS 102 366 Annex F,
-      // dependent substreams (strmtyp=1) cover the same presentation time as the preceding
-      // independent substream, so only audio blocks from independent substreams count toward the
-      // total sample duration.
+      // Per ETSI TS 102 366 Annex F, an EC-3 sample represents six audio blocks (1536 PCM
+      // samples). Additional independent substreams (substreamid > 0) and dependent substreams
+      // (strmtyp=1) are concurrent services that do not extend the presentation duration. Count
+      // only audio blocks from the primary independent substream (strmtyp=0, substreamid=0).
       int totalAudioBlocks = 0;
       int pos = buffer.position();
       int limit = buffer.limit();
@@ -549,11 +549,12 @@ public final class Ac3Util {
           break;
         }
         int strmtyp = (buffer.get(pos + 2) & 0xC0) >> 6;
+        int substreamid = (buffer.get(pos + 2) & 0x38) >> 3;
         int frmsiz = ((buffer.get(pos + 2) & 0x07) << 8) | (buffer.get(pos + 3) & 0xFF);
         int frameSize = (frmsiz + 1) * 2;
-        int fscod = (buffer.get(pos + 4) & 0xC0) >> 6;
-        int numblkscod = fscod == 0x03 ? 3 : (buffer.get(pos + 4) & 0x30) >> 4;
-        if (strmtyp != SyncFrameInfo.STREAM_TYPE_TYPE1) {
+        if (strmtyp == SyncFrameInfo.STREAM_TYPE_TYPE0 && substreamid == 0) {
+          int fscod = (buffer.get(pos + 4) & 0xC0) >> 6;
+          int numblkscod = fscod == 0x03 ? 3 : (buffer.get(pos + 4) & 0x30) >> 4;
           totalAudioBlocks += BLOCKS_PER_SYNCFRAME_BY_NUMBLKSCOD[numblkscod];
         }
         pos += frameSize;

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/Ac3Util.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/Ac3Util.java
@@ -527,11 +527,12 @@ public final class Ac3Util {
   }
 
   /**
-   * Reads the number of audio samples represented by the given (E-)AC-3 syncframe. The buffer's
-   * position is not modified.
+   * Reads the number of audio samples represented by the given (E-)AC-3 syncframe or access
+   * unit. For E-AC-3 access units, this uses the longest non-dependent substream timeline. 
+   * The buffer's position is not modified.
    *
-   * @param buffer The {@link ByteBuffer} from which to read the syncframe.
-   * @return The number of audio samples represented by the syncframe.
+   * @param buffer The {@link ByteBuffer} from which to read the syncframe or access unit.
+   * @return The number of audio samples represented by the syncframe or access unit.
    */
   public static int parseAc3SyncframeAudioSampleCount(ByteBuffer buffer) {
     // Parse the bitstream ID for AC-3 and E-AC-3 (see subsections 4.3, E.1.2 and E.1.3.1.6).

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/Ac3Util.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/Ac3Util.java
@@ -536,38 +536,50 @@ public final class Ac3Util {
   public static int parseAc3SyncframeAudioSampleCount(ByteBuffer buffer) {
     // Parse the bitstream ID for AC-3 and E-AC-3 (see subsections 4.3, E.1.2 and E.1.3.1.6).
     boolean isEac3 = ((buffer.get(buffer.position() + 5) & 0xF8) >> 3) > 10;
-    if (isEac3) {
-      // Per ETSI TS 102 366 Annex F, an EC-3 sample represents six audio blocks (1536 PCM
-      // samples). Additional independent substreams (substreamid > 0) and dependent substreams
-      // (strmtyp=1) are concurrent services that do not extend the presentation duration. Count
-      // only audio blocks from the primary independent substream (strmtyp=0, substreamid=0).
-      int totalAudioBlocks = 0;
-      int pos = buffer.position();
-      int limit = buffer.limit();
-      while (pos + 6 <= limit) {
-        if ((buffer.get(pos) & 0xFF) != 0x0B || (buffer.get(pos + 1) & 0xFF) != 0x77) {
-          break;
-        }
-        int strmtyp = (buffer.get(pos + 2) & 0xC0) >> 6;
-        int substreamid = (buffer.get(pos + 2) & 0x38) >> 3;
-        int frmsiz = ((buffer.get(pos + 2) & 0x07) << 8) | (buffer.get(pos + 3) & 0xFF);
-        int frameSize = (frmsiz + 1) * 2;
-        if (strmtyp == SyncFrameInfo.STREAM_TYPE_TYPE0 && substreamid == 0) {
-          int fscod = (buffer.get(pos + 4) & 0xC0) >> 6;
-          int numblkscod = fscod == 0x03 ? 3 : (buffer.get(pos + 4) & 0x30) >> 4;
-          totalAudioBlocks += BLOCKS_PER_SYNCFRAME_BY_NUMBLKSCOD[numblkscod];
-        }
-        pos += frameSize;
+    return isEac3
+        ? parseEAc3SyncframeOrAccessUnitAudioSampleCount(buffer)
+        : AC3_SYNCFRAME_AUDIO_SAMPLE_COUNT;
+  }
+
+  private static int parseEAc3SyncframeOrAccessUnitAudioSampleCount(ByteBuffer buffer) {
+    int firstSyncframeAudioBlockCount =
+        parseEAc3SyncframeAudioBlockCount(buffer, buffer.position());
+    int[] audioBlocksBySubstreamId = new int[8];
+    int maxAudioBlockCount = 0;
+    int position = buffer.position();
+    int limit = buffer.limit();
+    while (position + 6 <= limit && hasAc3Syncword(buffer, position)) {
+      int syncframeSize = parseEAc3SyncframeSize(buffer, position);
+      if (syncframeSize < 6 || position + syncframeSize > limit) {
+        break;
       }
-      if (totalAudioBlocks == 0) {
-        int fscod = (buffer.get(buffer.position() + 4) & 0xC0) >> 6;
-        int numblkscod = fscod == 0x03 ? 3 : (buffer.get(buffer.position() + 4) & 0x30) >> 4;
-        totalAudioBlocks = BLOCKS_PER_SYNCFRAME_BY_NUMBLKSCOD[numblkscod];
+      int syncframeAudioBlockCount = parseEAc3SyncframeAudioBlockCount(buffer, position);
+      int streamType = (buffer.get(position + 2) & 0xC0) >> 6;
+      if (streamType != SyncFrameInfo.STREAM_TYPE_TYPE1) {
+        int substreamId = (buffer.get(position + 2) & 0x38) >> 3;
+        audioBlocksBySubstreamId[substreamId] += syncframeAudioBlockCount;
+        maxAudioBlockCount = Math.max(maxAudioBlockCount, audioBlocksBySubstreamId[substreamId]);
       }
-      return totalAudioBlocks * AUDIO_SAMPLES_PER_AUDIO_BLOCK;
-    } else {
-      return AC3_SYNCFRAME_AUDIO_SAMPLE_COUNT;
+      position += syncframeSize;
     }
+    return (maxAudioBlockCount != 0 ? maxAudioBlockCount : firstSyncframeAudioBlockCount)
+        * AUDIO_SAMPLES_PER_AUDIO_BLOCK;
+  }
+
+  private static int parseEAc3SyncframeAudioBlockCount(ByteBuffer buffer, int offset) {
+    int fscod = (buffer.get(offset + 4) & 0xC0) >> 6;
+    int numblkscod = fscod == 0x03 ? 3 : (buffer.get(offset + 4) & 0x30) >> 4;
+    return BLOCKS_PER_SYNCFRAME_BY_NUMBLKSCOD[numblkscod];
+  }
+
+  private static int parseEAc3SyncframeSize(ByteBuffer buffer, int offset) {
+    int frameSize = (buffer.get(offset + 2) & 0x07) << 8;
+    frameSize |= buffer.get(offset + 3) & 0xFF;
+    return (frameSize + 1) * 2;
+  }
+
+  private static boolean hasAc3Syncword(ByteBuffer buffer, int offset) {
+    return (buffer.get(offset) & 0xFF) == 0x0B && (buffer.get(offset + 1) & 0xFF) == 0x77;
   }
 
   /**

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/Ac3Util.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/Ac3Util.java
@@ -539,7 +539,17 @@ public final class Ac3Util {
     if (isEac3) {
       int fscod = (buffer.get(buffer.position() + 4) & 0xC0) >> 6;
       int numblkscod = fscod == 0x03 ? 3 : (buffer.get(buffer.position() + 4) & 0x30) >> 4;
-      return BLOCKS_PER_SYNCFRAME_BY_NUMBLKSCOD[numblkscod] * AUDIO_SAMPLES_PER_AUDIO_BLOCK;
+      int samplesPerFrame = BLOCKS_PER_SYNCFRAME_BY_NUMBLKSCOD[numblkscod] * AUDIO_SAMPLES_PER_AUDIO_BLOCK;
+      // frmsiz is an 11-bit field at bits [21:31] of the sync frame header (bytes 2-3).
+      // Frame size in bytes = (frmsiz + 1) * 2.
+      int firstFrameBytes =
+          (((buffer.get(buffer.position() + 2) & 0x07) << 8
+                  | (buffer.get(buffer.position() + 3) & 0xFF))
+                  + 1)
+              * 2;
+      // MP4 access units may group multiple sync frames (ETSI TS 102 366 Annex F.6).
+      int numFrames = firstFrameBytes > 0 ? buffer.remaining() / firstFrameBytes : 1;
+      return numFrames * samplesPerFrame;
     } else {
       return AC3_SYNCFRAME_AUDIO_SAMPLE_COUNT;
     }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/Ac3Util.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/Ac3Util.java
@@ -537,19 +537,33 @@ public final class Ac3Util {
     // Parse the bitstream ID for AC-3 and E-AC-3 (see subsections 4.3, E.1.2 and E.1.3.1.6).
     boolean isEac3 = ((buffer.get(buffer.position() + 5) & 0xF8) >> 3) > 10;
     if (isEac3) {
-      int fscod = (buffer.get(buffer.position() + 4) & 0xC0) >> 6;
-      int numblkscod = fscod == 0x03 ? 3 : (buffer.get(buffer.position() + 4) & 0x30) >> 4;
-      int samplesPerFrame = BLOCKS_PER_SYNCFRAME_BY_NUMBLKSCOD[numblkscod] * AUDIO_SAMPLES_PER_AUDIO_BLOCK;
-      // frmsiz is an 11-bit field at bits [21:31] of the sync frame header (bytes 2-3).
-      // Frame size in bytes = (frmsiz + 1) * 2.
-      int firstFrameBytes =
-          (((buffer.get(buffer.position() + 2) & 0x07) << 8
-                  | (buffer.get(buffer.position() + 3) & 0xFF))
-                  + 1)
-              * 2;
-      // MP4 access units may group multiple sync frames (ETSI TS 102 366 Annex F.6).
-      int numFrames = firstFrameBytes > 0 ? buffer.remaining() / firstFrameBytes : 1;
-      return numFrames * samplesPerFrame;
+      // An EC-3 access unit may contain multiple syncframes. Per ETSI TS 102 366 Annex F,
+      // dependent substreams (strmtyp=1) cover the same presentation time as the preceding
+      // independent substream, so only audio blocks from independent substreams count toward the
+      // total sample duration.
+      int totalAudioBlocks = 0;
+      int pos = buffer.position();
+      int limit = buffer.limit();
+      while (pos + 6 <= limit) {
+        if ((buffer.get(pos) & 0xFF) != 0x0B || (buffer.get(pos + 1) & 0xFF) != 0x77) {
+          break;
+        }
+        int strmtyp = (buffer.get(pos + 2) & 0xC0) >> 6;
+        int frmsiz = ((buffer.get(pos + 2) & 0x07) << 8) | (buffer.get(pos + 3) & 0xFF);
+        int frameSize = (frmsiz + 1) * 2;
+        int fscod = (buffer.get(pos + 4) & 0xC0) >> 6;
+        int numblkscod = fscod == 0x03 ? 3 : (buffer.get(pos + 4) & 0x30) >> 4;
+        if (strmtyp != SyncFrameInfo.STREAM_TYPE_TYPE1) {
+          totalAudioBlocks += BLOCKS_PER_SYNCFRAME_BY_NUMBLKSCOD[numblkscod];
+        }
+        pos += frameSize;
+      }
+      if (totalAudioBlocks == 0) {
+        int fscod = (buffer.get(buffer.position() + 4) & 0xC0) >> 6;
+        int numblkscod = fscod == 0x03 ? 3 : (buffer.get(buffer.position() + 4) & 0x30) >> 4;
+        totalAudioBlocks = BLOCKS_PER_SYNCFRAME_BY_NUMBLKSCOD[numblkscod];
+      }
+      return totalAudioBlocks * AUDIO_SAMPLES_PER_AUDIO_BLOCK;
     } else {
       return AC3_SYNCFRAME_AUDIO_SAMPLE_COUNT;
     }

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/Ac3UtilTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/Ac3UtilTest.java
@@ -19,6 +19,9 @@ import static com.google.common.truth.Truth.assertThat;
 
 import androidx.media3.common.util.Util;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.common.primitives.Bytes;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -26,6 +29,7 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public final class Ac3UtilTest {
 
+  private static final int AUDIO_SAMPLES_PER_AUDIO_BLOCK = 256;
   private static final int TRUEHD_SYNCFRAME_SAMPLE_COUNT = 40;
   private static final byte[] TRUEHD_SYNCFRAME_HEADER =
       Util.getBytesFromHexString("C07504D8F8726FBA0097C00FB7520000");
@@ -42,5 +46,106 @@ public final class Ac3UtilTest {
   public void parseTrueHdSyncframeAudioSampleCount_syncframe() {
     assertThat(Ac3Util.parseTrueHdSyncframeAudioSampleCount(TRUEHD_SYNCFRAME_HEADER))
         .isEqualTo(TRUEHD_SYNCFRAME_SAMPLE_COUNT);
+  }
+
+  @Test
+  public void parseAc3SyncframeAudioSampleCount_eac3SingleSyncframe_returnsSyncframeSampleCount() {
+    byte[] syncframe =
+        buildEac3Syncframe(
+            Ac3Util.SyncFrameInfo.STREAM_TYPE_TYPE0,
+            /* substreamId= */ 0,
+            /* numblkscod= */ 2);
+
+    int sampleCount = Ac3Util.parseAc3SyncframeAudioSampleCount(ByteBuffer.wrap(syncframe));
+
+    assertThat(sampleCount).isEqualTo(3 * AUDIO_SAMPLES_PER_AUDIO_BLOCK);
+  }
+
+  @Test
+  public void parseAc3SyncframeAudioSampleCount_eac3SplitSyncframes_sumsSameSubstream() {
+    byte[] accessUnit =
+        Bytes.concat(
+            buildEac3Syncframe(
+                Ac3Util.SyncFrameInfo.STREAM_TYPE_TYPE0,
+                /* substreamId= */ 0,
+                /* numblkscod= */ 2),
+            buildEac3Syncframe(
+                Ac3Util.SyncFrameInfo.STREAM_TYPE_TYPE0,
+                /* substreamId= */ 0,
+                /* numblkscod= */ 2));
+
+    int sampleCount = Ac3Util.parseAc3SyncframeAudioSampleCount(ByteBuffer.wrap(accessUnit));
+
+    assertThat(sampleCount).isEqualTo(6 * AUDIO_SAMPLES_PER_AUDIO_BLOCK);
+  }
+
+  @Test
+  public void parseAc3SyncframeAudioSampleCount_eac3TruncatedSecondSyncframe_ignoresSecondFrame() {
+    byte[] secondSyncframe =
+        buildEac3Syncframe(
+            Ac3Util.SyncFrameInfo.STREAM_TYPE_TYPE0,
+            /* substreamId= */ 0,
+            /* numblkscod= */ 2);
+    byte[] accessUnit =
+        Bytes.concat(
+            buildEac3Syncframe(
+                Ac3Util.SyncFrameInfo.STREAM_TYPE_TYPE0,
+                /* substreamId= */ 0,
+                /* numblkscod= */ 2),
+            Arrays.copyOf(secondSyncframe, 6));
+
+    int sampleCount = Ac3Util.parseAc3SyncframeAudioSampleCount(ByteBuffer.wrap(accessUnit));
+
+    assertThat(sampleCount).isEqualTo(3 * AUDIO_SAMPLES_PER_AUDIO_BLOCK);
+  }
+
+  @Test
+  public void parseAc3SyncframeAudioSampleCount_eac3DependentSubstream_doesNotAddDuration() {
+    byte[] accessUnit =
+        Bytes.concat(
+            buildEac3Syncframe(
+                Ac3Util.SyncFrameInfo.STREAM_TYPE_TYPE0,
+                /* substreamId= */ 0,
+                /* numblkscod= */ 3),
+            buildEac3Syncframe(
+                Ac3Util.SyncFrameInfo.STREAM_TYPE_TYPE1,
+                /* substreamId= */ 0,
+                /* numblkscod= */ 3));
+
+    int sampleCount = Ac3Util.parseAc3SyncframeAudioSampleCount(ByteBuffer.wrap(accessUnit));
+
+    assertThat(sampleCount).isEqualTo(6 * AUDIO_SAMPLES_PER_AUDIO_BLOCK);
+  }
+
+  @Test
+  public void parseAc3SyncframeAudioSampleCount_eac3IndependentSubstreams_usesLongestTimeline() {
+    byte[] accessUnit =
+        Bytes.concat(
+            buildEac3Syncframe(
+                Ac3Util.SyncFrameInfo.STREAM_TYPE_TYPE0,
+                /* substreamId= */ 0,
+                /* numblkscod= */ 3),
+            buildEac3Syncframe(
+                Ac3Util.SyncFrameInfo.STREAM_TYPE_TYPE0,
+                /* substreamId= */ 1,
+                /* numblkscod= */ 3));
+
+    int sampleCount = Ac3Util.parseAc3SyncframeAudioSampleCount(ByteBuffer.wrap(accessUnit));
+
+    assertThat(sampleCount).isEqualTo(6 * AUDIO_SAMPLES_PER_AUDIO_BLOCK);
+  }
+
+  private static byte[] buildEac3Syncframe(
+      @Ac3Util.SyncFrameInfo.StreamType int streamType, int substreamId, int numblkscod) {
+    int frameSize = 8;
+    int frmsiz = frameSize / 2 - 1;
+    byte[] syncframe = new byte[frameSize];
+    syncframe[0] = 0x0B;
+    syncframe[1] = 0x77;
+    syncframe[2] = (byte) ((streamType << 6) | (substreamId << 3) | ((frmsiz >> 8) & 0x07));
+    syncframe[3] = (byte) (frmsiz & 0xFF);
+    syncframe[4] = (byte) (numblkscod << 4);
+    syncframe[5] = (byte) 0x80;
+    return syncframe;
   }
 }


### PR DESCRIPTION
Calculate the number of audio samples based on frame size and number of frames for EAC3.