### PR TITLE
Add muxer support for Dolby Atmos

### DIFF
--- a/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
+++ b/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
@@ -742,6 +742,9 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
         return damrBox(/* mode= */ (short) 0x83FF); // mode set: all enabled for AMR-WB
       case MimeTypes.AUDIO_OPUS:
         return dOpsBox(format);
+      case MimeTypes.AUDIO_E_AC3:
+      case MimeTypes.AUDIO_E_AC3_JOC:
+        return dec3Box(format);
       case MimeTypes.AUDIO_RAW:
         return ByteBuffer.allocate(0); // No codec specific box for raw audio.
       case MimeTypes.VIDEO_H263:
@@ -1590,6 +1593,19 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
     return BoxUtils.wrapIntoBox("av1C", ByteBuffer.wrap(csd0));
   }
 
+  /**
+   * Returns the dec3 box (EC3SpecificBox) for E-AC-3 / E-AC-3 JOC (Dolby Atmos) audio.
+   *
+   * <p>The dec3 box body is the codec-specific configuration, carried verbatim in csd-0. Stream-copy
+   * callers must populate {@code format.initializationData} with the source track's raw dec3 payload.
+   */
+  private static ByteBuffer dec3Box(Format format) {
+    checkArgument(
+        !format.initializationData.isEmpty(), "csd-0 (dec3 payload) not found for dec3 box.");
+    byte[] csd0 = format.initializationData.get(0);
+    return BoxUtils.wrapIntoBox("dec3", ByteBuffer.wrap(csd0));
+  }
+
   /** Returns a dvcC/dvwC/dvvC vision box which will be included in dolby vision box. */
   private static ByteBuffer doviBox(int profile, byte[] csd) {
     checkArgument(csd.length > 0, "csd is empty for dovi box.");
@@ -1792,6 +1808,9 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
         return "s263";
       case MimeTypes.AUDIO_OPUS:
         return "Opus";
+      case MimeTypes.AUDIO_E_AC3:
+      case MimeTypes.AUDIO_E_AC3_JOC:
+        return "ec-3";
       case MimeTypes.AUDIO_RAW:
         if (format.pcmEncoding == C.ENCODING_PCM_16BIT) {
           return "sowt";

--- a/libraries/muxer/src/main/java/androidx/media3/muxer/FragmentedMp4Muxer.java
+++ b/libraries/muxer/src/main/java/androidx/media3/muxer/FragmentedMp4Muxer.java
@@ -178,7 +178,9 @@ public final class FragmentedMp4Muxer implements Muxer {
           MimeTypes.AUDIO_AMR_WB,
           MimeTypes.AUDIO_OPUS,
           MimeTypes.AUDIO_VORBIS,
-          MimeTypes.AUDIO_RAW);
+          MimeTypes.AUDIO_RAW,
+          MimeTypes.AUDIO_E_AC3,
+          MimeTypes.AUDIO_E_AC3_JOC);
 
   // LINT.ThenChange(Boxes.java:codec_specific_boxes)
 

--- a/libraries/muxer/src/main/java/androidx/media3/muxer/Mp4Muxer.java
+++ b/libraries/muxer/src/main/java/androidx/media3/muxer/Mp4Muxer.java
@@ -404,7 +404,9 @@ public final class Mp4Muxer implements Muxer {
           MimeTypes.AUDIO_AMR_WB,
           MimeTypes.AUDIO_OPUS,
           MimeTypes.AUDIO_VORBIS,
-          MimeTypes.AUDIO_RAW);
+          MimeTypes.AUDIO_RAW,
+          MimeTypes.AUDIO_E_AC3,
+          MimeTypes.AUDIO_E_AC3_JOC);
 
   // LINT.ThenChange(Boxes.java:codec_specific_boxes)
 

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/BoxesTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/BoxesTest.java
@@ -401,6 +401,63 @@ public class BoxesTest {
   }
 
   @Test
