### PR TITLE
Add flag to show duration for live content (Issue 3239)

### DIFF
--- a/libraries/session/src/main/java/androidx/media3/session/MediaLibraryService.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaLibraryService.java
@@ -641,6 +641,26 @@ public abstract class MediaLibraryService extends MediaSessionService {
       }
 
       /**
+       * Sets whether playback position and duration are published for live media items to legacy
+       * controllers.
+       *
+       * <p>By default this is {@code false}, which keeps live playback position and duration
+       * hidden for legacy controllers such as {@code MediaControllerCompat}.
+       *
+       * <p>If set to {@code true}, live playback position and duration are published to legacy
+       * controllers based on the player's values.
+       *
+       * @param showPlaybackPositionForLiveStreams Whether to publish playback position and
+       *     duration for live streams to legacy controllers.
+       * @return The builder to allow chaining.
+       */
+      @UnstableApi
+      public Builder setShowPlaybackPositionForLiveStreams(
+          boolean showPlaybackPositionForLiveStreams) {
+        return super.setShowPlaybackPositionForLiveStreams(showPlaybackPositionForLiveStreams);
+      }
+
+      /**
        * Sets whether library result errors should be replicated to the platform media session's
        * {@link android.media.session.PlaybackState} as a fatal error, a non-fatal error or not
        * replicated at all. Replication is only executed for calling legacy browsers ({@link
@@ -729,6 +749,7 @@ public abstract class MediaLibraryService extends MediaSessionService {
             bitmapLoader,
             playIfSuppressed,
             isPeriodicPositionUpdateEnabled,
+            showPlaybackPositionForLiveStreams,
             libraryErrorReplicationMode,
             packageNameOverride);
       }
@@ -748,6 +769,7 @@ public abstract class MediaLibraryService extends MediaSessionService {
         BitmapLoader bitmapLoader,
         boolean playIfSuppressed,
         boolean isPeriodicPositionUpdateEnabled,
+        boolean showPlaybackPositionForLiveStreams,
         @LibraryErrorReplicationMode int libraryErrorReplicationMode,
         @Nullable String overridePackageName) {
       super(
@@ -764,6 +786,7 @@ public abstract class MediaLibraryService extends MediaSessionService {
           bitmapLoader,
           playIfSuppressed,
           isPeriodicPositionUpdateEnabled,
+          showPlaybackPositionForLiveStreams,
           libraryErrorReplicationMode,
           /* useLegacySurfaceHandling= */ false,
           overridePackageName);
@@ -784,6 +807,7 @@ public abstract class MediaLibraryService extends MediaSessionService {
         BitmapLoader bitmapLoader,
         boolean playIfSuppressed,
         boolean isPeriodicPositionUpdateEnabled,
+        boolean showPlaybackPositionForLiveStreams,
         @LibraryErrorReplicationMode int libraryErrorReplicationMode,
         boolean useLegacySurfaceHandling,
         @Nullable String overridePackageName) {
@@ -802,6 +826,7 @@ public abstract class MediaLibraryService extends MediaSessionService {
           bitmapLoader,
           playIfSuppressed,
           isPeriodicPositionUpdateEnabled,
+          showPlaybackPositionForLiveStreams,
           libraryErrorReplicationMode,
           overridePackageName);
     }

--- a/libraries/session/src/main/java/androidx/media3/session/MediaLibrarySessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaLibrarySessionImpl.java
@@ -82,6 +82,7 @@ import java.util.concurrent.Future;
       BitmapLoader bitmapLoader,
       boolean playIfSuppressed,
       boolean isPeriodicPositionUpdateEnabled,
