### PR TITLE
Adds HDR bitmap support to the image playback pipeline

### DIFF
--- a/libraries/effect/src/main/java/androidx/media3/effect/BitmapToHardwareBufferProcessor.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/BitmapToHardwareBufferProcessor.java
@@ -116,27 +116,25 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
       if (currentFrame == null) {
         HardwareBuffer buffer = null;
         try {
-          if (SDK_INT >= 31) {
+          if (nextBitmap.getConfig() == Config.RGBA_1010102) {
+            buffer = copyCpuBitmapToHardwareBuffer(nextBitmap, hardwareBufferJniWrapper);
+          } else if (SDK_INT >= 31) {
             if (nextBitmap.getConfig() == Config.HARDWARE) {
-              // Input is HARDWARE and API >= 31: Direct access to HardwareBuffer is possible.
               buffer = nextBitmap.getHardwareBuffer();
             } else {
-              // Input is not HARDWARE and API >= 31: We can create a HARDWARE Bitmap copy
-              // and get its HardwareBuffer.
-              buffer = nextBitmap.copy(Config.HARDWARE, /* isMutable= */ false).getHardwareBuffer();
+              Bitmap hwCopy = nextBitmap.copy(Config.HARDWARE, /* isMutable= */ false);
+              if (hwCopy != null) {
+                buffer = hwCopy.getHardwareBuffer();
+              }
             }
           }
           // Fallback to the native helper when the HardwareBuffer retrieved from the Bitmap was
           // null, or SDK_INT < 31.
           if (buffer == null) {
             if (nextBitmap.getConfig() == Config.HARDWARE) {
-              // Input is HARDWARE but API < 31: HardwareBuffer is not directly accessible.
-              // We must first copy to a software Bitmap (e.g. ARGB_8888)
-              // and then copy that to a new HardwareBuffer via JNI.
               Bitmap softwareBitmap = nextBitmap.copy(Config.ARGB_8888, /* isMutable= */ false);
               buffer = copyCpuBitmapToHardwareBuffer(softwareBitmap, hardwareBufferJniWrapper);
             } else {
-              // Input is not HARDWARE: Copy the software Bitmap to a new HardwareBuffer via JNI.
               buffer = copyCpuBitmapToHardwareBuffer(nextBitmap, hardwareBufferJniWrapper);
             }
           }
@@ -206,16 +204,19 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
    * <p>The created buffer will have {@linkplain HardwareBuffer#USAGE_GPU_SAMPLED_IMAGE GPU read},
    * {@linkplain HardwareBuffer#USAGE_GPU_COLOR_OUTPUT GPU write}, {@linkplain
    * HardwareBuffer#USAGE_CPU_READ_OFTEN CPU read} and {@linkplain
-   * HardwareBuffer#USAGE_CPU_WRITE_OFTEN CPU write} usage flags set, and pixelFormat of {@link
-   * HardwareBuffer#RGBA_8888}.
+   * HardwareBuffer#USAGE_CPU_WRITE_OFTEN CPU write} usage flags set.
    */
   private static HardwareBuffer copyCpuBitmapToHardwareBuffer(
       Bitmap bitmap, HardwareBufferJniWrapper hardwareBufferJniWrapper) {
+    int pixelFormat =
+        bitmap.getConfig() == Config.RGBA_1010102
+            ? HardwareBuffer.RGBA_1010102
+            : HardwareBuffer.RGBA_8888;
     HardwareBuffer buffer =
         HardwareBuffer.create(
             bitmap.getWidth(),
             bitmap.getHeight(),
-            /* pixelFormat= */ HardwareBuffer.RGBA_8888,
+            pixelFormat,
             /* layers= */ 1,
             /* usageFlags= */ HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE
                 | HardwareBuffer.USAGE_GPU_COLOR_OUTPUT

--- a/libraries/effect/src/main/java/androidx/media3/effect/BitmapToHardwareBufferProcessor.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/BitmapToHardwareBufferProcessor.java
@@ -116,15 +116,25 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
       if (currentFrame == null) {
         HardwareBuffer buffer = null;
         try {
-          if (nextBitmap.getConfig() == Config.RGBA_1010102) {
-            buffer = copyCpuBitmapToHardwareBuffer(nextBitmap, hardwareBufferJniWrapper);
-          } else if (SDK_INT >= 31) {
+          if (SDK_INT >= 31) {
             if (nextBitmap.getConfig() == Config.HARDWARE) {
+              // Input is HARDWARE and API >= 31: Direct access to HardwareBuffer is possible.
               buffer = nextBitmap.getHardwareBuffer();
             } else {
+              // Input is not HARDWARE and API >= 31: We can create a HARDWARE Bitmap copy
+              // and get its HardwareBuffer.
               Bitmap hwCopy = nextBitmap.copy(Config.HARDWARE, /* isMutable= */ false);
               if (hwCopy != null) {
                 buffer = hwCopy.getHardwareBuffer();
+                // Discard the buffer if the HARDWARE copy silently downgraded an HDR
+                // bitmap's bit depth. The CPU-copy fallback preserves the source pixel
+                // format.
+                if (buffer != null
+                    && buffer.getFormat()
+                        != getHardwareBufferPixelFormat(nextBitmap.getConfig())) {
+                  buffer.close();
+                  buffer = null;
+                }
               }
             }
           }
@@ -132,9 +142,13 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
           // null, or SDK_INT < 31.
           if (buffer == null) {
             if (nextBitmap.getConfig() == Config.HARDWARE) {
+              // Input is HARDWARE but API < 31: HardwareBuffer is not directly accessible.
+              // We must first copy to a software Bitmap (e.g. ARGB_8888)
+              // and then copy that to a new HardwareBuffer via JNI.
               Bitmap softwareBitmap = nextBitmap.copy(Config.ARGB_8888, /* isMutable= */ false);
               buffer = copyCpuBitmapToHardwareBuffer(softwareBitmap, hardwareBufferJniWrapper);
             } else {
+              // Input is not HARDWARE: Copy the software Bitmap to a new HardwareBuffer via JNI.
               buffer = copyCpuBitmapToHardwareBuffer(nextBitmap, hardwareBufferJniWrapper);
             }
           }
@@ -198,8 +212,9 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
   }
 
   /**
-   * Copies a {@link Bitmap.Config#ARGB_8888}, {@link Bitmap.Config#RGBA_F16} or {@link
-   * Bitmap.Config#RGBA_1010102} {@link Bitmap} to a {@link HardwareBuffer} using JNI.
+   * Copies a software {@link Bitmap} to a {@link HardwareBuffer} using JNI. The pixel format of the
+   * created buffer is derived from the source {@link Bitmap.Config} via {@link
+   * #getHardwareBufferPixelFormat} so that the source bit depth is preserved.
    *
    * <p>The created buffer will have {@linkplain HardwareBuffer#USAGE_GPU_SAMPLED_IMAGE GPU read},
    * {@linkplain HardwareBuffer#USAGE_GPU_COLOR_OUTPUT GPU write}, {@linkplain
@@ -208,15 +223,11 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
    */
   private static HardwareBuffer copyCpuBitmapToHardwareBuffer(
       Bitmap bitmap, HardwareBufferJniWrapper hardwareBufferJniWrapper) {
-    int pixelFormat =
-        bitmap.getConfig() == Config.RGBA_1010102
-            ? HardwareBuffer.RGBA_1010102
-            : HardwareBuffer.RGBA_8888;
     HardwareBuffer buffer =
         HardwareBuffer.create(
             bitmap.getWidth(),
             bitmap.getHeight(),
-            pixelFormat,
+            getHardwareBufferPixelFormat(bitmap.getConfig()),
             /* layers= */ 1,
             /* usageFlags= */ HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE
                 | HardwareBuffer.USAGE_GPU_COLOR_OUTPUT
@@ -225,6 +236,21 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
 
     checkState(hardwareBufferJniWrapper.nativeCopyBitmapToHardwareBuffer(bitmap, buffer));
     return buffer;
+  }
+
+  /**
+   * Returns the {@link HardwareBuffer} pixel format that matches the source bit depth of the given
+   * {@link Bitmap.Config}. Falls back to {@link HardwareBuffer#RGBA_8888} for configs whose bit
+   * depth is 8 bpc or unknown.
+   */
+  private static int getHardwareBufferPixelFormat(@Nullable Config config) {
+    if (config == Config.RGBA_1010102) {
+      return HardwareBuffer.RGBA_1010102;
+    }
+    if (config == Config.RGBA_F16) {
+      return HardwareBuffer.RGBA_FP16;
+    }
+    return HardwareBuffer.RGBA_8888;
   }
 
   private void releaseBuffer(HardwareBuffer buffer, @Nullable SyncFenceWrapper releaseFence) {

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/HardwareBufferFrameReader.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/HardwareBufferFrameReader.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import android.graphics.Bitmap;
+import android.graphics.ColorSpace;
 import android.hardware.HardwareBuffer;
 import android.os.Handler;
 import android.os.Looper;
@@ -228,7 +229,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
             .setSampleMimeType(MimeTypes.IMAGE_RAW)
             .setWidth(bitmap.getWidth())
             .setHeight(bitmap.getHeight())
-            .setColorInfo(ColorInfo.SRGB_BT709_FULL)
+            .setColorInfo(resolveColorInfoFromBitmap(bitmap))
             .setFrameRate(/* frameRate= */ DEFAULT_FRAME_RATE)
             .build();
     synchronized (this) {
@@ -504,6 +505,29 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     for (int i = 0; i < rendererWakeupListenerList.size(); i++) {
       rendererWakeupListenerList.get(i).onWakeup();
     }
+  }
+
+  private static ColorInfo resolveColorInfoFromBitmap(Bitmap bitmap) {
+    if (SDK_INT >= 34) {
+      ColorSpace colorSpace = bitmap.getColorSpace();
+      if (colorSpace != null) {
+        int id = colorSpace.getId();
+        if (id == ColorSpace.get(ColorSpace.Named.BT2020_HLG).getId()) {
+          return new ColorInfo.Builder()
+              .setColorSpace(C.COLOR_SPACE_BT2020)
+              .setColorRange(C.COLOR_RANGE_FULL)
+              .setColorTransfer(C.COLOR_TRANSFER_HLG)
+              .build();
+        } else if (id == ColorSpace.get(ColorSpace.Named.BT2020_PQ).getId()) {
+          return new ColorInfo.Builder()
+              .setColorSpace(C.COLOR_SPACE_BT2020)
+              .setColorRange(C.COLOR_RANGE_FULL)
+              .setColorTransfer(C.COLOR_TRANSFER_ST2084)
+              .build();
+        }
+      }
+    }
+    return ColorInfo.SRGB_BT709_FULL;
   }
 
   /**


### PR DESCRIPTION
Bug is https://partnerissuetracker.corp.google.com/issues/531143289

- HardwareBufferFrameReader derives ColorInfo from the bitmap's ColorSpace (BT2020 HLG/PQ) instead of always emitting SRGB_BT709_FULL.
  - BitmapToHardwareBufferProcessor derives the HardwareBuffer pixel format from Bitmap.Config (RGBA_1010102 → RGBA_1010102, RGBA_F16 → RGBA_FP16, else RGBA_8888) so bit depth is preserved independently of
  color space.
  - Prefers the Bitmap.copy(Config.HARDWARE) fast path for all configs. Falls back to CPU/JNI copy only when the HARDWARE path is unavailable or silently downgrades an HDR bitmap's bit depth.