+  public void createCodecSpecificBox_forEAc3_wrapsDec3PayloadVerbatim() {
+    byte[] payload = new byte[] {0x0F, (byte) 0x80, 0x00};
+    Format format =
+        FAKE_AUDIO_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
+            .setInitializationData(ImmutableList.of(payload))
+            .build();
+
+    ByteBuffer box = Boxes.codecSpecificBox(format);
+
+    // Box layout: 4 bytes size + 4 bytes "dec3" type + payload bytes.
+    assertThat(box.remaining()).isEqualTo(8 + payload.length);
+    byte[] typeBytes = new byte[4];
+    box.position(4);
+    box.get(typeBytes);
+    assertThat(new String(typeBytes)).isEqualTo("dec3");
+    byte[] actual = new byte[payload.length];
+    box.get(actual);
+    assertThat(actual).isEqualTo(payload);
+  }
+
+  @Test
+  public void createCodecSpecificBox_forEAc3Joc_wrapsDec3PayloadVerbatim() {
+    byte[] payload = new byte[] {0x0F, (byte) 0x80, 0x00};
+    Format format =
+        FAKE_AUDIO_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_E_AC3_JOC)
+            .setInitializationData(ImmutableList.of(payload))
+            .build();
+
+    ByteBuffer box = Boxes.codecSpecificBox(format);
+
+    assertThat(box.remaining()).isEqualTo(8 + payload.length);
+    byte[] typeBytes = new byte[4];
+    box.position(4);
+    box.get(typeBytes);
+    assertThat(new String(typeBytes)).isEqualTo("dec3");
+    byte[] actual = new byte[payload.length];
+    box.get(actual);
+    assertThat(actual).isEqualTo(payload);
+  }
+
+  @Test
+  public void createCodecSpecificBox_forEAc3WithNoCsd_throws() {
+    Format format =
+        FAKE_AUDIO_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
+            .setInitializationData(ImmutableList.of())
+            .build();
+
+    assertThrows(IllegalArgumentException.class, () -> Boxes.codecSpecificBox(format));
+  }
+
+  @Test
   public void createAudioSampleEntryBox_withUnknownAudioFormat_throws() {
     // The audio format contains an unknown MIME type.
     Format format = FAKE_AUDIO_FORMAT.buildUpon().setSampleMimeType("audio/mp4a-unknown").build();


### PR DESCRIPTION
## Summary

  Add support for muxing Dolby Atmos (E-AC-3 JOC) tracks in Mp4Muxer.

##  Problem

Mp4Muxer and FragmentedMp4Muxer did not support AUDIO_E_AC3 or AUDIO_E_AC3_JOC MIME types. Attempting to mux an E-AC-3 or Dolby Atmos track would fail at the supported-format check, and even if bypassed, the codec-specific box  (dec3) and fourcc (ec-3) were not implemented. This made stream-copy of Dolby Atmos audio from one MP4 container to another impossible using the in-app muxer.

##  Changes

  - Boxes.java: Added dec3Box() which wraps the raw EC3SpecificBox payload from format.initializationData (csd-0) verbatim into a dec3 box. Added AUDIO_E_AC3 / AUDIO_E_AC3_JOC cases in codecSpecificBox() and codecSpecificFourcc()
  (fourcc: ec-3).
  - Mp4Muxer.java: Added AUDIO_E_AC3 and AUDIO_E_AC3_JOC to SUPPORTED_AUDIO_SAMPLE_MIME_TYPES.
  - FragmentedMp4Muxer.java: Same addition to SUPPORTED_AUDIO_SAMPLE_MIME_TYPES.
  - BoxesTest.java: Added 3 unit tests — dec3 payload wrapping for E-AC3, dec3 payload wrapping for E-AC3 JOC, and a guard test verifying IllegalArgumentException when csd-0 is missing.

##  Testing

  - ./gradlew :lib-muxer:compileDebugJavaWithJavac — clean compile.
  - ./gradlew :lib-muxer:test — all existing tests pass; 3 new unit tests added and passing.
  - No device testing yet; the new code path is only exercised during stream-copy (no encoding/decoding involved).

##  Notes

  - This is a stream-copy only implementation. The dec3 payload must be populated in format.initializationData by the caller (e.g. copied verbatim from the source track's EC3SpecificBox). There is no encoding-side support.
  - The dec3 payload is carried verbatim with no parsing or validation beyond the non-empty check — consistent with how av1C and dOps are handled.
  - Follow-up work: end-to-end test with a real Atmos source file via Mp4MuxerEndToEndParameterizedTest once test assets are available.