+      boolean showPlaybackPositionForLiveStreams,
       @MediaLibrarySession.LibraryErrorReplicationMode int libraryErrorReplicationMode,
       @Nullable String packageNameOverride) {
     super(
@@ -99,6 +100,7 @@ import java.util.concurrent.Future;
         bitmapLoader,
         playIfSuppressed,
         isPeriodicPositionUpdateEnabled,
+        showPlaybackPositionForLiveStreams,
         /* useLegacySurfaceHandling= */ false,
         packageNameOverride);
     this.instance = instance;

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSession.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSession.java
@@ -473,6 +473,26 @@ public class MediaSession {
     }
 
     /**
+     * Sets whether playback position and duration are published for live media items to legacy
+     * controllers.
+     *
+     * <p>By default this is {@code false}, which keeps live playback position and duration hidden
+     * for legacy controllers such as {@code MediaControllerCompat}.
+     *
+     * <p>If set to {@code true}, live playback position and duration are published to legacy
+     * controllers based on the player's values.
+     *
+     * @param showPlaybackPositionForLiveStreams Whether to publish playback position and duration
+     *     for live streams to legacy controllers.
+     * @return The builder to allow chaining.
+     */
+    @UnstableApi
+    public Builder setShowPlaybackPositionForLiveStreams(
+        boolean showPlaybackPositionForLiveStreams) {
+      return super.setShowPlaybackPositionForLiveStreams(showPlaybackPositionForLiveStreams);
+    }
+
+    /**
      * Sets whether a play button is shown if playback is {@linkplain
      * Player#getPlaybackSuppressionReason() suppressed}.
      *
@@ -565,6 +585,7 @@ public class MediaSession {
           bitmapLoader,
           playIfSuppressed,
           isPeriodicPositionUpdateEnabled,
+          showPlaybackPositionForLiveStreams,
           MediaLibrarySession.LIBRARY_ERROR_REPLICATION_MODE_NONE,
           useLegacySurfaceHandling,
           packageNameOverride);
@@ -823,6 +844,7 @@ public class MediaSession {
       BitmapLoader bitmapLoader,
       boolean playIfSuppressed,
       boolean isPeriodicPositionUpdateEnabled,
+      boolean showPlaybackPositionForLiveStreams,
       @MediaLibrarySession.LibraryErrorReplicationMode int libraryErrorReplicationMode,
       boolean useLegacySurfaceHandling,
       @Nullable String overridePackageName) {
@@ -847,6 +869,7 @@ public class MediaSession {
             bitmapLoader,
             playIfSuppressed,
             isPeriodicPositionUpdateEnabled,
+            showPlaybackPositionForLiveStreams,
             libraryErrorReplicationMode,
             useLegacySurfaceHandling,
             overridePackageName);
@@ -866,6 +889,7 @@ public class MediaSession {
       BitmapLoader bitmapLoader,
       boolean playIfSuppressed,
       boolean isPeriodicPositionUpdateEnabled,
+      boolean showPlaybackPositionForLiveStreams,
       @MediaLibrarySession.LibraryErrorReplicationMode int libraryErrorReplicationMode,
       boolean useLegacySurfaceHandling,
       @Nullable String overridePackageName) {
@@ -884,6 +908,7 @@ public class MediaSession {
         bitmapLoader,
         playIfSuppressed,
         isPeriodicPositionUpdateEnabled,
+        showPlaybackPositionForLiveStreams,
         useLegacySurfaceHandling,
         overridePackageName);
   }
@@ -2731,6 +2756,7 @@ public class MediaSession {
     /* package */ ImmutableList<CommandButton> mediaButtonPreferences;
     /* package */ ImmutableList<CommandButton> commandButtonsForMediaItems;
     /* package */ boolean isPeriodicPositionUpdateEnabled;
+    /* package */ boolean showPlaybackPositionForLiveStreams;
     /* package */ @Nullable String packageNameOverride;
 
     public BuilderBase(Context context, Player player, CallbackT callback) {
@@ -2745,6 +2771,7 @@ public class MediaSession {
       mediaButtonPreferences = ImmutableList.of();
       playIfSuppressed = true;
       isPeriodicPositionUpdateEnabled = true;
+      showPlaybackPositionForLiveStreams = false;
       commandButtonsForMediaItems = ImmutableList.of();
     }
 
@@ -2826,6 +2853,14 @@ public class MediaSession {
     @SuppressWarnings("unchecked")
     public BuilderT setPeriodicPositionUpdateEnabled(boolean isPeriodicPositionUpdateEnabled) {
       this.isPeriodicPositionUpdateEnabled = isPeriodicPositionUpdateEnabled;
+      return (BuilderT) this;
+    }
+
+    @CanIgnoreReturnValue
+    @SuppressWarnings("unchecked")
+    /* package */ BuilderT setShowPlaybackPositionForLiveStreams(
+        boolean showPlaybackPositionForLiveStreams) {
+      this.showPlaybackPositionForLiveStreams = showPlaybackPositionForLiveStreams;
       return (BuilderT) this;
     }
 

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionImpl.java
@@ -184,6 +184,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       BitmapLoader bitmapLoader,
       boolean playIfSuppressed,
       boolean isPeriodicPositionUpdateEnabled,
+      boolean showPlaybackPositionForLiveStreams,
       boolean useLegacySurfaceHandling,
       @Nullable String packageNameOverride) {
     Log.i(
@@ -242,6 +243,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
             tokenExtras,
             sessionActivity,
             playIfSuppressed,
+            showPlaybackPositionForLiveStreams,
             customLayout,
             mediaButtonPreferences,
             defaultSessionCommands,

--- a/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
+++ b/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java
@@ -158,6 +158,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
   private Player.Commands availablePlayerCommands;
   @Nullable private PlaybackException customPlaybackException;
   @Nullable private Player.Commands playerCommandsForErrorState;
+  private final boolean showPlaybackPositionForLiveStreams;
 
   @SuppressWarnings({
     "PendingIntentMutability", // We can't use SaferPendingIntent
@@ -170,6 +171,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       Bundle tokenExtras,
       @Nullable PendingIntent sessionActivity,
       boolean playIfSuppressed,
+      boolean showPlaybackPositionForLiveStreams,
       ImmutableList<CommandButton> customLayout,
       ImmutableList<CommandButton> mediaButtonPreferences,
       SessionCommands availableSessionCommands,
@@ -178,6 +180,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       @Nullable String packageNameOverride) {
     this.sessionImpl = session;
     this.playIfSuppressed = playIfSuppressed;
+    this.showPlaybackPositionForLiveStreams = showPlaybackPositionForLiveStreams;
     this.customLayout = customLayout;
     this.mediaButtonPreferences = mediaButtonPreferences;
     this.availableSessionCommands = availableSessionCommands;
@@ -1755,7 +1758,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
       @Nullable MediaItem currentMediaItem = player.getCurrentMediaItemWithCommandCheck();
       MediaMetadata newMediaMetadata = player.getMediaMetadataWithCommandCheck();
       long newDurationMs =
-          player.isCurrentMediaItemLiveWithCommandCheck()
+          !showPlaybackPositionForLiveStreams && player.isCurrentMediaItemLiveWithCommandCheck()
               ? C.TIME_UNSET
               : player.getDurationWithCommandCheck();
       String newMediaId =
@@ -1902,7 +1905,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
         customPlaybackException != null ? customPlaybackException : player.getPlayerError();
     boolean canReadPositions =
         player.isCommandAvailable(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)
-            && !player.isCurrentMediaItemLive();
+            && (showPlaybackPositionForLiveStreams || !player.isCurrentMediaItemLive());
     boolean shouldShowPlayButton =
         publicPlaybackException != null || Util.shouldShowPlayButton(player, playIfSuppressed);
     int state =

--- a/libraries/test_session_common/src/main/java/androidx/media3/test/session/common/MediaSessionConstants.java
+++ b/libraries/test_session_common/src/main/java/androidx/media3/test/session/common/MediaSessionConstants.java
@@ -40,6 +40,7 @@ public class MediaSessionConstants {
       "testCustomActionWithProgressUpdate";
   public static final String TEST_SILENT_IPC_PARSING_FAILURE = "testSilentIpcParsingFailure";
   public static final String TEST_REJECT_SEEK = "testRejectSeek";
+  public static final String TEST_LIVE_POSITION_CONFIGURED = "testLivePositionConfigured";
   // Bundle keys
   public static final String KEY_AVAILABLE_SESSION_COMMANDS = "availableSessionCommands";
   public static final String KEY_CONTROLLER = "controllerKey";

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerCompatCallbackWithMediaSessionTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerCompatCallbackWithMediaSessionTest.java
@@ -28,6 +28,7 @@ import static androidx.media3.common.Player.STATE_READY;
 import static androidx.media3.test.session.common.MediaSessionConstants.KEY_IS_LEGACY_CONTROLLER;
 import static androidx.media3.test.session.common.MediaSessionConstants.NOTIFICATION_CONTROLLER_KEY;
 import static androidx.media3.test.session.common.MediaSessionConstants.TEST_CUSTOM_ACTION_WITH_PROGRESS_UPDATE;
+import static androidx.media3.test.session.common.MediaSessionConstants.TEST_LIVE_POSITION_CONFIGURED;
 import static androidx.media3.test.session.common.MediaSessionConstants.TEST_MEDIA_CONTROLLER_COMPAT_CALLBACK_WITH_MEDIA_SESSION_TEST;
 import static androidx.media3.test.session.common.MediaSessionConstants.TEST_SET_SHOW_PLAY_BUTTON_IF_SUPPRESSED_TO_FALSE;
 import static androidx.media3.test.session.common.TestUtils.LONG_TIMEOUT_MS;
@@ -1516,6 +1517,63 @@ public class MediaControllerCompatCallbackWithMediaSessionTest {
         .isEqualTo(0);
     assertThat(getterPlaybackStateCompat.getActions() & PlaybackStateCompat.ACTION_SEEK_TO)
         .isEqualTo(0);
+  }
+
+  @Test
+  public void playbackStateChange_forSeekableLiveStream_notifiesKnownPositionAndSeekAction()
+      throws Exception {
+    Bundle tokenExtras = new Bundle();
+    tokenExtras.putBoolean(
+        MediaSessionProviderService.KEY_ENABLE_FAKE_MEDIA_NOTIFICATION_MANAGER_CONTROLLER, true);
+    tokenExtras.putBoolean(
+        MediaSessionProviderService.KEY_ENABLE_LIVE_MEDIA_POSITION, true
+    );
+    RemoteMediaSession configuredSession = new RemoteMediaSession(TEST_LIVE_POSITION_CONFIGURED, context, tokenExtras);
+    MediaControllerCompat configuredControllerCompat = new MediaControllerCompat(context, configuredSession.getCompatToken());
+    waitUntilSessionReady(configuredControllerCompat);
+
+    long testCurrentPositionMs = 5000;
+    long testBufferedPositionMs = 6000;
+    AtomicReference<PlaybackStateCompat> playbackStateRef = new AtomicReference<>();
+    CountDownLatch latch = new CountDownLatch(1);
+    MediaControllerCompat.Callback callback =
+        new MediaControllerCompat.Callback() {
+          @Override
+          public void onPlaybackStateChanged(PlaybackStateCompat state) {
+            if (state.getPosition() == testCurrentPositionMs) {
+              playbackStateRef.set(state);
+              latch.countDown();
+            }
+          }
+        };
+    configuredControllerCompat.registerCallback(callback, handler);
+    configuredSession
+        .getMockPlayer()
+        .setTimeline(
+            new FakeTimeline(
+                new FakeTimeline.TimelineWindowDefinition.Builder()
+                    .setLive(true)
+                    .setSeekable(true)
+                    .build()));
+    configuredSession.getMockPlayer().setCurrentPosition(testCurrentPositionMs);
+    configuredSession.getMockPlayer().setBufferedPosition(testBufferedPositionMs);
+
+    configuredSession.getMockPlayer().notifyPlaybackStateChanged(STATE_READY);
+
+    assertThat(latch.await(TIMEOUT_MS, MILLISECONDS)).isTrue();
+    PlaybackStateCompat parameterPlaybackStateCompat = playbackStateRef.get();
+    PlaybackStateCompat getterPlaybackStateCompat = configuredControllerCompat.getPlaybackState();
+    assertThat(getterPlaybackStateCompat.getPosition()).isEqualTo(testCurrentPositionMs);
+    assertThat(parameterPlaybackStateCompat.getBufferedPosition()).isEqualTo(testBufferedPositionMs);
+    assertThat(getterPlaybackStateCompat.getBufferedPosition()).isEqualTo(testBufferedPositionMs);
+    assertThat(parameterPlaybackStateCompat.getPlaybackSpeed()).isEqualTo(0f);
+    assertThat(getterPlaybackStateCompat.getPlaybackSpeed()).isEqualTo(0f);
+    assertThat(parameterPlaybackStateCompat.getActions() & PlaybackStateCompat.ACTION_SEEK_TO)
+        .isNotEqualTo(0);
+    assertThat(getterPlaybackStateCompat.getActions() & PlaybackStateCompat.ACTION_SEEK_TO)
+        .isNotEqualTo(0);
+    // release local session
+    configuredSession.release();
   }
 
   @Test

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerCompatPlaybackStateCompatActionsWithMediaSessionTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerCompatPlaybackStateCompatActionsWithMediaSessionTest.java
@@ -30,6 +30,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.v4.media.MediaDescriptionCompat;
+import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.session.MediaControllerCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
@@ -546,6 +547,97 @@ public class MediaControllerCompatPlaybackStateCompatActionsWithMediaSessionTest
 
     assertThat(latch.await(TIMEOUT_MS, MILLISECONDS)).isTrue();
     assertThat(receiovedOnPositionDiscontinuity.get()).isFalse();
+
+    mediaSession.release();
+    releasePlayer(player);
+  }
+
+  @Test
+  public void livePlayback_defaultBehavior_hidesPositionAndDurationForLegacyController()
+      throws Exception {
+    Player player =
+        createPlayerWithAvailableCommand(
+            createPlayer(
+                /* onPostCreationTask= */ createdPlayer -> {
+                  createdPlayer.setMediaItem(MediaItem.fromUri("asset:///media/wav/sample.wav"));
+                  createdPlayer.prepare();
+                }),
+            Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM);
+    Player livePlayer =
+        new ForwardingPlayer(player) {
+          @Override
+          public boolean isCurrentMediaItemLive() {
+            return true;
+          }
+
+          @Override
+          public long getDuration() {
+            return 3 * 60 * 60 * 1000L;
+          }
+
+          @Override
+          public long getCurrentPosition() {
+            return 60_000L;
+          }
+        };
+    MediaSession mediaSession = createMediaSession(livePlayer, /* callback= */ null);
+    MediaControllerCompat controllerCompat = createMediaControllerCompat(mediaSession);
+
+    assertThat(
+            controllerCompat.getPlaybackState().getActions() & PlaybackStateCompat.ACTION_SEEK_TO)
+        .isEqualTo(0);
+    assertThat(controllerCompat.getPlaybackState().getPosition())
+        .isEqualTo(PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN);
+    assertThat(controllerCompat.getMetadata().getLong(MediaMetadataCompat.METADATA_KEY_DURATION))
+        .isEqualTo(-1L);
+
+    mediaSession.release();
+    releasePlayer(player);
+  }
+
+  @Test
+  public void livePlayback_flagEnabled_publishesPositionAndDurationForLegacyController()
+      throws Exception {
+    Player player =
+        createPlayerWithAvailableCommand(
+            createPlayer(
+                /* onPostCreationTask= */ createdPlayer -> {
+                  createdPlayer.setMediaItem(MediaItem.fromUri("asset:///media/wav/sample.wav"));
+                  createdPlayer.prepare();
+                }),
+            Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM);
+    long testDurationMs = 3 * 60 * 60 * 1000L;
+    long testPositionMs = 60_000L;
+    Player livePlayer =
+        new ForwardingPlayer(player) {
+          @Override
+          public boolean isCurrentMediaItemLive() {
+            return true;
+          }
+
+          @Override
+          public long getDuration() {
+            return testDurationMs;
+          }
+
+          @Override
+          public long getCurrentPosition() {
+            return testPositionMs;
+          }
+        };
+    MediaSession mediaSession =
+        createMediaSession(
+            livePlayer,
+            /* callback= */ null,
+            /* showPlaybackPositionForLiveStreams= */ true);
+    MediaControllerCompat controllerCompat = createMediaControllerCompat(mediaSession);
+
+    assertThat(
+            controllerCompat.getPlaybackState().getActions() & PlaybackStateCompat.ACTION_SEEK_TO)
+        .isNotEqualTo(0);
+    assertThat(controllerCompat.getPlaybackState().getPosition()).isEqualTo(testPositionMs);
+    assertThat(controllerCompat.getMetadata().getLong(MediaMetadataCompat.METADATA_KEY_DURATION))
+        .isEqualTo(testDurationMs);
 
     mediaSession.release();
     releasePlayer(player);
@@ -2308,13 +2400,25 @@ public class MediaControllerCompatPlaybackStateCompatActionsWithMediaSessionTest
   }
 
   private static MediaSession createMediaSession(Player player) {
-    return createMediaSession(player, /* callback= */ null);
+    return createMediaSession(
+        player,
+        /* callback= */ null,
+        /* showPlaybackPositionForLiveStreams= */ false);
   }
 
   private static MediaSession createMediaSession(
       Player player, @Nullable MediaSession.Callback callback) {
+    return createMediaSession(
+        player, callback, /* showPlaybackPositionForLiveStreams= */ false);
+  }
+
+  private static MediaSession createMediaSession(
+      Player player,
+      @Nullable MediaSession.Callback callback,
+      boolean showPlaybackPositionForLiveStreams) {
     MediaSession.Builder session =
-        new MediaSession.Builder(ApplicationProvider.getApplicationContext(), player);
+        new MediaSession.Builder(ApplicationProvider.getApplicationContext(), player)
+            .setShowPlaybackPositionForLiveStreams(showPlaybackPositionForLiveStreams);
     if (callback != null) {
       session.setCallback(callback);
     }

--- a/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerCompatPlaybackStateCompatActionsWithMediaSessionTest.java
+++ b/libraries/test_session_current/src/androidTest/java/androidx/media3/session/MediaControllerCompatPlaybackStateCompatActionsWithMediaSessionTest.java
@@ -588,8 +588,6 @@ public class MediaControllerCompatPlaybackStateCompatActionsWithMediaSessionTest
         .isEqualTo(0);
     assertThat(controllerCompat.getPlaybackState().getPosition())
         .isEqualTo(PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN);
-    assertThat(controllerCompat.getMetadata().getLong(MediaMetadataCompat.METADATA_KEY_DURATION))
-        .isEqualTo(-1L);
 
     mediaSession.release();
     releasePlayer(player);

--- a/libraries/test_session_current/src/main/java/androidx/media3/session/MediaSessionProviderService.java
+++ b/libraries/test_session_current/src/main/java/androidx/media3/session/MediaSessionProviderService.java
@@ -145,6 +145,7 @@ public class MediaSessionProviderService extends Service {
 
   public static final String KEY_ENABLE_FAKE_MEDIA_NOTIFICATION_MANAGER_CONTROLLER =
       "key_enable_fake_media_notification_manager_controller";
+  public static final String KEY_ENABLE_LIVE_MEDIA_POSITION = "key_enable_live_media_position";
   private static final String TAG = "MSProviderService";
 
   private Map<String, MediaSession> sessionMap = new HashMap<>();
@@ -202,10 +203,16 @@ public class MediaSessionProviderService extends Service {
       boolean useFakeMediaNotificationManagerController =
           tokenExtras.getBoolean(
               KEY_ENABLE_FAKE_MEDIA_NOTIFICATION_MANAGER_CONTROLLER, /* defaultValue= */ false);
+
+      boolean usePositionForLiveContent = tokenExtras.getBoolean(
+          KEY_ENABLE_LIVE_MEDIA_POSITION, false
+      );
       MockPlayer mockPlayer =
           new MockPlayer.Builder().setApplicationLooper(handler.getLooper()).build();
       MediaSession.Builder builder =
-          new MediaSession.Builder(MediaSessionProviderService.this, mockPlayer).setId(sessionId);
+          new MediaSession.Builder(MediaSessionProviderService.this, mockPlayer)
+              .setShowPlaybackPositionForLiveStreams(usePositionForLiveContent)
+              .setId(sessionId);
 
       builder.setExtras(tokenExtras);
       switch (sessionId) {


### PR DESCRIPTION
https://github.com/androidx/media/issues/3260: In the case of event playlist live content that is long running, it can useful to allow user's to scrub through the content. However, due the changes from this issue https://github.com/androidx/media/issues/1758, that is no longer an option.

Solution:
It was suggested in the issue thread that there could be a flag in the MediaSession builder which could allow devs to decide if they want to show the seek bar for live content. Below is a summary of the changes:

Add new flag, showPlaybackPositionForLiveStreams to MediaSession and MediaLibraryService
Add setters for the new flag
Add test coverage for the new case