### PR TITLE
BugFix: Fix DV playback if SDR fallback is added to the manifest

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecUtil.java
@@ -223,6 +223,55 @@ public final class MediaCodecUtil {
   }
 
   /**
+   * Returns a list of decoders that can decode media in the specified format, in the priority order
+   * specified by the {@link MediaCodecSelector}.
+   * Unlike {@link #getDecoderInfosSoftMatch}, this method may exclude decoders that match the
+   * sample MIME type but do not support relevant format details.
+   *
+   * <p>This list is more complete than {@link #getDecoderInfos}, as it also considers alternative
+   * MIME types that are a close match using {@link #getAlternativeCodecMimeType}.
+   *
+   * @param context The application context.
+   * @param mediaCodecSelector The decoder selector.
+   * @param format The {@link Format} for which a decoder is required.
+   * @param requiresSecureDecoder Whether a secure decoder is required.
+   * @param requiresTunnelingDecoder Whether a tunneling decoder is required.
+   * @return A list of {@link MediaCodecInfo}s corresponding to decoders. May be empty.
+   * @throws DecoderQueryException Thrown if there was an error querying decoders.
+   */
+  @RequiresNonNull("#3.sampleMimeType")
+  public static List<MediaCodecInfo> getDecoderInfosSoftMatchFilteredByFormatSupport(
+      Context context,
+      MediaCodecSelector mediaCodecSelector,
+      Format format,
+      boolean requiresSecureDecoder,
+      boolean requiresTunnelingDecoder)
+      throws DecoderQueryException {
+
+    List<MediaCodecInfo> decoderInfos =
+        mediaCodecSelector.getDecoderInfos(
+            format.sampleMimeType, requiresSecureDecoder, requiresTunnelingDecoder);
+
+    ImmutableList.Builder<MediaCodecInfo> result = ImmutableList.builder();
+
+    for (MediaCodecInfo decoderInfo : decoderInfos) {
+      if (!decoderInfo.isFormatSupported(context, format)) {
+        continue;
+      }
+      result.add(decoderInfo);
+    }
+
+    result.addAll(
+        getAlternativeDecoderInfos(
+            mediaCodecSelector,
+            format,
+            requiresSecureDecoder,
+            requiresTunnelingDecoder));
+
+    return result.build();
+  }
+
+  /**
    * Returns a list of decoders for {@linkplain #getAlternativeCodecMimeType alternative MIME types}
    * that can decode samples of the provided {@link Format}, in the priority order specified by the
    * {@link MediaCodecSelector}.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/trackselection/DefaultTrackSelector.java
@@ -3937,7 +3937,7 @@ public class DefaultTrackSelector extends MappingTrackSelector
               == RendererCapabilities.HARDWARE_ACCELERATION_SUPPORTED;
       this.resolvedMimeType = resolvedMimeType;
       codecPreferenceScore = getVideoCodecPreferenceScore(resolvedMimeType);
-      isHdr = usesPrimaryDecoder && ColorInfo.isTransferHdr(format.colorInfo);
+      isHdr = usesPrimaryOrFallbackDecoder && ColorInfo.isTransferHdr(format.colorInfo);
       selectionEligibility = evaluateSelectionEligibility(formatSupport, requiredAdaptiveSupport);
     }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -940,8 +940,13 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
         return alternativeDecoderInfos;
       }
     }
-    return MediaCodecUtil.getDecoderInfosSoftMatch(
-        mediaCodecSelector, format, requiresSecureDecoder, requiresTunnelingDecoder);
+    if (MimeTypes.VIDEO_DOLBY_VISION.equals(format.sampleMimeType)) {
+      return MediaCodecUtil.getDecoderInfosSoftMatchFilteredByFormatSupport(
+          context, mediaCodecSelector, format, requiresSecureDecoder, requiresTunnelingDecoder);
+    } else {
+      return MediaCodecUtil.getDecoderInfosSoftMatch(
+          mediaCodecSelector, format, requiresSecureDecoder, requiresTunnelingDecoder);
+    }
   }
 
   @RequiresApi(26)


### PR DESCRIPTION
The partial fix in aa5b318 moved HDR and codec score preferences into quality preferences and resolved fallback MIME types, but testing indicates there is still SDR track instead of Dolby Vision track selected on some TV devices.

Original issue: https://github.com/androidx/media/issues/3135
Related-commit: aa5b318406d40de7fdb31dabc3802b4e1624f710

This change fixes the remaining portion of #3135 not addressed by aa5b318. (The details can be found in inline comments.)