### PR TITLE
Adds E-AC-3 / Dolby Atmos (E-AC-3 JOC) support across the MP4 extractor and muxer.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -24,6 +24,9 @@
         Custom `AssetLoader` implementations must implement these new methods.
 *   Track Selection:
 *   Extractors:
+    *   MP4: Preserve E-AC-3 and E-AC-3 JOC (Dolby Atmos) format metadata during
+        demuxing to enable lossless stream-copying
+        ([#3317](https://github.com/androidx/media/pull/3317)).
 *   Inspector:
 *   Inspector Frame:
 *   Audio:
@@ -40,6 +43,9 @@
 *   Muxers:
     *   Fix crash in `Mp4Writer` when writing an EOS sample before any other
         samples are written.
+    *   MP4: Add support for writing E-AC-3 and E-AC-3 JOC (Dolby Atmos) audio
+        tracks in `Mp4Muxer` and `FragmentedMp4Muxer`
+        ([#3317](https://github.com/androidx/media/pull/3317)).
 *   IMA extension:
 *   Session:
 *   UI:

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -24,9 +24,6 @@
         Custom `AssetLoader` implementations must implement these new methods.
 *   Track Selection:
 *   Extractors:
-    *   MP4: Preserve E-AC-3 and E-AC-3 JOC (Dolby Atmos) format metadata during
-        demuxing to enable lossless stream-copying
-        ([#3317](https://github.com/androidx/media/pull/3317)).
 *   Inspector:
 *   Inspector Frame:
 *   Audio:
@@ -43,9 +40,6 @@
 *   Muxers:
     *   Fix crash in `Mp4Writer` when writing an EOS sample before any other
         samples are written.
-    *   MP4: Add support for writing E-AC-3 and E-AC-3 JOC (Dolby Atmos) audio
-        tracks in `Mp4Muxer` and `FragmentedMp4Muxer`
-        ([#3317](https://github.com/androidx/media/pull/3317)).
 *   IMA extension:
 *   Session:
 *   UI:

--- a/libraries/container/src/main/java/androidx/media3/container/FormatSpecificTransmuxingData.java
+++ b/libraries/container/src/main/java/androidx/media3/container/FormatSpecificTransmuxingData.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.container;
+
+import androidx.annotation.Nullable;
+import androidx.media3.common.Metadata;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.common.util.Util;
+import java.util.Arrays;
+
+/**
+ * Stores the raw payload of a format-specific box so it can be re-written during transmuxing (stream
+ * copy) without re-encoding.
+ *
+ * <p>Some codecs store codec configuration in a container box whose bytes are not otherwise exposed
+ * on {@link androidx.media3.common.Format} (for example the E-AC-3 {@code dec3} / EC3SpecificBox).
+ * The extractor preserves that box's payload here so a muxer can reproduce the box verbatim.
+ *
+ * <p>The {@link #data} holds the box body only, i.e. excluding the 4-byte size and 4-byte type
+ * header, and {@link #boxType} identifies which box the payload belongs to (for example {@code
+ * dec3}).
+ */
+@UnstableApi
+public final class FormatSpecificTransmuxingData implements Metadata.Entry {
+
+  /** The four-character type of the box the {@link #data} belongs to, for example {@code dec3}. */
+  public final String boxType;
+
+  /** The raw box payload (the box body, excluding its 4-byte size and 4-byte type header). */
+  public final byte[] data;
+
+  /** Creates an instance. */
+  public FormatSpecificTransmuxingData(String boxType, byte[] data) {
+    this.boxType = boxType;
+    this.data = data;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    FormatSpecificTransmuxingData other = (FormatSpecificTransmuxingData) obj;
+    return boxType.equals(other.boxType) && Arrays.equals(data, other.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * boxType.hashCode() + Arrays.hashCode(data);
+  }
+
+  @Override
+  public String toString() {
+    return "FormatSpecificTransmuxingData: boxType=" + boxType;
+  }
+}

--- a/libraries/container/src/main/java/androidx/media3/container/FormatSpecificTransmuxingData.java
+++ b/libraries/container/src/main/java/androidx/media3/container/FormatSpecificTransmuxingData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Android Open Source Project
+ * Copyright 2026 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package androidx.media3.container;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import androidx.annotation.Nullable;
 import androidx.media3.common.Metadata;
@@ -43,8 +45,8 @@ public final class FormatSpecificTransmuxingData implements Metadata.Entry {
 
   /** Creates an instance. */
   public FormatSpecificTransmuxingData(String boxType, byte[] data) {
-    this.boxType = boxType;
-    this.data = data;
+    this.boxType = checkNotNull(boxType);
+    this.data = checkNotNull(data).clone();
   }
 
   @Override

--- a/libraries/container/src/main/java/androidx/media3/container/FormatSpecificTransmuxingData.java
+++ b/libraries/container/src/main/java/androidx/media3/container/FormatSpecificTransmuxingData.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
  *
  * <p>Some codecs store codec configuration in a container box whose bytes are not otherwise exposed
  * on {@link androidx.media3.common.Format} (for example the E-AC-3 {@code dec3} / EC3SpecificBox).
- * The extractor preserves that box's payload here so a muxer can reproduce the box verbatim.
  *
  * <p>The {@link #data} holds the box body only, i.e. excluding the 4-byte size and 4-byte type
  * header, and {@link #boxType} identifies which box the payload belongs to (for example {@code

--- a/libraries/container/src/main/java/androidx/media3/container/FormatSpecificTransmuxingData.java
+++ b/libraries/container/src/main/java/androidx/media3/container/FormatSpecificTransmuxingData.java
@@ -18,12 +18,11 @@ package androidx.media3.container;
 import androidx.annotation.Nullable;
 import androidx.media3.common.Metadata;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.common.util.Util;
 import java.util.Arrays;
 
 /**
- * Stores the raw payload of a format-specific box so it can be re-written during transmuxing (stream
- * copy) without re-encoding.
+ * Stores the raw payload of a format-specific box so it can be re-written during transmuxing
+ * (stream copy) without re-encoding.
  *
  * <p>Some codecs store codec configuration in a container box whose bytes are not otherwise exposed
  * on {@link androidx.media3.common.Format} (for example the E-AC-3 {@code dec3} / EC3SpecificBox).

--- a/libraries/container/src/main/java/androidx/media3/container/Mp4FormatSpecificMetadataEntry.java
+++ b/libraries/container/src/main/java/androidx/media3/container/Mp4FormatSpecificMetadataEntry.java
@@ -34,7 +34,7 @@ import java.util.Arrays;
  * dec3}).
  */
 @UnstableApi
-public final class FormatSpecificTransmuxingData implements Metadata.Entry {
+public final class Mp4FormatSpecificMetadataEntry implements Metadata.Entry {
 
   /** The four-character type of the box the {@link #data} belongs to, for example {@code dec3}. */
   public final String boxType;
@@ -43,7 +43,7 @@ public final class FormatSpecificTransmuxingData implements Metadata.Entry {
   public final byte[] data;
 
   /** Creates an instance. */
-  public FormatSpecificTransmuxingData(String boxType, byte[] data) {
+  public Mp4FormatSpecificMetadataEntry(String boxType, byte[] data) {
     this.boxType = checkNotNull(boxType);
     this.data = checkNotNull(data).clone();
   }
@@ -56,7 +56,7 @@ public final class FormatSpecificTransmuxingData implements Metadata.Entry {
     if (obj == null || getClass() != obj.getClass()) {
       return false;
     }
-    FormatSpecificTransmuxingData other = (FormatSpecificTransmuxingData) obj;
+    Mp4FormatSpecificMetadataEntry other = (Mp4FormatSpecificMetadataEntry) obj;
     return boxType.equals(other.boxType) && Arrays.equals(data, other.data);
   }
 
@@ -67,6 +67,6 @@ public final class FormatSpecificTransmuxingData implements Metadata.Entry {
 
   @Override
   public String toString() {
-    return "FormatSpecificTransmuxingData: boxType=" + boxType;
+    return "Mp4FormatSpecificMetadataEntry: boxType=" + boxType;
   }
 }

--- a/libraries/container/src/main/java/androidx/media3/container/Mp4FormatSpecificMetadataEntry.java
+++ b/libraries/container/src/main/java/androidx/media3/container/Mp4FormatSpecificMetadataEntry.java
@@ -15,9 +15,8 @@
  */
 package androidx.media3.container;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import androidx.annotation.Nullable;
+import androidx.media3.common.Format;
 import androidx.media3.common.Metadata;
 import androidx.media3.common.util.UnstableApi;
 import java.util.Arrays;
@@ -27,7 +26,8 @@ import java.util.Arrays;
  * (stream copy) without re-encoding.
  *
  * <p>Some codecs store codec configuration in a container box whose bytes are not otherwise exposed
- * on {@link androidx.media3.common.Format} (for example the E-AC-3 {@code dec3} / EC3SpecificBox).
+ * on {@link Format} or {@link Format#initializationData} (for example the E-AC-3 {@code dec3} /
+ * EC3SpecificBox).
  *
  * <p>The {@link #data} holds the box body only, i.e. excluding the 4-byte size and 4-byte type
  * header, and {@link #boxType} identifies which box the payload belongs to (for example {@code
@@ -44,8 +44,8 @@ public final class Mp4FormatSpecificMetadataEntry implements Metadata.Entry {
 
   /** Creates an instance. */
   public Mp4FormatSpecificMetadataEntry(String boxType, byte[] data) {
-    this.boxType = checkNotNull(boxType);
-    this.data = checkNotNull(data).clone();
+    this.boxType = boxType;
+    this.data = data.clone();
   }
 
   @Override

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
@@ -41,6 +41,7 @@ import androidx.media3.common.util.ParsableByteArray;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
 import androidx.media3.container.DolbyVisionConfig;
+import androidx.media3.container.FormatSpecificTransmuxingData;
 import androidx.media3.container.Mp4AlternateGroupData;
 import androidx.media3.container.Mp4Box;
 import androidx.media3.container.Mp4Box.LeafBox;
@@ -2251,9 +2252,25 @@ public final class BoxParser {
         out.format =
             Ac3Util.parseAc3AnnexFFormat(parent, Integer.toString(trackId), language, drmInitData);
       } else if (childAtomType == Mp4Box.TYPE_dec3) {
+        // Preserve the raw EC3SpecificBox body as format-specific transmuxing metadata so that
+        // downstream components (e.g. the muxer for stream-copy) can rewrite the dec3 box.
+        int childAtomBodySize = childAtomSize - Mp4Box.HEADER_SIZE;
+        byte[] ec3SpecificBoxPayload = new byte[childAtomBodySize];
         parent.setPosition(Mp4Box.HEADER_SIZE + childPosition);
-        out.format =
+        parent.readBytes(ec3SpecificBoxPayload, /* offset= */ 0, childAtomBodySize);
+        parent.setPosition(Mp4Box.HEADER_SIZE + childPosition);
+        Format eac3Format =
             Ac3Util.parseEAc3AnnexFFormat(parent, Integer.toString(trackId), language, drmInitData);
+        Metadata.Entry dec3TransmuxingData =
+            new FormatSpecificTransmuxingData("dec3", ec3SpecificBoxPayload);
+        out.format =
+            eac3Format
+                .buildUpon()
+                .setMetadata(
+                    eac3Format.metadata != null
+                        ? eac3Format.metadata.copyWithAppendedEntries(dec3TransmuxingData)
+                        : new Metadata(dec3TransmuxingData))
+                .build();
       } else if (childAtomType == Mp4Box.TYPE_dac4) {
         parent.setPosition(Mp4Box.HEADER_SIZE + childPosition);
         out.format =

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
@@ -41,10 +41,10 @@ import androidx.media3.common.util.ParsableByteArray;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
 import androidx.media3.container.DolbyVisionConfig;
-import androidx.media3.container.FormatSpecificTransmuxingData;
 import androidx.media3.container.Mp4AlternateGroupData;
 import androidx.media3.container.Mp4Box;
 import androidx.media3.container.Mp4Box.LeafBox;
+import androidx.media3.container.Mp4FormatSpecificMetadataEntry;
 import androidx.media3.container.Mp4LocationData;
 import androidx.media3.container.Mp4TimestampData;
 import androidx.media3.container.NalUnitUtil;
@@ -2262,7 +2262,7 @@ public final class BoxParser {
         Format eac3Format =
             Ac3Util.parseEAc3AnnexFFormat(parent, Integer.toString(trackId), language, drmInitData);
         Metadata.Entry dec3TransmuxingData =
-            new FormatSpecificTransmuxingData("dec3", ec3SpecificBoxPayload);
+            new Mp4FormatSpecificMetadataEntry("dec3", ec3SpecificBoxPayload);
         out.format =
             eac3Format
                 .buildUpon()

--- a/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
+++ b/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
@@ -784,7 +784,13 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
         return iacbBox(format);
       case MimeTypes.AUDIO_E_AC3:
       case MimeTypes.AUDIO_E_AC3_JOC:
-        byte[] dec3Payload = getTransmuxingBoxPayload(format, "dec3");
+        @Nullable
+        Mp4FormatSpecificMetadataEntry dec3Entry =
+            format.metadata != null
+                ? format.metadata.getFirstEntryOfType(Mp4FormatSpecificMetadataEntry.class)
+                : null;
+        byte[] dec3Payload =
+            dec3Entry != null && dec3Entry.boxType.equals("dec3") ? dec3Entry.data : null;
         checkArgument(
             dec3Payload != null && dec3Payload.length > 0, "dec3 payload not found for dec3 box.");
         return BoxUtils.wrapIntoBox("dec3", ByteBuffer.wrap(dec3Payload));
@@ -1648,22 +1654,6 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
     byte[] csd0 = format.initializationData.get(0);
 
     return BoxUtils.wrapIntoBox("av1C", ByteBuffer.wrap(csd0));
-  }
-
-  /**
-   * Returns the raw payload of the {@link Mp4FormatSpecificMetadataEntry} entry on {@code
-   * format.metadata} whose {@linkplain Mp4FormatSpecificMetadataEntry#boxType boxType} matches
-   * {@code boxType}, or {@code null} if there is no such entry.
-   */
-  @Nullable
-  private static byte[] getTransmuxingBoxPayload(Format format, String boxType) {
-    if (format.metadata == null) {
-      return null;
-    }
-    @Nullable
-    Mp4FormatSpecificMetadataEntry entry =
-        format.metadata.getFirstEntryOfType(Mp4FormatSpecificMetadataEntry.class);
-    return entry != null && entry.boxType.equals(boxType) ? entry.data : null;
   }
 
   /** Returns a dvcC/dvwC/dvvC vision box which will be included in dolby vision box. */

--- a/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
+++ b/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
@@ -30,10 +30,12 @@ import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
+import androidx.media3.common.Metadata;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.CodecSpecificDataUtil;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.Util;
+import androidx.media3.container.FormatSpecificTransmuxingData;
 import androidx.media3.container.MdtaMetadataEntry;
 import androidx.media3.container.Mp4LocationData;
 import androidx.media3.container.NalUnitUtil;
@@ -781,6 +783,9 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
         return dOpsBox(format);
       case MimeTypes.AUDIO_IAMF:
         return iacbBox(format);
+      case MimeTypes.AUDIO_E_AC3:
+      case MimeTypes.AUDIO_E_AC3_JOC:
+        return dec3Box(format);
       case MimeTypes.AUDIO_RAW:
         return ByteBuffer.allocate(0); // No codec specific box for raw audio.
       case MimeTypes.VIDEO_H263:
@@ -1643,6 +1648,42 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
     return BoxUtils.wrapIntoBox("av1C", ByteBuffer.wrap(csd0));
   }
 
+  /**
+   * Returns the dec3 box (EC3SpecificBox) for E-AC-3 / E-AC-3 JOC (Dolby Atmos) audio.
+   *
+   * <p>The dec3 box body is carried verbatim in a {@link FormatSpecificTransmuxingData} entry (with
+   * {@linkplain FormatSpecificTransmuxingData#boxType boxType} {@code "dec3"}) on {@link
+   * Format#metadata}. Stream-copy callers must populate it with the source track's raw dec3 payload;
+   * the MP4 extractor populates this from the source {@code dec3} box.
+   */
+  private static ByteBuffer dec3Box(Format format) {
+    byte[] dec3Payload = getTransmuxingBoxPayload(format, "dec3");
+    checkArgument(
+        dec3Payload != null && dec3Payload.length > 0, "dec3 payload not found for dec3 box.");
+    return BoxUtils.wrapIntoBox("dec3", ByteBuffer.wrap(dec3Payload));
+  }
+
+  /**
+   * Returns the raw payload of the {@link FormatSpecificTransmuxingData} entry on {@code
+   * format.metadata} whose {@linkplain FormatSpecificTransmuxingData#boxType boxType} matches {@code
+   * boxType}, or {@code null} if there is no such entry.
+   */
+  @Nullable
+  private static byte[] getTransmuxingBoxPayload(Format format, String boxType) {
+    @Nullable Metadata metadata = format.metadata;
+    if (metadata == null) {
+      return null;
+    }
+    for (int i = 0; i < metadata.length(); i++) {
+      Metadata.Entry entry = metadata.get(i);
+      if (entry instanceof FormatSpecificTransmuxingData
+          && ((FormatSpecificTransmuxingData) entry).boxType.equals(boxType)) {
+        return ((FormatSpecificTransmuxingData) entry).data;
+      }
+    }
+    return null;
+  }
+
   /** Returns a dvcC/dvwC/dvvC vision box which will be included in dolby vision box. */
   private static ByteBuffer doviBox(int profile, byte[] csd) {
     checkArgument(csd.length > 0, "csd is empty for dovi box.");
@@ -1847,6 +1888,9 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
         return "Opus";
       case MimeTypes.AUDIO_IAMF:
         return "iamf";
+      case MimeTypes.AUDIO_E_AC3:
+      case MimeTypes.AUDIO_E_AC3_JOC:
+        return "ec-3";
       case MimeTypes.AUDIO_RAW:
         if (format.pcmEncoding == C.ENCODING_PCM_16BIT) {
           return "sowt";

--- a/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
+++ b/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
@@ -34,8 +34,8 @@ import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.CodecSpecificDataUtil;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.Util;
-import androidx.media3.container.FormatSpecificTransmuxingData;
 import androidx.media3.container.MdtaMetadataEntry;
+import androidx.media3.container.Mp4FormatSpecificMetadataEntry;
 import androidx.media3.container.Mp4LocationData;
 import androidx.media3.container.NalUnitUtil;
 import androidx.media3.muxer.FragmentedMp4Writer.SampleMetadata;
@@ -1651,8 +1651,8 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
   }
 
   /**
-   * Returns the raw payload of the {@link FormatSpecificTransmuxingData} entry on {@code
-   * format.metadata} whose {@linkplain FormatSpecificTransmuxingData#boxType boxType} matches
+   * Returns the raw payload of the {@link Mp4FormatSpecificMetadataEntry} entry on {@code
+   * format.metadata} whose {@linkplain Mp4FormatSpecificMetadataEntry#boxType boxType} matches
    * {@code boxType}, or {@code null} if there is no such entry.
    */
   @Nullable
@@ -1661,8 +1661,8 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
       return null;
     }
     @Nullable
-    FormatSpecificTransmuxingData entry =
-        format.metadata.getFirstEntryOfType(FormatSpecificTransmuxingData.class);
+    Mp4FormatSpecificMetadataEntry entry =
+        format.metadata.getFirstEntryOfType(Mp4FormatSpecificMetadataEntry.class);
     return entry != null && entry.boxType.equals(boxType) ? entry.data : null;
   }
 

--- a/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
+++ b/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
@@ -785,7 +785,10 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
         return iacbBox(format);
       case MimeTypes.AUDIO_E_AC3:
       case MimeTypes.AUDIO_E_AC3_JOC:
-        return dec3Box(format);
+        byte[] dec3Payload = getTransmuxingBoxPayload(format, "dec3");
+        checkArgument(
+            dec3Payload != null && dec3Payload.length > 0, "dec3 payload not found for dec3 box.");
+        return BoxUtils.wrapIntoBox("dec3", ByteBuffer.wrap(dec3Payload));
       case MimeTypes.AUDIO_RAW:
         return ByteBuffer.allocate(0); // No codec specific box for raw audio.
       case MimeTypes.VIDEO_H263:
@@ -1649,33 +1652,17 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
   }
 
   /**
-   * Returns the dec3 box (EC3SpecificBox) for E-AC-3 / E-AC-3 JOC (Dolby Atmos) audio.
-   *
-   * <p>The dec3 box body is carried verbatim in a {@link FormatSpecificTransmuxingData} entry (with
-   * {@linkplain FormatSpecificTransmuxingData#boxType boxType} {@code "dec3"}) on {@link
-   * Format#metadata}. Stream-copy callers must populate it with the source track's raw dec3
-   * payload; the MP4 extractor populates this from the source {@code dec3} box.
-   */
-  private static ByteBuffer dec3Box(Format format) {
-    byte[] dec3Payload = getTransmuxingBoxPayload(format, "dec3");
-    checkArgument(
-        dec3Payload != null && dec3Payload.length > 0, "dec3 payload not found for dec3 box.");
-    return BoxUtils.wrapIntoBox("dec3", ByteBuffer.wrap(dec3Payload));
-  }
-
-  /**
    * Returns the raw payload of the {@link FormatSpecificTransmuxingData} entry on {@code
    * format.metadata} whose {@linkplain FormatSpecificTransmuxingData#boxType boxType} matches
    * {@code boxType}, or {@code null} if there is no such entry.
    */
   @Nullable
   private static byte[] getTransmuxingBoxPayload(Format format, String boxType) {
-    @Nullable Metadata metadata = format.metadata;
-    if (metadata == null) {
+    if (format.metadata == null) {
       return null;
     }
-    for (int i = 0; i < metadata.length(); i++) {
-      Metadata.Entry entry = metadata.get(i);
+    for (int i = 0; i < format.metadata.length(); i++) {
+      Metadata.Entry entry = format.metadata.get(i);
       if (entry instanceof FormatSpecificTransmuxingData
           && ((FormatSpecificTransmuxingData) entry).boxType.equals(boxType)) {
         return ((FormatSpecificTransmuxingData) entry).data;

--- a/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
+++ b/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
@@ -1653,8 +1653,8 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
    *
    * <p>The dec3 box body is carried verbatim in a {@link FormatSpecificTransmuxingData} entry (with
    * {@linkplain FormatSpecificTransmuxingData#boxType boxType} {@code "dec3"}) on {@link
-   * Format#metadata}. Stream-copy callers must populate it with the source track's raw dec3 payload;
-   * the MP4 extractor populates this from the source {@code dec3} box.
+   * Format#metadata}. Stream-copy callers must populate it with the source track's raw dec3
+   * payload; the MP4 extractor populates this from the source {@code dec3} box.
    */
   private static ByteBuffer dec3Box(Format format) {
     byte[] dec3Payload = getTransmuxingBoxPayload(format, "dec3");
@@ -1665,8 +1665,8 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
 
   /**
    * Returns the raw payload of the {@link FormatSpecificTransmuxingData} entry on {@code
-   * format.metadata} whose {@linkplain FormatSpecificTransmuxingData#boxType boxType} matches {@code
-   * boxType}, or {@code null} if there is no such entry.
+   * format.metadata} whose {@linkplain FormatSpecificTransmuxingData#boxType boxType} matches
+   * {@code boxType}, or {@code null} if there is no such entry.
    */
   @Nullable
   private static byte[] getTransmuxingBoxPayload(Format format, String boxType) {

--- a/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
+++ b/libraries/muxer/src/main/java/androidx/media3/muxer/Boxes.java
@@ -30,7 +30,6 @@ import androidx.annotation.Nullable;
 import androidx.media3.common.C;
 import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
-import androidx.media3.common.Metadata;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.CodecSpecificDataUtil;
 import androidx.media3.common.util.Log;
@@ -1661,14 +1660,10 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
     if (format.metadata == null) {
       return null;
     }
-    for (int i = 0; i < format.metadata.length(); i++) {
-      Metadata.Entry entry = format.metadata.get(i);
-      if (entry instanceof FormatSpecificTransmuxingData
-          && ((FormatSpecificTransmuxingData) entry).boxType.equals(boxType)) {
-        return ((FormatSpecificTransmuxingData) entry).data;
-      }
-    }
-    return null;
+    @Nullable
+    FormatSpecificTransmuxingData entry =
+        format.metadata.getFirstEntryOfType(FormatSpecificTransmuxingData.class);
+    return entry != null && entry.boxType.equals(boxType) ? entry.data : null;
   }
 
   /** Returns a dvcC/dvwC/dvvC vision box which will be included in dolby vision box. */

--- a/libraries/muxer/src/main/java/androidx/media3/muxer/FragmentedMp4Muxer.java
+++ b/libraries/muxer/src/main/java/androidx/media3/muxer/FragmentedMp4Muxer.java
@@ -62,6 +62,8 @@ import java.nio.channels.WritableByteChannel;
  *         <li>Opus
  *         <li>Vorbis
  *         <li>Raw Audio
+ *         <li>E-AC-3 (Dolby Digital Plus)
+ *         <li>E-AC-3 JOC (Dolby Atmos)
  *       </ul>
  *   <li>Metadata
  * </ul>
@@ -180,7 +182,9 @@ public final class FragmentedMp4Muxer implements Muxer {
           MimeTypes.AUDIO_IAMF,
           MimeTypes.AUDIO_OPUS,
           MimeTypes.AUDIO_VORBIS,
-          MimeTypes.AUDIO_RAW);
+          MimeTypes.AUDIO_RAW,
+          MimeTypes.AUDIO_E_AC3,
+          MimeTypes.AUDIO_E_AC3_JOC);
 
   // LINT.ThenChange(Boxes.java:codec_specific_boxes)
 

--- a/libraries/muxer/src/main/java/androidx/media3/muxer/Mp4Muxer.java
+++ b/libraries/muxer/src/main/java/androidx/media3/muxer/Mp4Muxer.java
@@ -84,6 +84,8 @@ import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
  *         <li>Opus
  *         <li>Vorbis
  *         <li>Raw Audio
+ *         <li>E-AC-3 (Dolby Digital Plus)
+ *         <li>E-AC-3 JOC (Dolby Atmos)
  *       </ul>
  *   <li>Metadata
  * </ul>
@@ -414,6 +416,8 @@ public final class Mp4Muxer implements Muxer {
           MimeTypes.AUDIO_OPUS,
           MimeTypes.AUDIO_VORBIS,
           MimeTypes.AUDIO_RAW,
+          MimeTypes.AUDIO_E_AC3,
+          MimeTypes.AUDIO_E_AC3_JOC,
           MimeTypes.AUDIO_IAMF);
 
   // LINT.ThenChange(Boxes.java:codec_specific_boxes)

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/BoxesTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/BoxesTest.java
@@ -32,8 +32,8 @@ import androidx.media3.common.Format;
 import androidx.media3.common.Metadata;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Util;
-import androidx.media3.container.FormatSpecificTransmuxingData;
 import androidx.media3.container.MdtaMetadataEntry;
+import androidx.media3.container.Mp4FormatSpecificMetadataEntry;
 import androidx.media3.container.Mp4LocationData;
 import androidx.media3.muxer.FragmentedMp4Writer.SampleMetadata;
 import androidx.media3.test.utils.DumpFileAsserts;
@@ -412,7 +412,7 @@ public class BoxesTest {
         FAKE_AUDIO_FORMAT
             .buildUpon()
             .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
-            .setMetadata(new Metadata(new FormatSpecificTransmuxingData("dec3", payload)))
+            .setMetadata(new Metadata(new Mp4FormatSpecificMetadataEntry("dec3", payload)))
             .build();
 
     ByteBuffer box = Boxes.codecSpecificBox(format);
@@ -435,7 +435,7 @@ public class BoxesTest {
         FAKE_AUDIO_FORMAT
             .buildUpon()
             .setSampleMimeType(MimeTypes.AUDIO_E_AC3_JOC)
-            .setMetadata(new Metadata(new FormatSpecificTransmuxingData("dec3", payload)))
+            .setMetadata(new Metadata(new Mp4FormatSpecificMetadataEntry("dec3", payload)))
             .build();
 
     ByteBuffer box = Boxes.codecSpecificBox(format);
@@ -452,7 +452,7 @@ public class BoxesTest {
 
   @Test
   public void createCodecSpecificBox_forEAc3WithNoTransmuxingData_throws() {
-    // No FormatSpecificTransmuxingData entry on the format's metadata.
+    // No Mp4FormatSpecificMetadataEntry entry on the format's metadata.
     Format format = FAKE_AUDIO_FORMAT.buildUpon().setSampleMimeType(MimeTypes.AUDIO_E_AC3).build();
 
     assertThrows(IllegalArgumentException.class, () -> Boxes.codecSpecificBox(format));
@@ -464,7 +464,7 @@ public class BoxesTest {
         FAKE_AUDIO_FORMAT
             .buildUpon()
             .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
-            .setMetadata(new Metadata(new FormatSpecificTransmuxingData("dec3", new byte[0])))
+            .setMetadata(new Metadata(new Mp4FormatSpecificMetadataEntry("dec3", new byte[0])))
             .build();
 
     assertThrows(IllegalArgumentException.class, () -> Boxes.codecSpecificBox(format));
@@ -478,7 +478,7 @@ public class BoxesTest {
             .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
             .setMetadata(
                 new Metadata(
-                    new FormatSpecificTransmuxingData(
+                    new Mp4FormatSpecificMetadataEntry(
                         "wrong", new byte[] {0x0F, (byte) 0x80, 0x00})))
             .build();
 
@@ -493,7 +493,7 @@ public class BoxesTest {
             .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
             .setMetadata(
                 new Metadata(
-                    new FormatSpecificTransmuxingData(
+                    new Mp4FormatSpecificMetadataEntry(
                         "dec3", new byte[] {0x0F, (byte) 0x80, 0x00})))
             .build();
 
@@ -514,7 +514,7 @@ public class BoxesTest {
             .setSampleMimeType(MimeTypes.AUDIO_E_AC3_JOC)
             .setMetadata(
                 new Metadata(
-                    new FormatSpecificTransmuxingData(
+                    new Mp4FormatSpecificMetadataEntry(
                         "dec3", new byte[] {0x0F, (byte) 0x80, 0x00})))
             .build();
 

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/BoxesTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/BoxesTest.java
@@ -478,7 +478,8 @@ public class BoxesTest {
             .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
             .setMetadata(
                 new Metadata(
-                    new FormatSpecificTransmuxingData("dec3", new byte[] {0x0F, (byte) 0x80, 0x00})))
+                    new FormatSpecificTransmuxingData(
+                        "dec3", new byte[] {0x0F, (byte) 0x80, 0x00})))
             .build();
 
     ByteBuffer box = Boxes.audioSampleEntry(format);

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/BoxesTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/BoxesTest.java
@@ -35,6 +35,7 @@ import androidx.media3.common.util.Util;
 import androidx.media3.container.FormatSpecificTransmuxingData;
 import androidx.media3.container.MdtaMetadataEntry;
 import androidx.media3.container.Mp4LocationData;
+import androidx.media3.container.Mp4TimestampData;
 import androidx.media3.muxer.FragmentedMp4Writer.SampleMetadata;
 import androidx.media3.test.utils.DumpFileAsserts;
 import androidx.media3.test.utils.DumpableMp4Box;
@@ -471,11 +472,73 @@ public class BoxesTest {
   }
 
   @Test
+  public void createCodecSpecificBox_forEAc3WithWrongBoxType_throws() {
+    Format format =
+        FAKE_AUDIO_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
+            .setMetadata(
+                new Metadata(
+                    new FormatSpecificTransmuxingData(
+                        "wrong", new byte[] {0x0F, (byte) 0x80, 0x00})))
+            .build();
+
+    assertThrows(IllegalArgumentException.class, () -> Boxes.codecSpecificBox(format));
+  }
+
+  @Test
+  public void createCodecSpecificBox_forEAc3WithMultipleMetadataEntries_findsCorrectPayload() {
+    byte[] payload = new byte[] {0x0F, (byte) 0x80, 0x00};
+    Format format =
+        FAKE_AUDIO_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
+            .setMetadata(
+                new Metadata(
+                    new FormatSpecificTransmuxingData("wrong", new byte[] {1, 2, 3}),
+                    new Mp4TimestampData(100_000_000L, 500_000_000L),
+                    new FormatSpecificTransmuxingData("dec3", payload)))
+            .build();
+
+    ByteBuffer box = Boxes.codecSpecificBox(format);
+
+    assertThat(box.remaining()).isEqualTo(8 + payload.length);
+    byte[] typeBytes = new byte[4];
+    box.position(4);
+    box.get(typeBytes);
+    assertThat(Util.fromUtf8Bytes(typeBytes)).isEqualTo("dec3");
+    byte[] actual = new byte[payload.length];
+    box.get(actual);
+    assertThat(actual).isEqualTo(payload);
+  }
+
+  @Test
   public void createAudioSampleEntryBox_forEAc3_usesEc3Fourcc() {
     Format format =
         FAKE_AUDIO_FORMAT
             .buildUpon()
             .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
+            .setMetadata(
+                new Metadata(
+                    new FormatSpecificTransmuxingData(
+                        "dec3", new byte[] {0x0F, (byte) 0x80, 0x00})))
+            .build();
+
+    ByteBuffer box = Boxes.audioSampleEntry(format);
+
+    // Sample entry box layout: 4 bytes size + 4 bytes fourcc + ...
+    byte[] fourccBytes = new byte[4];
+    box.position(4);
+    box.get(fourccBytes);
+    assertThat(Util.fromUtf8Bytes(fourccBytes)).isEqualTo("ec-3");
+  }
+
+  @Test
+  public void createAudioSampleEntryBox_forEAc3Joc_usesEc3Fourcc() {
+    Format format =
+        FAKE_AUDIO_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_E_AC3_JOC)
             .setMetadata(
                 new Metadata(
                     new FormatSpecificTransmuxingData(

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/BoxesTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/BoxesTest.java
@@ -35,7 +35,6 @@ import androidx.media3.common.util.Util;
 import androidx.media3.container.FormatSpecificTransmuxingData;
 import androidx.media3.container.MdtaMetadataEntry;
 import androidx.media3.container.Mp4LocationData;
-import androidx.media3.container.Mp4TimestampData;
 import androidx.media3.muxer.FragmentedMp4Writer.SampleMetadata;
 import androidx.media3.test.utils.DumpFileAsserts;
 import androidx.media3.test.utils.DumpableMp4Box;
@@ -484,32 +483,6 @@ public class BoxesTest {
             .build();
 
     assertThrows(IllegalArgumentException.class, () -> Boxes.codecSpecificBox(format));
-  }
-
-  @Test
-  public void createCodecSpecificBox_forEAc3WithMultipleMetadataEntries_findsCorrectPayload() {
-    byte[] payload = new byte[] {0x0F, (byte) 0x80, 0x00};
-    Format format =
-        FAKE_AUDIO_FORMAT
-            .buildUpon()
-            .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
-            .setMetadata(
-                new Metadata(
-                    new FormatSpecificTransmuxingData("wrong", new byte[] {1, 2, 3}),
-                    new Mp4TimestampData(100_000_000L, 500_000_000L),
-                    new FormatSpecificTransmuxingData("dec3", payload)))
-            .build();
-
-    ByteBuffer box = Boxes.codecSpecificBox(format);
-
-    assertThat(box.remaining()).isEqualTo(8 + payload.length);
-    byte[] typeBytes = new byte[4];
-    box.position(4);
-    box.get(typeBytes);
-    assertThat(Util.fromUtf8Bytes(typeBytes)).isEqualTo("dec3");
-    byte[] actual = new byte[payload.length];
-    box.get(actual);
-    assertThat(actual).isEqualTo(payload);
   }
 
   @Test

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/BoxesTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/BoxesTest.java
@@ -29,8 +29,10 @@ import android.media.MediaCodec;
 import androidx.media3.common.C;
 import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
+import androidx.media3.common.Metadata;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.common.util.Util;
+import androidx.media3.container.FormatSpecificTransmuxingData;
 import androidx.media3.container.MdtaMetadataEntry;
 import androidx.media3.container.Mp4LocationData;
 import androidx.media3.muxer.FragmentedMp4Writer.SampleMetadata;
@@ -401,6 +403,91 @@ public class BoxesTest {
         context,
         dumpableBox,
         MuxerTestUtil.getExpectedMp4DumpFilePath("audio_sample_entry_box_vorbis"));
+  }
+
+  @Test
+  public void createCodecSpecificBox_forEAc3_wrapsDec3PayloadVerbatim() {
+    byte[] payload = new byte[] {0x0F, (byte) 0x80, 0x00};
+    Format format =
+        FAKE_AUDIO_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
+            .setMetadata(new Metadata(new FormatSpecificTransmuxingData("dec3", payload)))
+            .build();
+
+    ByteBuffer box = Boxes.codecSpecificBox(format);
+
+    // Box layout: 4 bytes size + 4 bytes "dec3" type + payload bytes.
+    assertThat(box.remaining()).isEqualTo(8 + payload.length);
+    byte[] typeBytes = new byte[4];
+    box.position(4);
+    box.get(typeBytes);
+    assertThat(Util.fromUtf8Bytes(typeBytes)).isEqualTo("dec3");
+    byte[] actual = new byte[payload.length];
+    box.get(actual);
+    assertThat(actual).isEqualTo(payload);
+  }
+
+  @Test
+  public void createCodecSpecificBox_forEAc3Joc_wrapsDec3PayloadVerbatim() {
+    byte[] payload = new byte[] {0x0F, (byte) 0x80, 0x00};
+    Format format =
+        FAKE_AUDIO_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_E_AC3_JOC)
+            .setMetadata(new Metadata(new FormatSpecificTransmuxingData("dec3", payload)))
+            .build();
+
+    ByteBuffer box = Boxes.codecSpecificBox(format);
+
+    assertThat(box.remaining()).isEqualTo(8 + payload.length);
+    byte[] typeBytes = new byte[4];
+    box.position(4);
+    box.get(typeBytes);
+    assertThat(Util.fromUtf8Bytes(typeBytes)).isEqualTo("dec3");
+    byte[] actual = new byte[payload.length];
+    box.get(actual);
+    assertThat(actual).isEqualTo(payload);
+  }
+
+  @Test
+  public void createCodecSpecificBox_forEAc3WithNoTransmuxingData_throws() {
+    // No FormatSpecificTransmuxingData entry on the format's metadata.
+    Format format = FAKE_AUDIO_FORMAT.buildUpon().setSampleMimeType(MimeTypes.AUDIO_E_AC3).build();
+
+    assertThrows(IllegalArgumentException.class, () -> Boxes.codecSpecificBox(format));
+  }
+
+  @Test
+  public void createCodecSpecificBox_forEAc3WithEmptyPayload_throws() {
+    Format format =
+        FAKE_AUDIO_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
+            .setMetadata(new Metadata(new FormatSpecificTransmuxingData("dec3", new byte[0])))
+            .build();
+
+    assertThrows(IllegalArgumentException.class, () -> Boxes.codecSpecificBox(format));
+  }
+
+  @Test
+  public void createAudioSampleEntryBox_forEAc3_usesEc3Fourcc() {
+    Format format =
+        FAKE_AUDIO_FORMAT
+            .buildUpon()
+            .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
+            .setMetadata(
+                new Metadata(
+                    new FormatSpecificTransmuxingData("dec3", new byte[] {0x0F, (byte) 0x80, 0x00})))
+            .build();
+
+    ByteBuffer box = Boxes.audioSampleEntry(format);
+
+    // Sample entry box layout: 4 bytes size + 4 bytes fourcc + ...
+    byte[] fourccBytes = new byte[4];
+    box.position(4);
+    box.get(fourccBytes);
+    assertThat(Util.fromUtf8Bytes(fourccBytes)).isEqualTo("ec-3");
   }
 
   @Test

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/FragmentedMp4MuxerEndToEndTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/FragmentedMp4MuxerEndToEndTest.java
@@ -268,7 +268,10 @@ public class FragmentedMp4MuxerEndToEndTest {
    */
   private void transmuxToFragmentedAndAssert(String inputFileName) throws Exception {
     FakeExtractorOutput inputExtractorOutput =
-        TestUtil.extractAllSamplesFromFile(new Mp4Extractor(), context, "media/" + inputFileName);
+        TestUtil.extractAllSamplesFromFile(
+            new Mp4Extractor(new DefaultSubtitleParserFactory()),
+            context,
+            "media/" + inputFileName);
     FakeTrackOutput audioTrackOutput =
         Iterables.getOnlyElement(inputExtractorOutput.getTrackOutputsForType(C.TRACK_TYPE_AUDIO));
     Format audioFormat = checkNotNull(audioTrackOutput.lastFormat);

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/FragmentedMp4MuxerEndToEndTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/FragmentedMp4MuxerEndToEndTest.java
@@ -19,17 +19,21 @@ import static androidx.media3.muxer.MuxerTestUtil.feedInputDataToMuxer;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import android.content.Context;
+import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
 import androidx.media3.container.Mp4TimestampData;
 import androidx.media3.extractor.mp4.FragmentedMp4Extractor;
+import androidx.media3.extractor.mp4.Mp4Extractor;
 import androidx.media3.extractor.text.DefaultSubtitleParserFactory;
 import androidx.media3.test.utils.DumpFileAsserts;
 import androidx.media3.test.utils.DumpableMp4Box;
 import androidx.media3.test.utils.FakeExtractorOutput;
+import androidx.media3.test.utils.FakeTrackOutput;
 import androidx.media3.test.utils.TestUtil;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.common.collect.Iterables;
 import java.io.FileOutputStream;
 import java.nio.ByteBuffer;
 import org.junit.Rule;
@@ -242,5 +246,65 @@ public class FragmentedMp4MuxerEndToEndTest {
         context,
         dumpableMp4Box,
         MuxerTestUtil.getExpectedMp4DumpFilePath("fragmented_mp4_with_unknown_track.mp4"));
+  }
+
+  @Test
+  public void writeFragmentedMp4File_fromEAc3Input_matchesExpected() throws Exception {
+    transmuxToFragmentedAndAssert(/* inputFileName= */ "mp4/sample_eac3.mp4");
+  }
+
+  @Test
+  public void writeFragmentedMp4File_fromEAc3JocInput_matchesExpected() throws Exception {
+    transmuxToFragmentedAndAssert(/* inputFileName= */ "mp4/sample_eac3joc.mp4");
+  }
+
+  /**
+   * Stream-copies an MP4 audio track through {@link FragmentedMp4Muxer} and asserts the re-extracted
+   * output against the expected dump.
+   *
+   * <p>The input is read with {@link Mp4Extractor} (rather than {@code MediaExtractorCompat}) so that
+   * {@link Format#metadata} — which carries the E-AC-3 {@code dec3} payload as a {@code
+   * FormatSpecificTransmuxingData} entry — is preserved and passed to the muxer.
+   */
+  private void transmuxToFragmentedAndAssert(String inputFileName) throws Exception {
+    FakeExtractorOutput inputExtractorOutput =
+        TestUtil.extractAllSamplesFromFile(new Mp4Extractor(), context, "media/" + inputFileName);
+    FakeTrackOutput audioTrackOutput =
+        Iterables.getOnlyElement(inputExtractorOutput.getTrackOutputsForType(C.TRACK_TYPE_AUDIO));
+    Format audioFormat = checkNotNull(audioTrackOutput.lastFormat);
+    String outputFilePath = temporaryFolder.newFile().getPath();
+
+    try (FragmentedMp4Muxer muxer =
+        new FragmentedMp4Muxer.Builder(new FileOutputStream(outputFilePath).getChannel()).build()) {
+      // Use fixed timestamps so the output (and its dump) is deterministic.
+      muxer.addMetadataEntry(
+          new Mp4TimestampData(
+              /* creationTimestampSeconds= */ 100_000_000L,
+              /* modificationTimestampSeconds= */ 500_000_000L));
+      int trackId = muxer.addTrack(audioFormat);
+      for (int i = 0; i < audioTrackOutput.getSampleCount(); i++) {
+        byte[] sampleData = audioTrackOutput.getSampleData(i);
+        ByteBuffer sampleBuffer = ByteBuffer.allocateDirect(sampleData.length);
+        sampleBuffer.put(sampleData);
+        sampleBuffer.rewind();
+        muxer.writeSampleData(
+            trackId,
+            sampleBuffer,
+            new BufferInfo(
+                audioTrackOutput.getSampleTimeUs(i),
+                sampleData.length,
+                audioTrackOutput.getSampleFlags(i)));
+      }
+    }
+
+    FakeExtractorOutput outputExtractorOutput =
+        TestUtil.extractAllSamplesFromFilePath(
+            new FragmentedMp4Extractor(new DefaultSubtitleParserFactory()),
+            checkNotNull(outputFilePath));
+    DumpFileAsserts.assertOutput(
+        context,
+        outputExtractorOutput,
+        MuxerTestUtil.getExpectedDumpFilePath(
+            MuxerTestUtil.getSubstitutedPath(inputFileName, MuxerTestUtil.MP4) + "_fragmented"));
   }
 }

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/FragmentedMp4MuxerEndToEndTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/FragmentedMp4MuxerEndToEndTest.java
@@ -259,11 +259,11 @@ public class FragmentedMp4MuxerEndToEndTest {
   }
 
   /**
-   * Stream-copies an MP4 audio track through {@link FragmentedMp4Muxer} and asserts the re-extracted
-   * output against the expected dump.
+   * Stream-copies an MP4 audio track through {@link FragmentedMp4Muxer} and asserts the
+   * re-extracted output against the expected dump.
    *
-   * <p>The input is read with {@link Mp4Extractor} (rather than {@code MediaExtractorCompat}) so that
-   * {@link Format#metadata} — which carries the E-AC-3 {@code dec3} payload as a {@code
+   * <p>The input is read with {@link Mp4Extractor} (rather than {@code MediaExtractorCompat}) so
+   * that {@link Format#metadata} — which carries the E-AC-3 {@code dec3} payload as a {@code
    * FormatSpecificTransmuxingData} entry — is preserved and passed to the muxer.
    */
   private void transmuxToFragmentedAndAssert(String inputFileName) throws Exception {

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/FragmentedMp4MuxerEndToEndTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/FragmentedMp4MuxerEndToEndTest.java
@@ -264,7 +264,7 @@ public class FragmentedMp4MuxerEndToEndTest {
    *
    * <p>The input is read with {@link Mp4Extractor} (rather than {@code MediaExtractorCompat}) so
    * that {@link Format#metadata} — which carries the E-AC-3 {@code dec3} payload as a {@code
-   * FormatSpecificTransmuxingData} entry — is preserved and passed to the muxer.
+   * Mp4FormatSpecificMetadataEntry} entry — is preserved and passed to the muxer.
    */
   private void transmuxToFragmentedAndAssert(String inputFileName) throws Exception {
     FakeExtractorOutput inputExtractorOutput =

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/Mp4MuxerEndToEndTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/Mp4MuxerEndToEndTest.java
@@ -116,51 +116,6 @@ public class Mp4MuxerEndToEndTest {
     transmuxAndAssert(/* inputFileName= */ "sample_eac3joc.mp4");
   }
 
-  /**
-   * Stream-copies an MP4 audio track through {@link Mp4Muxer} and asserts the re-extracted output
-   * against the expected dump.
-   *
-   * <p>The input is read with {@link Mp4Extractor} (rather than {@code MediaExtractorCompat}) so
-   * that {@link Format#metadata} — which carries the E-AC-3 {@code dec3} payload as a {@code
-   * FormatSpecificTransmuxingData} entry — is preserved and passed to the muxer.
-   */
-  private void transmuxAndAssert(String inputFileName) throws Exception {
-    FakeExtractorOutput inputExtractorOutput =
-        TestUtil.extractAllSamplesFromFile(
-            new Mp4Extractor(), context, "media/mp4/" + inputFileName);
-    FakeTrackOutput audioTrackOutput =
-        Iterables.getOnlyElement(inputExtractorOutput.getTrackOutputsForType(C.TRACK_TYPE_AUDIO));
-    Format audioFormat = checkNotNull(audioTrackOutput.lastFormat);
-    String outputFilePath = temporaryFolder.newFile().getPath();
-
-    try (Mp4Muxer muxer = new Mp4Muxer.Builder(SeekableMuxerOutput.of(outputFilePath)).build()) {
-      // Use fixed timestamps so the output (and its dump) is deterministic.
-      muxer.addMetadataEntry(
-          new Mp4TimestampData(
-              /* creationTimestampSeconds= */ 100_000_000L,
-              /* modificationTimestampSeconds= */ 500_000_000L));
-      int trackId = muxer.addTrack(audioFormat);
-      for (int i = 0; i < audioTrackOutput.getSampleCount(); i++) {
-        byte[] sampleData = audioTrackOutput.getSampleData(i);
-        ByteBuffer sampleBuffer = ByteBuffer.allocateDirect(sampleData.length);
-        sampleBuffer.put(sampleData);
-        sampleBuffer.rewind();
-        muxer.writeSampleData(
-            trackId,
-            sampleBuffer,
-            new BufferInfo(
-                audioTrackOutput.getSampleTimeUs(i),
-                sampleData.length,
-                audioTrackOutput.getSampleFlags(i)));
-      }
-    }
-
-    FakeExtractorOutput outputExtractorOutput =
-        TestUtil.extractAllSamplesFromFilePath(new Mp4Extractor(), outputFilePath);
-    DumpFileAsserts.assertOutput(
-        context, outputExtractorOutput, MuxerTestUtil.getExpectedMp4DumpFilePath(inputFileName));
-  }
-
   @Test
   public void createMp4File_addTrackAndMetadataButNoSamples_createsEmptyFile() throws Exception {
     String outputFilePath = temporaryFolder.newFile().getPath();
@@ -1271,5 +1226,53 @@ public class Mp4MuxerEndToEndTest {
 
     byte[] outputFileBytes = TestUtil.getByteArrayFromFilePath(outputFilePath);
     assertThat(outputFileBytes).isEmpty();
+  }
+
+  /**
+   * Stream-copies an MP4 audio track through {@link Mp4Muxer} and asserts the re-extracted output
+   * against the expected dump.
+   *
+   * <p>The input is read with {@link Mp4Extractor} (rather than {@code MediaExtractorCompat}) so
+   * that {@link Format#metadata} — which carries the E-AC-3 {@code dec3} payload as a {@code
+   * FormatSpecificTransmuxingData} entry — is preserved and passed to the muxer.
+   */
+  private void transmuxAndAssert(String inputFileName) throws Exception {
+    FakeExtractorOutput inputExtractorOutput =
+        TestUtil.extractAllSamplesFromFile(
+            new Mp4Extractor(new DefaultSubtitleParserFactory()),
+            context,
+            "media/mp4/" + inputFileName);
+    FakeTrackOutput audioTrackOutput =
+        Iterables.getOnlyElement(inputExtractorOutput.getTrackOutputsForType(C.TRACK_TYPE_AUDIO));
+    Format audioFormat = checkNotNull(audioTrackOutput.lastFormat);
+    String outputFilePath = temporaryFolder.newFile().getPath();
+
+    try (Mp4Muxer muxer = new Mp4Muxer.Builder(SeekableMuxerOutput.of(outputFilePath)).build()) {
+      // Use fixed timestamps so the output (and its dump) is deterministic.
+      muxer.addMetadataEntry(
+          new Mp4TimestampData(
+              /* creationTimestampSeconds= */ 100_000_000L,
+              /* modificationTimestampSeconds= */ 500_000_000L));
+      int trackId = muxer.addTrack(audioFormat);
+      for (int i = 0; i < audioTrackOutput.getSampleCount(); i++) {
+        byte[] sampleData = audioTrackOutput.getSampleData(i);
+        ByteBuffer sampleBuffer = ByteBuffer.allocateDirect(sampleData.length);
+        sampleBuffer.put(sampleData);
+        sampleBuffer.rewind();
+        muxer.writeSampleData(
+            trackId,
+            sampleBuffer,
+            new BufferInfo(
+                audioTrackOutput.getSampleTimeUs(i),
+                sampleData.length,
+                audioTrackOutput.getSampleFlags(i)));
+      }
+    }
+
+    FakeExtractorOutput outputExtractorOutput =
+        TestUtil.extractAllSamplesFromFilePath(
+            new Mp4Extractor(new DefaultSubtitleParserFactory()), outputFilePath);
+    DumpFileAsserts.assertOutput(
+        context, outputExtractorOutput, MuxerTestUtil.getExpectedMp4DumpFilePath(inputFileName));
   }
 }

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/Mp4MuxerEndToEndTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/Mp4MuxerEndToEndTest.java
@@ -120,8 +120,8 @@ public class Mp4MuxerEndToEndTest {
    * Stream-copies an MP4 audio track through {@link Mp4Muxer} and asserts the re-extracted output
    * against the expected dump.
    *
-   * <p>The input is read with {@link Mp4Extractor} (rather than {@code MediaExtractorCompat}) so that
-   * {@link Format#metadata} — which carries the E-AC-3 {@code dec3} payload as a {@code
+   * <p>The input is read with {@link Mp4Extractor} (rather than {@code MediaExtractorCompat}) so
+   * that {@link Format#metadata} — which carries the E-AC-3 {@code dec3} payload as a {@code
    * FormatSpecificTransmuxingData} entry — is preserved and passed to the muxer.
    */
   private void transmuxAndAssert(String inputFileName) throws Exception {

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/Mp4MuxerEndToEndTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/Mp4MuxerEndToEndTest.java
@@ -43,6 +43,7 @@ import androidx.media3.extractor.text.DefaultSubtitleParserFactory;
 import androidx.media3.test.utils.DumpFileAsserts;
 import androidx.media3.test.utils.DumpableMp4Box;
 import androidx.media3.test.utils.FakeExtractorOutput;
+import androidx.media3.test.utils.FakeTrackOutput;
 import androidx.media3.test.utils.TestUtil;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -103,6 +104,61 @@ public class Mp4MuxerEndToEndTest {
         context,
         dumpableBox,
         MuxerTestUtil.getExpectedMp4DumpFilePath("mp4_with_samples_and_metadata.mp4"));
+  }
+
+  @Test
+  public void writeMp4File_fromEAc3Input_matchesExpected() throws Exception {
+    transmuxAndAssert(/* inputFileName= */ "sample_eac3.mp4");
+  }
+
+  @Test
+  public void writeMp4File_fromEAc3JocInput_matchesExpected() throws Exception {
+    transmuxAndAssert(/* inputFileName= */ "sample_eac3joc.mp4");
+  }
+
+  /**
+   * Stream-copies an MP4 audio track through {@link Mp4Muxer} and asserts the re-extracted output
+   * against the expected dump.
+   *
+   * <p>The input is read with {@link Mp4Extractor} (rather than {@code MediaExtractorCompat}) so that
+   * {@link Format#metadata} — which carries the E-AC-3 {@code dec3} payload as a {@code
+   * FormatSpecificTransmuxingData} entry — is preserved and passed to the muxer.
+   */
+  private void transmuxAndAssert(String inputFileName) throws Exception {
+    FakeExtractorOutput inputExtractorOutput =
+        TestUtil.extractAllSamplesFromFile(
+            new Mp4Extractor(), context, "media/mp4/" + inputFileName);
+    FakeTrackOutput audioTrackOutput =
+        Iterables.getOnlyElement(inputExtractorOutput.getTrackOutputsForType(C.TRACK_TYPE_AUDIO));
+    Format audioFormat = checkNotNull(audioTrackOutput.lastFormat);
+    String outputFilePath = temporaryFolder.newFile().getPath();
+
+    try (Mp4Muxer muxer = new Mp4Muxer.Builder(SeekableMuxerOutput.of(outputFilePath)).build()) {
+      // Use fixed timestamps so the output (and its dump) is deterministic.
+      muxer.addMetadataEntry(
+          new Mp4TimestampData(
+              /* creationTimestampSeconds= */ 100_000_000L,
+              /* modificationTimestampSeconds= */ 500_000_000L));
+      int trackId = muxer.addTrack(audioFormat);
+      for (int i = 0; i < audioTrackOutput.getSampleCount(); i++) {
+        byte[] sampleData = audioTrackOutput.getSampleData(i);
+        ByteBuffer sampleBuffer = ByteBuffer.allocateDirect(sampleData.length);
+        sampleBuffer.put(sampleData);
+        sampleBuffer.rewind();
+        muxer.writeSampleData(
+            trackId,
+            sampleBuffer,
+            new BufferInfo(
+                audioTrackOutput.getSampleTimeUs(i),
+                sampleData.length,
+                audioTrackOutput.getSampleFlags(i)));
+      }
+    }
+
+    FakeExtractorOutput outputExtractorOutput =
+        TestUtil.extractAllSamplesFromFilePath(new Mp4Extractor(), outputFilePath);
+    DumpFileAsserts.assertOutput(
+        context, outputExtractorOutput, MuxerTestUtil.getExpectedMp4DumpFilePath(inputFileName));
   }
 
   @Test

--- a/libraries/muxer/src/test/java/androidx/media3/muxer/Mp4MuxerEndToEndTest.java
+++ b/libraries/muxer/src/test/java/androidx/media3/muxer/Mp4MuxerEndToEndTest.java
@@ -1234,7 +1234,7 @@ public class Mp4MuxerEndToEndTest {
    *
    * <p>The input is read with {@link Mp4Extractor} (rather than {@code MediaExtractorCompat}) so
    * that {@link Format#metadata} — which carries the E-AC-3 {@code dec3} payload as a {@code
-   * FormatSpecificTransmuxingData} entry — is preserved and passed to the muxer.
+   * Mp4FormatSpecificMetadataEntry} entry — is preserved and passed to the muxer.
    */
   private void transmuxAndAssert(String inputFileName) throws Exception {
     FakeExtractorOutput inputExtractorOutput =

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.0.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.1.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
   sample 0:
     time = 576000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.1.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
   sample 0:
     time = 576000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.2.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
   sample 0:
     time = 1152000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.2.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
   sample 0:
     time = 1152000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.3.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
   sample 0:
     time = 1696000
     flags = 536870913

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.3.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
   sample 0:
     time = 1696000
     flags = 536870913

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.unknown_length.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3.mp4.unknown_length.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.0.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.0.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.1.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
   sample 0:
     time = 576000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.1.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
   sample 0:
     time = 576000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.2.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
   sample 0:
     time = 1152000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.2.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
   sample 0:
     time = 1152000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.3.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
   sample 0:
     time = 1696000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.3.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
   sample 0:
     time = 1696000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.unknown_length.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3_fragmented.mp4.unknown_length.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086719, modification time=3662086719, timescale=1000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.0.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.1.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
   sample 0:
     time = 672000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.1.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
   sample 0:
     time = 672000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.2.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
   sample 0:
     time = 1344000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.2.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
   sample 0:
     time = 1344000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.3.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
   sample 0:
     time = 2016000
     flags = 536870913

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.3.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
   sample 0:
     time = 2016000
     flags = 536870913

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.unknown_length.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc.mp4.unknown_length.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.0.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.0.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.0.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.1.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
   sample 0:
     time = 672000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.1.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.1.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
   sample 0:
     time = 672000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.2.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
   sample 0:
     time = 1344000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.2.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.2.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
   sample 0:
     time = 1344000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.3.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
   sample 0:
     time = 2016000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.3.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.3.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
   sample 0:
     time = 2016000
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.unknown_length.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.unknown_length.dump
+++ b/libraries/test_data/src/test/assets/extractordumps/mp4/sample_eac3joc_fragmented.mp4.unknown_length.dump
@@ -18,7 +18,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=3662086977, modification time=3662086977, timescale=1000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3.mp4.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=100000000, modification time=500000000, timescale=10000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=100000000, modification time=500000000, timescale=10000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3.mp4.dump
@@ -1,10 +1,10 @@
 seekMap:
   isSeekable = true
   duration = 1728000
-  getPosition(0) = [[timeUs=0, position=898]]
-  getPosition(1) = [[timeUs=1, position=898]]
-  getPosition(864000) = [[timeUs=864000, position=108898]]
-  getPosition(1728000) = [[timeUs=1728000, position=212898]]
+  getPosition(0) = [[timeUs=0, position=400052]]
+  getPosition(1) = [[timeUs=1, position=400052]]
+  getPosition(864000) = [[timeUs=864000, position=508052]]
+  getPosition(1728000) = [[timeUs=1728000, position=612052]]
 numberOfTracks = 1
 track 0:
   total output bytes = 216000
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=100000000, modification time=500000000, timescale=10000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3.mp4_fragmented.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3.mp4_fragmented.dump
@@ -1,26 +1,20 @@
 seekMap:
-  isSeekable = true
-  duration = 1728000
-  getPosition(0) = [[timeUs=0, position=898]]
-  getPosition(1) = [[timeUs=1, position=898]]
-  getPosition(864000) = [[timeUs=864000, position=108898]]
-  getPosition(1728000) = [[timeUs=1728000, position=212898]]
+  isSeekable = false
+  duration = UNSET TIME
+  getPosition(0) = [[timeUs=0, position=569]]
 numberOfTracks = 1
 track 0:
   total output bytes = 216000
   sample count = 54
-  track duration = 1728000
   format 0:
-    averageBitrate = 1000000
     peakBitrate = 1000000
     id = 1
     containerMimeType = audio/mp4
     sampleMimeType = audio/eac3
-    maxInputSize = 4030
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086526, modification time=3662086526, timescale=48000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=100000000, modification time=500000000, timescale=10000]
   sample 0:
     time = 0
     flags = 1
@@ -235,6 +229,6 @@ track 0:
     data = length 4000, hash 4C987B7C
   sample 53:
     time = 1696000
-    flags = 536870913
+    flags = 1
     data = length 4000, hash 4C987B7C
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3.mp4_fragmented.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3.mp4_fragmented.dump
@@ -14,7 +14,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=100000000, modification time=500000000, timescale=10000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=100000000, modification time=500000000, timescale=10000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3joc.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3joc.mp4.dump
@@ -1,10 +1,10 @@
 seekMap:
   isSeekable = true
   duration = 2048000
-  getPosition(0) = [[timeUs=0, position=956]]
-  getPosition(1) = [[timeUs=1, position=956]]
-  getPosition(1024000) = [[timeUs=1024000, position=82876]]
-  getPosition(2048000) = [[timeUs=2048000, position=162236]]
+  getPosition(0) = [[timeUs=0, position=400052]]
+  getPosition(1) = [[timeUs=1, position=400052]]
+  getPosition(1024000) = [[timeUs=1024000, position=481972]]
+  getPosition(2048000) = [[timeUs=2048000, position=561332]]
 numberOfTracks = 1
 track 0:
   total output bytes = 163840
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=100000000, modification time=500000000, timescale=10000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3joc.mp4.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3joc.mp4.dump
@@ -20,7 +20,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=100000000, modification time=500000000, timescale=10000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=100000000, modification time=500000000, timescale=10000]
   sample 0:
     time = 0
     flags = 1

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3joc.mp4_fragmented.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3joc.mp4_fragmented.dump
@@ -1,26 +1,20 @@
 seekMap:
-  isSeekable = true
-  duration = 2048000
-  getPosition(0) = [[timeUs=0, position=956]]
-  getPosition(1) = [[timeUs=1, position=956]]
-  getPosition(1024000) = [[timeUs=1024000, position=82876]]
-  getPosition(2048000) = [[timeUs=2048000, position=162236]]
+  isSeekable = false
+  duration = UNSET TIME
+  getPosition(0) = [[timeUs=0, position=571]]
 numberOfTracks = 1
 track 0:
   total output bytes = 163840
   sample count = 64
-  track duration = 2048000
   format 0:
-    averageBitrate = 640000
     peakBitrate = 640000
     id = 1
     containerMimeType = audio/mp4
     sampleMimeType = audio/eac3-joc
-    maxInputSize = 2590
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=3662086940, modification time=3662086940, timescale=48000]
+    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=100000000, modification time=500000000, timescale=10000]
   sample 0:
     time = 0
     flags = 1
@@ -275,6 +269,6 @@ track 0:
     data = length 2560, hash 10C62F30
   sample 63:
     time = 2016000
-    flags = 536870913
+    flags = 1
     data = length 2560, hash EE4F848A
 tracksEnded = true

--- a/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3joc.mp4_fragmented.dump
+++ b/libraries/test_data/src/test/assets/muxerdumps/mp4/sample_eac3joc.mp4_fragmented.dump
@@ -14,7 +14,7 @@ track 0:
     channelCount = 6
     sampleRate = 48000
     language = und
-    metadata = entries=[FormatSpecificTransmuxingData: boxType=dec3, Mp4Timestamp: creation time=100000000, modification time=500000000, timescale=10000]
+    metadata = entries=[Mp4FormatSpecificMetadataEntry: boxType=dec3, Mp4Timestamp: creation time=100000000, modification time=500000000, timescale=10000]
   sample 0:
     time = 0
     flags = 1


### PR DESCRIPTION
Adds E-AC-3 / Dolby Atmos (E-AC-3 JOC) support across the MP4 extractor and muxer.
- New Mp4FormatSpecificMetadataEntry (Metadata.Entry, media3-container) carries a raw box payload for transmuxing.
- Extractor attaches the dec3 payload to Format.metadata (not initializationData), so the E-AC-3 decode path is unchanged.
- Muxer writes the dec3 box / ec-3 fourcc from that metadata entry; AUDIO_E_AC3 / AUDIO_E_AC3_JOC added to Mp4Muxer + FragmentedMp4Muxer supported types, so Transformer can transmux Atmos.
- Tests: BoxesTest + end-to-end transmux (Mp4MuxerEndToEndTest, FragmentedMp4MuxerEndToEndTest); extractor golden dumps regenerated.

Let's go Dolby! 