### PR TITLE
Recover from non-monotonic presentationTimeUs caused by naively-muxed B-frame content

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/Format.java
+++ b/libraries/common/src/main/java/androidx/media3/common/Format.java
@@ -172,6 +172,7 @@ public final class Format {
     @Nullable private DrmInitData drmInitData;
     private long subsampleOffsetUs;
     private boolean hasPrerollSamples;
+    private boolean hasReliablePresentationTimestamps;
 
     // Video specific.
 
@@ -218,6 +219,10 @@ public final class Format {
       maxInputSize = NO_VALUE;
       maxNumReorderSamples = NO_VALUE;
       subsampleOffsetUs = OFFSET_SAMPLE_RELATIVE;
+      // Default to true: nearly every extractor/format provides trustworthy per-sample
+      // presentation timestamps. Only set to false where the source is known not to (see
+      // Format#hasReliablePresentationTimestamps).
+      hasReliablePresentationTimestamps = true;
       // Video specific.
       width = NO_VALUE;
       height = NO_VALUE;
@@ -270,6 +275,7 @@ public final class Format {
       this.drmInitData = format.drmInitData;
       this.subsampleOffsetUs = format.subsampleOffsetUs;
       this.hasPrerollSamples = format.hasPrerollSamples;
+      this.hasReliablePresentationTimestamps = format.hasReliablePresentationTimestamps;
       // Video specific.
       this.width = format.width;
       this.height = format.height;
@@ -587,6 +593,20 @@ public final class Format {
     @CanIgnoreReturnValue
     public Builder setHasPrerollSamples(boolean hasPrerollSamples) {
       this.hasPrerollSamples = hasPrerollSamples;
+      return this;
+    }
+
+    /**
+     * Sets {@link Format#hasReliablePresentationTimestamps}. The default value is {@code true}.
+     *
+     * @param hasReliablePresentationTimestamps The {@link
+     *     Format#hasReliablePresentationTimestamps}.
+     * @return The builder.
+     */
+    @CanIgnoreReturnValue
+    public Builder setHasReliablePresentationTimestamps(
+        boolean hasReliablePresentationTimestamps) {
+      this.hasReliablePresentationTimestamps = hasReliablePresentationTimestamps;
       return this;
     }
 
@@ -1051,6 +1071,19 @@ public final class Format {
    */
   @UnstableApi public final boolean hasPrerollSamples;
 
+  /**
+   * Indicates whether per-sample presentation timestamps for this track are known to be
+   * accurate.
+   *
+   * <p>When {@code false}, the source (typically a container demuxer) could not determine each
+   * sample's true composition/presentation time — for example an MP4 track with B-frame
+   * reordering but no {@code ctts} box, where every sample's timestamp collapses to its decode
+   * time. Renderers should not treat such timestamps as ground truth for scheduling decisions
+   * (e.g. dropping "late" output buffers); doing so can misread decoder-level reordering as
+   * lateness. Defaults to {@code true}.
+   */
+  @UnstableApi public final boolean hasReliablePresentationTimestamps;
+
   // Video specific.
 
   /** The width of the video in pixels, or {@link #NO_VALUE} if unknown or not applicable. */
@@ -1218,6 +1251,7 @@ public final class Format {
     drmInitData = builder.drmInitData;
     subsampleOffsetUs = builder.subsampleOffsetUs;
     hasPrerollSamples = builder.hasPrerollSamples;
+    hasReliablePresentationTimestamps = builder.hasReliablePresentationTimestamps;
     // Video specific.
     width = builder.width;
     height = builder.height;

--- a/libraries/common/src/main/java/androidx/media3/common/Format.java
+++ b/libraries/common/src/main/java/androidx/media3/common/Format.java
@@ -219,10 +219,7 @@ public final class Format {
       maxInputSize = NO_VALUE;
       maxNumReorderSamples = NO_VALUE;
       subsampleOffsetUs = OFFSET_SAMPLE_RELATIVE;
-      // Default to true: nearly every extractor/format provides trustworthy per-sample
-      // presentation timestamps. Only set to false where the source is known not to (see
-      // Format#hasReliablePresentationTimestamps).
-      hasReliablePresentationTimestamps = true;
+      hasReliablePresentationTimestamps = true; // most formats have accurate per-sample timestamps
       // Video specific.
       width = NO_VALUE;
       height = NO_VALUE;
@@ -1072,15 +1069,11 @@ public final class Format {
   @UnstableApi public final boolean hasPrerollSamples;
 
   /**
-   * Indicates whether per-sample presentation timestamps for this track are known to be
-   * accurate.
+   * Indicates whether per-sample presentation timestamps for this track are known to be accurate.
    *
-   * <p>When {@code false}, the source (typically a container demuxer) could not determine each
-   * sample's true composition/presentation time — for example an MP4 track with B-frame
-   * reordering but no {@code ctts} box, where every sample's timestamp collapses to its decode
-   * time. Renderers should not treat such timestamps as ground truth for scheduling decisions
-   * (e.g. dropping "late" output buffers); doing so can misread decoder-level reordering as
-   * lateness. Defaults to {@code true}.
+   * <p>When {@code false}, the source couldn't determine each sample's true presentation time
+   * (for example an MP4 track with no {@code ctts} box). Consumers shouldn't treat the
+   * timestamps as ground truth for scheduling decisions. Defaults to {@code true}.
    */
   @UnstableApi public final boolean hasReliablePresentationTimestamps;
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -422,18 +422,18 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   // B-frame reordering but no ctts box, where every sample's presentationTimeUs is just its
   // decode time. MediaCodec faithfully echoes back whatever (unreliable) timestamp it was
   // queued with, so the codec's raw output can look non-monotonic even though its buffer
-  // *release order* is correct. Re-deriving each buffer's timestamp from its release order and
-  // the stream's known frame duration corrects this without reordering or holding buffers — this
-  // is a best-effort reconstruction for a source that has already told us it doesn't know the
-  // real answer, not a workaround for a specific decoder defect (see
-  // https://github.com/androidx/media/issues/3347).
-  // Kept unrounded and only rounded per-frame at the point of use (see below) — rounding this
-  // once and multiplying by a growing frame index would accumulate error linearly over the
-  // life of the stream (e.g. ~0.33us/frame for 24000/1001fps content is only 0.7ms over a 90s
-  // clip, but ~58ms over a 2-hour movie).
-  private double arrivalOrderPtsFrameDurationUs = -1;
-  private long arrivalOrderPtsBaseUs = C.TIME_UNSET;
-  private long arrivalOrderPtsFrameIndex;
+  // *release order* is correct.
+  //
+  // Re-associating each dequeued output buffer with the presentationTimeUs of the next
+  // input buffer *in queue order* (not the codec's own echoed value) corrects this without
+  // reordering or holding buffers. This mirrors what a completely independent player (VLC, via
+  // its MP4 demuxer + a FIFO of queued-but-not-yet-consumed timestamps) already does for exactly
+  // this situation. Queue order is always monotonic by construction (it's a direct echo of the
+  // container's decode-time-to-sample table), and — importantly — this preserves each sample's
+  // *real* duration exactly as declared by the container: unlike re-deriving from a single
+  // assumed constant frame rate, this does not corrupt genuinely variable-frame-rate content
+  // (where Format#frameRate is at best an average, not a true per-sample value).
+  private final ArrayDeque<Long> arrivalOrderPtsQueue = new ArrayDeque<>();
 
   /**
    * @param context A context.
@@ -1129,8 +1129,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
         codecReconfigured ? RECONFIGURATION_STATE_WRITE_PENDING : RECONFIGURATION_STATE_NONE;
     hasSkippedFlushAndWaitingForQueueInputBuffer = false;
     skippedFlushOffsetUs = 0;
-    arrivalOrderPtsBaseUs = C.TIME_UNSET;
-    arrivalOrderPtsFrameIndex = 0;
+    arrivalOrderPtsQueue.clear();
   }
 
   /**
@@ -1668,6 +1667,14 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       hasSkippedFlushAndWaitingForQueueInputBuffer = false;
     }
 
+    if (getTrackType() == C.TRACK_TYPE_VIDEO
+        && inputFormat != null
+        && !inputFormat.hasReliablePresentationTimestamps) {
+      // Recorded in the same (pre skippedFlushOffsetUs) scale that drainOutputBuffer converts
+      // dequeued output timestamps back to, so it can be substituted directly for the codec's
+      // own echoed value there. See arrivalOrderPtsQueue's declaration for why.
+      arrivalOrderPtsQueue.addLast(presentationTimeUs);
+    }
     onQueueInputBuffer(buffer);
     int flags = getCodecBufferFlags(buffer);
     presentationTimeUs += skippedFlushOffsetUs;
@@ -2277,24 +2284,13 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       if (getTrackType() == C.TRACK_TYPE_VIDEO
           && inputFormat != null
           && !inputFormat.hasReliablePresentationTimestamps
-          && inputFormat.frameRate != Format.NO_VALUE
-          && inputFormat.frameRate > 0) {
-        if (arrivalOrderPtsFrameDurationUs < 0) {
-          arrivalOrderPtsFrameDurationUs = 1_000_000.0 / inputFormat.frameRate;
-        }
-        if (arrivalOrderPtsBaseUs == C.TIME_UNSET) {
-          // Anchor to the first real output buffer's own reported timestamp; only the spacing
-          // of subsequent buffers is re-derived, not the absolute position in the stream.
-          arrivalOrderPtsBaseUs = outputBufferInfo.presentationTimeUs;
-          arrivalOrderPtsFrameIndex = 0;
-        } else {
-          arrivalOrderPtsFrameIndex++;
-          // Round only the final offset, not the per-frame duration, so rounding error can't
-          // accumulate across the length of the stream.
-          outputBufferInfo.presentationTimeUs =
-              arrivalOrderPtsBaseUs
-                  + Math.round(arrivalOrderPtsFrameIndex * arrivalOrderPtsFrameDurationUs);
-        }
+          && !arrivalOrderPtsQueue.isEmpty()) {
+        // Replace the codec's own (unreliable, possibly-reordered) echoed timestamp with the
+        // presentationTimeUs of the next sample in queue order. Queue order is a direct echo of
+        // the container's decode-time-to-sample table, so it's always monotonic and always
+        // reflects each sample's true declared duration — including on genuinely
+        // variable-frame-rate content, where a single Format#frameRate value would not.
+        outputBufferInfo.presentationTimeUs = arrivalOrderPtsQueue.removeFirst();
       }
 
       this.outputIndex = outputIndex;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -417,6 +417,13 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   private CodecParameters activeCodecParameters;
   private CodecParameters lastDispatchedCodecParameters;
   private ImmutableSet<String> subscribedCodecParameterKeys;
+  // Some MediaCodec implementations (observed on c2.mtk.hevc.decoder) return output buffers
+  // whose presentationTimeUs is not monotonically increasing, while the codec's own buffer
+  // *release order* remains correct. Re-deriving each buffer's timestamp from its release order
+  // and the stream's known frame duration corrects this without reordering or holding buffers.
+  private long arrivalOrderPtsFrameDurationUs = C.TIME_UNSET;
+  private long arrivalOrderPtsBaseUs = C.TIME_UNSET;
+  private long arrivalOrderPtsFrameIndex;
 
   /**
    * @param context A context.
@@ -1112,6 +1119,8 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
         codecReconfigured ? RECONFIGURATION_STATE_WRITE_PENDING : RECONFIGURATION_STATE_NONE;
     hasSkippedFlushAndWaitingForQueueInputBuffer = false;
     skippedFlushOffsetUs = 0;
+    arrivalOrderPtsBaseUs = C.TIME_UNSET;
+    arrivalOrderPtsFrameIndex = 0;
   }
 
   /**
@@ -2253,6 +2262,25 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
         // The dequeued buffer indicates the end of the stream. Process it immediately.
         processEndOfStream();
         return false;
+      }
+
+      if (getTrackType() == C.TRACK_TYPE_VIDEO
+          && inputFormat != null
+          && inputFormat.frameRate != Format.NO_VALUE
+          && inputFormat.frameRate > 0) {
+        if (arrivalOrderPtsFrameDurationUs == C.TIME_UNSET) {
+          arrivalOrderPtsFrameDurationUs = Math.round(1_000_000.0 / inputFormat.frameRate);
+        }
+        if (arrivalOrderPtsBaseUs == C.TIME_UNSET) {
+          // Anchor to the first real output buffer's own reported timestamp; only the spacing
+          // of subsequent buffers is re-derived, not the absolute position in the stream.
+          arrivalOrderPtsBaseUs = outputBufferInfo.presentationTimeUs;
+          arrivalOrderPtsFrameIndex = 0;
+        } else {
+          arrivalOrderPtsFrameIndex++;
+          outputBufferInfo.presentationTimeUs =
+              arrivalOrderPtsBaseUs + arrivalOrderPtsFrameIndex * arrivalOrderPtsFrameDurationUs;
+        }
       }
 
       this.outputIndex = outputIndex;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -417,22 +417,10 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   private CodecParameters activeCodecParameters;
   private CodecParameters lastDispatchedCodecParameters;
   private ImmutableSet<String> subscribedCodecParameterKeys;
-  // Used only when Format#hasReliablePresentationTimestamps is false (see that field's javadoc):
-  // the source told us it has no real per-sample composition timing, e.g. an MP4 track with
-  // B-frame reordering but no ctts box, where every sample's presentationTimeUs is just its
-  // decode time. MediaCodec faithfully echoes back whatever (unreliable) timestamp it was
-  // queued with, so the codec's raw output can look non-monotonic even though its buffer
-  // *release order* is correct.
-  //
-  // Re-associating each dequeued output buffer with the presentationTimeUs of the next
-  // input buffer *in queue order* (not the codec's own echoed value) corrects this without
-  // reordering or holding buffers. This mirrors what a completely independent player (VLC, via
-  // its MP4 demuxer + a FIFO of queued-but-not-yet-consumed timestamps) already does for exactly
-  // this situation. Queue order is always monotonic by construction (it's a direct echo of the
-  // container's decode-time-to-sample table), and — importantly — this preserves each sample's
-  // *real* duration exactly as declared by the container: unlike re-deriving from a single
-  // assumed constant frame rate, this does not corrupt genuinely variable-frame-rate content
-  // (where Format#frameRate is at best an average, not a true per-sample value).
+  // Used only when Format#hasReliablePresentationTimestamps is false: replays each sample's own
+  // queued presentationTimeUs in output-arrival order instead of trusting MediaCodec's echoed
+  // (possibly non-monotonic) timestamp. Preserves true per-sample duration, unlike deriving from
+  // a single assumed frame rate.
   private final ArrayDeque<Long> arrivalOrderPtsQueue = new ArrayDeque<>();
 
   /**
@@ -1670,9 +1658,8 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     if (getTrackType() == C.TRACK_TYPE_VIDEO
         && inputFormat != null
         && !inputFormat.hasReliablePresentationTimestamps) {
-      // Recorded in the same (pre skippedFlushOffsetUs) scale that drainOutputBuffer converts
-      // dequeued output timestamps back to, so it can be substituted directly for the codec's
-      // own echoed value there. See arrivalOrderPtsQueue's declaration for why.
+      // Must run before the += skippedFlushOffsetUs below, to match the scale drainOutputBuffer
+      // converts dequeued timestamps back to.
       arrivalOrderPtsQueue.addLast(presentationTimeUs);
     }
     onQueueInputBuffer(buffer);
@@ -2285,11 +2272,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
           && inputFormat != null
           && !inputFormat.hasReliablePresentationTimestamps
           && !arrivalOrderPtsQueue.isEmpty()) {
-        // Replace the codec's own (unreliable, possibly-reordered) echoed timestamp with the
-        // presentationTimeUs of the next sample in queue order. Queue order is a direct echo of
-        // the container's decode-time-to-sample table, so it's always monotonic and always
-        // reflects each sample's true declared duration — including on genuinely
-        // variable-frame-rate content, where a single Format#frameRate value would not.
+        // See arrivalOrderPtsQueue's declaration.
         outputBufferInfo.presentationTimeUs = arrivalOrderPtsQueue.removeFirst();
       }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -1656,8 +1656,15 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     }
 
     if (getTrackType() == C.TRACK_TYPE_VIDEO
-        && inputFormat != null
-        && !inputFormat.hasReliablePresentationTimestamps) {
+        && codecInputFormat != null
+        && !codecInputFormat.hasReliablePresentationTimestamps
+        && !getConfiguration().tunneling) {
+      // codecInputFormat, not inputFormat: this must describe the format actually governing the
+      // buffer being queued right now, which during a full codec reinit can briefly lag behind
+      // inputFormat (see drainOutputBuffer's matching check). Skipped entirely in tunneling mode,
+      // where drainOutputBuffer -- and so the corresponding pop -- never runs at all; queueing
+      // here without ever draining would just grow this unboundedly.
+      //
       // Must run before the += skippedFlushOffsetUs below, to match the scale drainOutputBuffer
       // converts dequeued timestamps back to.
       arrivalOrderPtsQueue.addLast(presentationTimeUs);
@@ -2269,10 +2276,13 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       }
 
       if (getTrackType() == C.TRACK_TYPE_VIDEO
-          && inputFormat != null
-          && !inputFormat.hasReliablePresentationTimestamps
+          && codecInputFormat != null
+          && !codecInputFormat.hasReliablePresentationTimestamps
           && !arrivalOrderPtsQueue.isEmpty()) {
-        // See arrivalOrderPtsQueue's declaration.
+        // codecInputFormat, not inputFormat -- see the matching check in feedInputBuffer. No
+        // tunneling check needed here: in tunneling mode this method isn't called at all (see
+        // updateOutputFormatForTime's javadoc), so the push side already prevents anything from
+        // reaching this queue to begin with.
         outputBufferInfo.presentationTimeUs = arrivalOrderPtsQueue.removeFirst();
       }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -47,6 +47,7 @@ import androidx.annotation.CheckResult;
 import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.annotation.VisibleForTesting;
 import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
@@ -422,6 +423,11 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   // (possibly non-monotonic) timestamp. Preserves true per-sample duration, unlike deriving from
   // a single assumed frame rate.
   private final ArrayDeque<Long> arrivalOrderPtsQueue = new ArrayDeque<>();
+
+  @VisibleForTesting
+  /* package */ int getArrivalOrderPtsQueueSizeForTesting() {
+    return arrivalOrderPtsQueue.size();
+  }
 
   /**
    * @param context A context.

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -421,7 +421,11 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   // whose presentationTimeUs is not monotonically increasing, while the codec's own buffer
   // *release order* remains correct. Re-deriving each buffer's timestamp from its release order
   // and the stream's known frame duration corrects this without reordering or holding buffers.
-  private long arrivalOrderPtsFrameDurationUs = C.TIME_UNSET;
+  // Kept unrounded and only rounded per-frame at the point of use (see below) — rounding this
+  // once and multiplying by a growing frame index would accumulate error linearly over the
+  // life of the stream (e.g. ~0.33us/frame for 24000/1001fps content is only 0.7ms over a 90s
+  // clip, but ~58ms over a 2-hour movie).
+  private double arrivalOrderPtsFrameDurationUs = -1;
   private long arrivalOrderPtsBaseUs = C.TIME_UNSET;
   private long arrivalOrderPtsFrameIndex;
 
@@ -2268,8 +2272,8 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
           && inputFormat != null
           && inputFormat.frameRate != Format.NO_VALUE
           && inputFormat.frameRate > 0) {
-        if (arrivalOrderPtsFrameDurationUs == C.TIME_UNSET) {
-          arrivalOrderPtsFrameDurationUs = Math.round(1_000_000.0 / inputFormat.frameRate);
+        if (arrivalOrderPtsFrameDurationUs < 0) {
+          arrivalOrderPtsFrameDurationUs = 1_000_000.0 / inputFormat.frameRate;
         }
         if (arrivalOrderPtsBaseUs == C.TIME_UNSET) {
           // Anchor to the first real output buffer's own reported timestamp; only the spacing
@@ -2278,8 +2282,11 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
           arrivalOrderPtsFrameIndex = 0;
         } else {
           arrivalOrderPtsFrameIndex++;
+          // Round only the final offset, not the per-frame duration, so rounding error can't
+          // accumulate across the length of the stream.
           outputBufferInfo.presentationTimeUs =
-              arrivalOrderPtsBaseUs + arrivalOrderPtsFrameIndex * arrivalOrderPtsFrameDurationUs;
+              arrivalOrderPtsBaseUs
+                  + Math.round(arrivalOrderPtsFrameIndex * arrivalOrderPtsFrameDurationUs);
         }
       }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/mediacodec/MediaCodecRenderer.java
@@ -417,10 +417,16 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   private CodecParameters activeCodecParameters;
   private CodecParameters lastDispatchedCodecParameters;
   private ImmutableSet<String> subscribedCodecParameterKeys;
-  // Some MediaCodec implementations (observed on c2.mtk.hevc.decoder) return output buffers
-  // whose presentationTimeUs is not monotonically increasing, while the codec's own buffer
-  // *release order* remains correct. Re-deriving each buffer's timestamp from its release order
-  // and the stream's known frame duration corrects this without reordering or holding buffers.
+  // Used only when Format#hasReliablePresentationTimestamps is false (see that field's javadoc):
+  // the source told us it has no real per-sample composition timing, e.g. an MP4 track with
+  // B-frame reordering but no ctts box, where every sample's presentationTimeUs is just its
+  // decode time. MediaCodec faithfully echoes back whatever (unreliable) timestamp it was
+  // queued with, so the codec's raw output can look non-monotonic even though its buffer
+  // *release order* is correct. Re-deriving each buffer's timestamp from its release order and
+  // the stream's known frame duration corrects this without reordering or holding buffers — this
+  // is a best-effort reconstruction for a source that has already told us it doesn't know the
+  // real answer, not a workaround for a specific decoder defect (see
+  // https://github.com/androidx/media/issues/3347).
   // Kept unrounded and only rounded per-frame at the point of use (see below) — rounding this
   // once and multiplying by a growing frame index would accumulate error linearly over the
   // life of the stream (e.g. ~0.33us/frame for 24000/1001fps content is only 0.7ms over a 90s
@@ -2270,6 +2276,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
 
       if (getTrackType() == C.TRACK_TYPE_VIDEO
           && inputFormat != null
+          && !inputFormat.hasReliablePresentationTimestamps
           && inputFormat.frameRate != Format.NO_VALUE
           && inputFormat.frameRate > 0) {
         if (arrivalOrderPtsFrameDurationUs < 0) {

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -2167,8 +2167,13 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       long earlyUs, long elapsedRealtimeUs, boolean isLastBuffer) {
     @Nullable Format codecInputFormat = getCodecInputFormat();
     if (codecInputFormat != null && !codecInputFormat.hasReliablePresentationTimestamps) {
-      // earlyUs here is derived from a reconstructed timestamp, not ground truth — don't drop on it.
-      return false;
+      // earlyUs is derived from a reconstructed timestamp here, not ground truth, so the normal
+      // threshold is too trigger-happy: pipeline depth from the decoder's own reorder buffering
+      // can plausibly look this late even with no real backlog. But it's still a genuine
+      // pacing signal (see arrivalOrderPtsQueue's declaration), so don't disable dropping
+      // outright either -- that would leave no recovery path if the decoder is genuinely falling
+      // behind. Require VERY_LATE-level lateness instead of the normal threshold as a backstop.
+      return earlyUs < MIN_EARLY_US_VERY_LATE_THRESHOLD && !isLastBuffer;
     }
     return earlyUs < MIN_EARLY_US_LATE_THRESHOLD && !isLastBuffer;
   }
@@ -2187,7 +2192,9 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       long earlyUs, long elapsedRealtimeUs, boolean isLastBuffer) {
     @Nullable Format codecInputFormat = getCodecInputFormat();
     if (codecInputFormat != null && !codecInputFormat.hasReliablePresentationTimestamps) {
-      // See shouldDropOutputBuffer.
+      // Unlike shouldDropOutputBuffer, stays disabled here: this skips to a keyframe based on
+      // *how many* buffers to discard, which needs real per-sample identity we don't have in this
+      // case -- getting that wrong risks skipping past buffers that were never actually late.
       return false;
     }
     return earlyUs < MIN_EARLY_US_VERY_LATE_THRESHOLD && !isLastBuffer;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -2165,6 +2165,16 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
    */
   protected boolean shouldDropOutputBuffer(
       long earlyUs, long elapsedRealtimeUs, boolean isLastBuffer) {
+    @Nullable Format codecInputFormat = getCodecInputFormat();
+    if (codecInputFormat != null && !codecInputFormat.hasReliablePresentationTimestamps) {
+      // The source told us it has no real per-sample composition timing (see
+      // Format#hasReliablePresentationTimestamps), so presentationTimeUs here is at best a
+      // best-effort reconstruction, not ground truth. Treating it as ground truth for a "how
+      // late is this buffer" decision risks dropping buffers whose only real fault is a
+      // decoder-level or reconstruction-level ordering wobble, not genuine lateness — render
+      // everything and let it look approximately right instead.
+      return false;
+    }
     return earlyUs < MIN_EARLY_US_LATE_THRESHOLD && !isLastBuffer;
   }
 
@@ -2180,6 +2190,13 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
    */
   protected boolean shouldDropBuffersToKeyframe(
       long earlyUs, long elapsedRealtimeUs, boolean isLastBuffer) {
+    @Nullable Format codecInputFormat = getCodecInputFormat();
+    if (codecInputFormat != null && !codecInputFormat.hasReliablePresentationTimestamps) {
+      // See shouldDropOutputBuffer: an apparent large "very late" reading can itself be a
+      // reconstruction artifact (e.g. before arrivalOrderPtsBaseUs has anchored) rather than
+      // genuinely falling behind, so don't act on it here either.
+      return false;
+    }
     return earlyUs < MIN_EARLY_US_VERY_LATE_THRESHOLD && !isLastBuffer;
   }
 

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/video/MediaCodecVideoRenderer.java
@@ -2167,12 +2167,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       long earlyUs, long elapsedRealtimeUs, boolean isLastBuffer) {
     @Nullable Format codecInputFormat = getCodecInputFormat();
     if (codecInputFormat != null && !codecInputFormat.hasReliablePresentationTimestamps) {
-      // The source told us it has no real per-sample composition timing (see
-      // Format#hasReliablePresentationTimestamps), so presentationTimeUs here is at best a
-      // best-effort reconstruction, not ground truth. Treating it as ground truth for a "how
-      // late is this buffer" decision risks dropping buffers whose only real fault is a
-      // decoder-level or reconstruction-level ordering wobble, not genuine lateness — render
-      // everything and let it look approximately right instead.
+      // earlyUs here is derived from a reconstructed timestamp, not ground truth — don't drop on it.
       return false;
     }
     return earlyUs < MIN_EARLY_US_LATE_THRESHOLD && !isLastBuffer;
@@ -2192,9 +2187,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer
       long earlyUs, long elapsedRealtimeUs, boolean isLastBuffer) {
     @Nullable Format codecInputFormat = getCodecInputFormat();
     if (codecInputFormat != null && !codecInputFormat.hasReliablePresentationTimestamps) {
-      // See shouldDropOutputBuffer: an apparent large "very late" reading can itself be a
-      // reconstruction artifact (e.g. before arrivalOrderPtsBaseUs has anchored) rather than
-      // genuinely falling behind, so don't act on it here either.
+      // See shouldDropOutputBuffer.
       return false;
     }
     return earlyUs < MIN_EARLY_US_VERY_LATE_THRESHOLD && !isLastBuffer;

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/mediacodec/MediaCodecRendererTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/mediacodec/MediaCodecRendererTest.java
@@ -939,6 +939,41 @@ public class MediaCodecRendererTest {
     assertThat(stringListCaptor.getValue()).containsExactly("key1", "key2");
   }
 
+  @Test
+  public void feedInputBuffer_withUnreliablePtsAndTunneling_doesNotGrowArrivalOrderPtsQueue()
+      throws Exception {
+    // In tunneling mode drainOutputBuffer -- and so the queue's pop side -- never runs (see its
+    // javadoc), so feedInputBuffer must skip pushing altogether or the queue grows unboundedly for
+    // the life of the session. Track type must be video: the guard is a no-op for other types.
+    Format unreliablePtsVideo =
+        new Format.Builder()
+            .setSampleMimeType(MimeTypes.VIDEO_H264)
+            .setHasReliablePresentationTimestamps(false)
+            .build();
+    FakeSampleStream fakeSampleStream =
+        createFakeSampleStream(unreliablePtsVideo, /* sampleTimesUs...= */ 0, 100, 200);
+    VideoTestRenderer renderer = new VideoTestRenderer();
+    renderer.init(/* index= */ 0, PlayerId.UNSET, Clock.DEFAULT);
+    renderer.enable(
+        new RendererConfiguration(/* tunneling= */ true),
+        new Format[] {unreliablePtsVideo},
+        fakeSampleStream,
+        /* positionUs= */ 0,
+        /* joining= */ false,
+        /* mayRenderStartOfStream= */ true,
+        /* startPositionUs= */ 0,
+        /* offsetUs= */ 0,
+        new MediaSource.MediaPeriodId(new Object()));
+    renderer.start();
+    long positionUs = 0;
+    while (!renderer.hasReadStreamToEnd()) {
+      renderer.render(positionUs, SystemClock.elapsedRealtime());
+      positionUs += 100;
+    }
+
+    assertThat(renderer.getArrivalOrderPtsQueueSizeForTesting()).isEqualTo(0);
+  }
+
   private TestRenderer setUpAndEnableRenderer(Format format) throws Exception {
     MediaCodecAdapter mockCodecAdapter = mock(MediaCodecAdapter.class);
     MediaCodecAdapter.Factory mockCodecAdapterFactory = configuration -> mockCodecAdapter;
@@ -1064,6 +1099,107 @@ public class MediaCodecRendererTest {
       applyCodecParametersToMediaFormat(mediaFormat);
       return MediaCodecAdapter.Configuration.createForAudioDecoding(
           codecInfo, mediaFormat, format, crypto, /* loudnessCodecController= */ null);
+    }
+
+    @Override
+    protected boolean processOutputBuffer(
+        long positionUs,
+        long elapsedRealtimeUs,
+        @Nullable MediaCodecAdapter codec,
+        @Nullable ByteBuffer buffer,
+        int bufferIndex,
+        int bufferFlags,
+        int sampleCount,
+        long bufferPresentationTimeUs,
+        boolean isDecodeOnlyBuffer,
+        boolean isLastBuffer,
+        Format format)
+        throws ExoPlaybackException {
+      if (bufferPresentationTimeUs <= positionUs) {
+        // Only release buffers when the position advances far enough for realistic behavior where
+        // input of buffers to the codec is faster than output.
+        if (codec != null) {
+          codec.releaseOutputBuffer(bufferIndex, /* render= */ true);
+        }
+        return true;
+      }
+      return false;
+    }
+
+    @Override
+    protected void onCodecParametersChanged(CodecParameters codecParameters) {
+      // No-op for this test renderer.
+    }
+
+    @Override
+    protected DecoderReuseEvaluation canReuseCodec(
+        MediaCodecInfo codecInfo,
+        Format oldFormat,
+        Format newFormat,
+        boolean isAdaptiveFormatChange) {
+      return codecInfo.canReuseCodec(oldFormat, newFormat);
+    }
+  }
+
+  /** Same as {@link TestRenderer}, but with {@link C#TRACK_TYPE_VIDEO} for video-only guards. */
+  private static class VideoTestRenderer extends MediaCodecRenderer {
+
+    VideoTestRenderer() {
+      this(MediaCodecAdapter.Factory.getDefault(ApplicationProvider.getApplicationContext()));
+    }
+
+    VideoTestRenderer(MediaCodecAdapter.Factory mediaCodecAdapterFactory) {
+      super(
+          ApplicationProvider.getApplicationContext(),
+          C.TRACK_TYPE_VIDEO,
+          mediaCodecAdapterFactory,
+          /* mediaCodecSelector= */ (mimeType, requiresSecureDecoder, requiresTunnelingDecoder) ->
+              Collections.singletonList(
+                  MediaCodecInfo.newInstance(
+                      /* name= */ "name",
+                      /* mimeType= */ mimeType,
+                      /* codecMimeType= */ mimeType,
+                      /* capabilities= */ null,
+                      /* hardwareAccelerated= */ false,
+                      /* softwareOnly= */ true,
+                      /* vendor= */ false,
+                      /* forceDisableAdaptive= */ false,
+                      /* forceSecure= */ false)),
+          /* enableDecoderFallback= */ false,
+          /* assumedMinimumCodecOperatingRate= */ 44100);
+      experimentalEnableProcessedStreamChangedAtStart();
+    }
+
+    @Override
+    public String getName() {
+      return "videoTest";
+    }
+
+    @Override
+    protected @Capabilities int supportsFormat(MediaCodecSelector mediaCodecSelector, Format format) {
+      return RendererCapabilities.create(C.FORMAT_HANDLED);
+    }
+
+    @Override
+    protected List<MediaCodecInfo> getDecoderInfos(
+        MediaCodecSelector mediaCodecSelector, Format format, boolean requiresSecureDecoder)
+        throws MediaCodecUtil.DecoderQueryException {
+      return mediaCodecSelector.getDecoderInfos(
+          format.sampleMimeType,
+          /* requiresSecureDecoder= */ false,
+          /* requiresTunnelingDecoder= */ false);
+    }
+
+    @Override
+    protected MediaCodecAdapter.Configuration getMediaCodecConfiguration(
+        MediaCodecInfo codecInfo,
+        Format format,
+        @Nullable MediaCrypto crypto,
+        float codecOperatingRate) {
+      MediaFormat mediaFormat = new MediaFormat();
+      applyCodecParametersToMediaFormat(mediaFormat);
+      return MediaCodecAdapter.Configuration.createForVideoDecoding(
+          codecInfo, mediaFormat, format, /* surface= */ null, crypto);
     }
 
     @Override

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/video/MediaCodecVideoRendererTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/video/MediaCodecVideoRendererTest.java
@@ -40,6 +40,7 @@ import static androidx.media3.test.utils.TestUtil.createByteArray;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -295,6 +296,103 @@ public class MediaCodecVideoRendererTest {
     }
     mediaCodecVideoRenderer.setCurrentStreamFinal();
     int posUs = 80_001; // Ensures buffer will be 30_001us late.
+    while (!mediaCodecVideoRenderer.isEnded()) {
+      mediaCodecVideoRenderer.render(posUs, SystemClock.elapsedRealtime() * 1000);
+      codecAdapterFactory.idleQueueingAndCallbackThreads();
+      posUs += 40_000;
+    }
+    shadowOf(testMainLooper).idle();
+
+    verify(eventListener).onDroppedFrames(eq(1), anyLong());
+  }
+
+  @Test
+  public void render_withUnreliablePtsAndModeratelyLateBuffer_doesNotDrop() throws Exception {
+    // Point 3: unreliable timestamps must not disable drop detection outright (see
+    // shouldDropOutputBuffer), but do need much more slack than normal since earlyUs isn't ground
+    // truth here. 100ms late clears the normal 30ms threshold but not the widened 500ms one.
+    Format unreliablePts =
+        VIDEO_H264.buildUpon().setHasReliablePresentationTimestamps(false).build();
+    FakeSampleStream fakeSampleStream =
+        new FakeSampleStream(
+            new DefaultAllocator(/* trimOnReset= */ true, /* individualAllocationSize= */ 1024),
+            /* mediaSourceEventDispatcher= */ null,
+            DrmSessionManager.DRM_UNSUPPORTED,
+            new DrmSessionEventListener.EventDispatcher(),
+            /* initialFormat= */ unreliablePts,
+            ImmutableList.of(
+                oneByteSample(/* timeUs= */ 0, C.BUFFER_FLAG_KEY_FRAME), // First buffer.
+                oneByteSample(/* timeUs= */ 50_000), // Moderately late buffer.
+                oneByteSample(/* timeUs= */ 100_000), // Last buffer.
+                END_OF_STREAM_ITEM));
+    fakeSampleStream.writeData(/* startPositionUs= */ 0);
+    mediaCodecVideoRenderer.enable(
+        RendererConfiguration.DEFAULT,
+        new Format[] {unreliablePts},
+        fakeSampleStream,
+        /* positionUs= */ 0,
+        /* joining= */ false,
+        /* mayRenderStartOfStream= */ true,
+        /* startPositionUs= */ 0,
+        /* offsetUs= */ 0,
+        /* mediaPeriodId= */ new MediaSource.MediaPeriodId(new Object()));
+
+    mediaCodecVideoRenderer.start();
+    mediaCodecVideoRenderer.render(0, SystemClock.elapsedRealtime() * 1000);
+    for (int i = 0; i < 5; i++) {
+      mediaCodecVideoRenderer.render(40_000, SystemClock.elapsedRealtime() * 1000);
+      codecAdapterFactory.idleQueueingAndCallbackThreads();
+    }
+    mediaCodecVideoRenderer.setCurrentStreamFinal();
+    int posUs = 150_001; // ~100ms late relative to the 50_000 sample.
+    while (!mediaCodecVideoRenderer.isEnded()) {
+      mediaCodecVideoRenderer.render(posUs, SystemClock.elapsedRealtime() * 1000);
+      codecAdapterFactory.idleQueueingAndCallbackThreads();
+      posUs += 40_000;
+    }
+    shadowOf(testMainLooper).idle();
+
+    verify(eventListener, never()).onDroppedFrames(anyInt(), anyLong());
+  }
+
+  @Test
+  public void render_withUnreliablePtsAndVeryLateBuffer_stillDrops() throws Exception {
+    // Same as render_withUnreliablePtsAndModeratelyLateBuffer_doesNotDrop, but ~600ms late --
+    // past the widened threshold, proving the backstop actually engages.
+    Format unreliablePts =
+        VIDEO_H264.buildUpon().setHasReliablePresentationTimestamps(false).build();
+    FakeSampleStream fakeSampleStream =
+        new FakeSampleStream(
+            new DefaultAllocator(/* trimOnReset= */ true, /* individualAllocationSize= */ 1024),
+            /* mediaSourceEventDispatcher= */ null,
+            DrmSessionManager.DRM_UNSUPPORTED,
+            new DrmSessionEventListener.EventDispatcher(),
+            /* initialFormat= */ unreliablePts,
+            ImmutableList.of(
+                oneByteSample(/* timeUs= */ 0, C.BUFFER_FLAG_KEY_FRAME), // First buffer.
+                oneByteSample(/* timeUs= */ 50_000), // Very late buffer.
+                oneByteSample(/* timeUs= */ 100_000), // Last buffer.
+                END_OF_STREAM_ITEM));
+    fakeSampleStream.writeData(/* startPositionUs= */ 0);
+    mediaCodecVideoRenderer.enable(
+        RendererConfiguration.DEFAULT,
+        new Format[] {unreliablePts},
+        fakeSampleStream,
+        /* positionUs= */ 0,
+        /* joining= */ false,
+        /* mayRenderStartOfStream= */ true,
+        /* startPositionUs= */ 0,
+        /* offsetUs= */ 0,
+        /* mediaPeriodId= */ new MediaSource.MediaPeriodId(new Object()));
+
+    mediaCodecVideoRenderer.start();
+    mediaCodecVideoRenderer.render(0, SystemClock.elapsedRealtime() * 1000);
+    for (int i = 0; i < 5; i++) {
+      mediaCodecVideoRenderer.render(40_000, SystemClock.elapsedRealtime() * 1000);
+      codecAdapterFactory.idleQueueingAndCallbackThreads();
+    }
+    mediaCodecVideoRenderer.setCurrentStreamFinal();
+    int posUs = 650_001; // ~600ms late relative to the 50_000 sample.
     while (!mediaCodecVideoRenderer.isEnded()) {
       mediaCodecVideoRenderer.render(posUs, SystemClock.elapsedRealtime() * 1000);
       codecAdapterFactory.idleQueueingAndCallbackThreads();
@@ -1343,6 +1441,81 @@ public class MediaCodecVideoRendererTest {
     // them in feed order proves codecInputFormat -- not the already-advanced inputFormat -- gated
     // the FIFO replay while the old codec's format-A output was still draining.
     assertThat(processedTimestamps.subList(0, 2)).containsExactly(40_000L, 0L).inOrder();
+  }
+
+  @Test
+  public void render_withUnreliablePtsAndVariableFrameSpacing_preservesPerSampleDurations()
+      throws Exception {
+    // Point 6: a VFR stream with real reordering and no ctts can't have its true per-frame
+    // presentation instants reconstructed exactly (there's no ctts to say what they are). What
+    // arrivalOrderPtsQueue can and must do is replay each sample's own queued timestamp exactly,
+    // not flatten irregular gaps to an assumed constant frame rate -- the bug this queue replaced.
+    Format unreliablePtsVfr =
+        VIDEO_H264.buildUpon().setHasReliablePresentationTimestamps(false).build();
+    List<Long> processedTimestamps = new ArrayList<>();
+    FakeSampleStream fakeSampleStream =
+        new FakeSampleStream(
+            new DefaultAllocator(/* trimOnReset= */ true, /* individualAllocationSize= */ 1024),
+            /* mediaSourceEventDispatcher= */ null,
+            DrmSessionManager.DRM_UNSUPPORTED,
+            new DrmSessionEventListener.EventDispatcher(),
+            /* initialFormat= */ unreliablePtsVfr,
+            ImmutableList.of(
+                oneByteSample(/* timeUs= */ 0, C.BUFFER_FLAG_KEY_FRAME),
+                oneByteSample(/* timeUs= */ 40_000),
+                oneByteSample(/* timeUs= */ 80_000),
+                oneByteSample(/* timeUs= */ 280_000), // Large VFR jump, e.g. a scene cut.
+                oneByteSample(/* timeUs= */ 300_000), // Small gap right after.
+                END_OF_STREAM_ITEM));
+    fakeSampleStream.writeData(/* startPositionUs= */ 0);
+    MediaCodecVideoRenderer renderer =
+        new MediaCodecVideoRenderer(
+            new MediaCodecVideoRenderer.Builder(ApplicationProvider.getApplicationContext())
+                .setCodecAdapterFactory(codecAdapterFactory)
+                .setMediaCodecSelector(mediaCodecSelector)
+                .setAllowedJoiningTimeMs(0)
+                .setEnableDecoderFallback(false)
+                .setEventHandler(new Handler(testMainLooper))
+                .setEventListener(eventListener)
+                .setMaxDroppedFramesToNotify(1)) {
+          @Override
+          protected @Capabilities int supportsFormat(
+              MediaCodecSelector mediaCodecSelector, Format format) {
+            return RendererCapabilities.create(C.FORMAT_HANDLED);
+          }
+
+          @Override
+          protected void onProcessedOutputBuffer(long presentationTimeUs) {
+            super.onProcessedOutputBuffer(presentationTimeUs);
+            processedTimestamps.add(presentationTimeUs);
+          }
+        };
+    renderer.init(/* index= */ 0, PlayerId.UNSET, Clock.DEFAULT);
+    renderer.handleMessage(Renderer.MSG_SET_VIDEO_OUTPUT, surface);
+    renderer.enable(
+        RendererConfiguration.DEFAULT,
+        new Format[] {unreliablePtsVfr},
+        fakeSampleStream,
+        /* positionUs= */ 0,
+        /* joining= */ false,
+        /* mayRenderStartOfStream= */ true,
+        /* startPositionUs= */ 0,
+        /* offsetUs= */ 0,
+        new MediaSource.MediaPeriodId(new Object()));
+    renderer.start();
+    renderer.setCurrentStreamFinal();
+    int positionUs = 0;
+    while (!renderer.isEnded()) {
+      ShadowSystemClock.advanceBy(Duration.ofMillis(40));
+      renderer.render(positionUs, msToUs(SystemClock.elapsedRealtime()));
+      codecAdapterFactory.idleQueueingAndCallbackThreads();
+      positionUs += 40_000;
+    }
+    shadowOf(testMainLooper).idle();
+
+    assertThat(processedTimestamps)
+        .containsExactly(0L, 40_000L, 80_000L, 280_000L, 300_000L)
+        .inOrder();
   }
 
   @Config(minSdk = 30)

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/video/MediaCodecVideoRendererTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/video/MediaCodecVideoRendererTest.java
@@ -1247,6 +1247,104 @@ public class MediaCodecVideoRendererTest {
     verify(eventListener, times(2)).onVideoDecoderInitialized(any(), anyLong(), anyLong());
   }
 
+  @Config(maxSdk = 29)
+  @Test
+  public void
+      render_withUnreliablePtsDuringIncompatibleFormatChange_stillFifoOrdersDrainingOldCodecOutput()
+          throws Exception {
+    // codecInputFormat (not inputFormat) must gate arrivalOrderPtsQueue, since inputFormat can
+    // advance to the new format before the old codec has finished draining its buffered output
+    // under the old format. Reuses render_withIncompatibleFrameRateChangeUpToSdk29_discardsCodec's
+    // 24fps->30fps trigger for a full codec reinit (REUSE_RESULT_NO) on SDK<=29, but the first
+    // format also has hasReliablePresentationTimestamps=false and out-of-order sample timestamps,
+    // and the codec adapter reorders dequeued output by ascending timestamp (simulating an
+    // untrustworthy decoder echo) so a wrong field choice is actually observable.
+    SystemClock.setCurrentTimeMillis(876_000_000);
+    Format unreliablePts24Fps =
+        VIDEO_H264_24FPS.buildUpon().setHasReliablePresentationTimestamps(false).build();
+    Format reliablePts30Fps =
+        VIDEO_H264_30FPS.buildUpon().setHasReliablePresentationTimestamps(true).build();
+    List<Long> processedTimestamps = new ArrayList<>();
+    FakeSampleStream fakeSampleStream =
+        new FakeSampleStream(
+            new DefaultAllocator(/* trimOnReset= */ true, /* individualAllocationSize= */ 1024),
+            /* mediaSourceEventDispatcher= */ null,
+            DrmSessionManager.DRM_UNSUPPORTED,
+            new DrmSessionEventListener.EventDispatcher(),
+            /* initialFormat= */ unreliablePts24Fps,
+            ImmutableList.of(
+                // Deliberately out of order: with no ctts, these are decode-order values, not
+                // true presentation times, which is the whole point of hasReliablePresentationTimestamps.
+                oneByteSample(/* timeUs= */ 40_000, C.BUFFER_FLAG_KEY_FRAME),
+                oneByteSample(/* timeUs= */ 0)));
+    fakeSampleStream.writeData(/* startPositionUs= */ 0);
+    MediaCodecVideoRenderer renderer =
+        new MediaCodecVideoRenderer(
+            new MediaCodecVideoRenderer.Builder(ApplicationProvider.getApplicationContext())
+                .setCodecAdapterFactory(
+                    new ForwardingSynchronousMediaCodecAdapterWithReordering.Factory())
+                .setMediaCodecSelector(mediaCodecSelector)
+                .setAllowedJoiningTimeMs(0)
+                .setEnableDecoderFallback(false)
+                .setEventHandler(new Handler(testMainLooper))
+                .setEventListener(eventListener)
+                .setMaxDroppedFramesToNotify(1)) {
+          @Override
+          protected @Capabilities int supportsFormat(
+              MediaCodecSelector mediaCodecSelector, Format format) {
+            return RendererCapabilities.create(C.FORMAT_HANDLED);
+          }
+
+          @Override
+          protected void onProcessedOutputBuffer(long presentationTimeUs) {
+            super.onProcessedOutputBuffer(presentationTimeUs);
+            processedTimestamps.add(presentationTimeUs);
+          }
+        };
+    renderer.init(/* index= */ 0, PlayerId.UNSET, Clock.DEFAULT);
+    renderer.handleMessage(Renderer.MSG_SET_VIDEO_OUTPUT, surface);
+    renderer.enable(
+        RendererConfiguration.DEFAULT,
+        new Format[] {unreliablePts24Fps, reliablePts30Fps},
+        fakeSampleStream,
+        /* positionUs= */ 0,
+        /* joining= */ false,
+        /* mayRenderStartOfStream= */ true,
+        /* startPositionUs= */ 0,
+        /* offsetUs= */ 0,
+        new MediaSource.MediaPeriodId(new Object()));
+    renderer.start();
+    // Render first sample to initialize codec.
+    renderer.render(/* positionUs= */ 0, msToUs(SystemClock.elapsedRealtime()));
+    codecAdapterFactory.idleQueueingAndCallbackThreads();
+    shadowOf(testMainLooper).idle();
+
+    // Feed format change from 24->30 fps, which is not generally compatible and should reset
+    // codec, while the old codec may still be draining its format-A output.
+    fakeSampleStream.append(
+        ImmutableList.of(
+            format(reliablePts30Fps),
+            oneByteSample(/* timeUs= */ 80_000, C.BUFFER_FLAG_KEY_FRAME),
+            END_OF_STREAM_ITEM));
+    fakeSampleStream.writeData(/* startPositionUs= */ 40_000);
+    renderer.setCurrentStreamFinal();
+    int positionUs = 40_000;
+    while (!renderer.isEnded()) {
+      ShadowSystemClock.advanceBy(Duration.ofMillis(40));
+      renderer.render(positionUs, msToUs(SystemClock.elapsedRealtime()));
+      codecAdapterFactory.idleQueueingAndCallbackThreads();
+      positionUs += 40_000;
+    }
+    shadowOf(testMainLooper).idle();
+
+    verify(eventListener).onVideoDecoderReleased(any());
+    verify(eventListener, times(2)).onVideoDecoderInitialized(any(), anyLong(), anyLong());
+    // The reordering adapter would otherwise hand these back sorted ascending (0, 40_000). Seeing
+    // them in feed order proves codecInputFormat -- not the already-advanced inputFormat -- gated
+    // the FIFO replay while the old codec's format-A output was still draining.
+    assertThat(processedTimestamps.subList(0, 2)).containsExactly(40_000L, 0L).inOrder();
+  }
+
   @Config(minSdk = 30)
   @Test
   public void render_withIncompatibleFrameRateChangeFromSdk30_keepsCodec() throws Exception {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
@@ -962,9 +962,14 @@ public final class BoxParser {
     long editedDurationUs =
         Util.scaleLargeTimestamp(pts, C.MICROS_PER_SECOND, track.movieTimescale);
     // No ctts means no real per-sample composition time was ever recorded (see
-    // https://github.com/androidx/media/issues/3347) — every sample's timestamp is just decode time.
+    // https://github.com/androidx/media/issues/3347) — every sample's timestamp is just decode
+    // time, which only matters if the bitstream actually reorders frames. maxNumReorderSamples
+    // (from the SPS, not the container) is 0 only when we positively know it doesn't; treat
+    // NO_VALUE (couldn't be determined) the same as "might reorder", not as "doesn't".
     boolean hasReliablePresentationTimestamps =
-        !(track.type == C.TRACK_TYPE_VIDEO && ctts == null);
+        !(track.type == C.TRACK_TYPE_VIDEO
+            && ctts == null
+            && track.format.maxNumReorderSamples != 0);
     if (hasPrerollSamples || !hasReliablePresentationTimestamps) {
       Format format =
           track

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
@@ -961,11 +961,8 @@ public final class BoxParser {
     }
     long editedDurationUs =
         Util.scaleLargeTimestamp(pts, C.MICROS_PER_SECOND, track.movieTimescale);
-    // A video track with no ctts box has no real per-sample composition-time information: every
-    // sample's timestamp is just its decode time. For content with B-frame reordering that's a
-    // silently-wrong presentation timestamp, not merely a missing optimization (see
-    // https://github.com/androidx/media/issues/3347) — flag it so renderers don't treat these
-    // timestamps as ground truth for lateness-based decisions.
+    // No ctts means no real per-sample composition time was ever recorded (see
+    // https://github.com/androidx/media/issues/3347) — every sample's timestamp is just decode time.
     boolean hasReliablePresentationTimestamps =
         !(track.type == C.TRACK_TYPE_VIDEO && ctts == null);
     if (hasPrerollSamples || !hasReliablePresentationTimestamps) {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
@@ -448,6 +448,20 @@ public final class BoxParser {
       GaplessInfoHolder gaplessInfoHolder,
       boolean omitTrackSampleTable)
       throws ParserException {
+    // Computed and applied to track up front, before any of the return paths below (including
+    // the sampleCount==0 and omitTrackSampleTable ones), so all of them carry the correct flag --
+    // this doesn't depend on anything computed later in this method. See the field's javadoc for
+    // what NO_VALUE-vs-0 means here.
+    boolean hasReliablePresentationTimestamps =
+        !(track.type == C.TRACK_TYPE_VIDEO
+            && stblBox.getLeafBoxOfType(Mp4Box.TYPE_ctts) == null
+            && track.format.maxNumReorderSamples != 0);
+    if (!hasReliablePresentationTimestamps) {
+      track =
+          track.copyWithFormat(
+              track.format.buildUpon().setHasReliablePresentationTimestamps(false).build());
+    }
+
     SampleSizeBox sampleSizeBox;
     @Nullable LeafBox stszAtom = stblBox.getLeafBoxOfType(Mp4Box.TYPE_stsz);
     if (stszAtom != null) {
@@ -961,23 +975,10 @@ public final class BoxParser {
     }
     long editedDurationUs =
         Util.scaleLargeTimestamp(pts, C.MICROS_PER_SECOND, track.movieTimescale);
-    // No ctts means no real per-sample composition time was ever recorded (see
-    // https://github.com/androidx/media/issues/3347) — every sample's timestamp is just decode
-    // time, which only matters if the bitstream actually reorders frames. maxNumReorderSamples
-    // (from the SPS, not the container) is 0 only when we positively know it doesn't; treat
-    // NO_VALUE (couldn't be determined) the same as "might reorder", not as "doesn't".
-    boolean hasReliablePresentationTimestamps =
-        !(track.type == C.TRACK_TYPE_VIDEO
-            && ctts == null
-            && track.format.maxNumReorderSamples != 0);
-    if (hasPrerollSamples || !hasReliablePresentationTimestamps) {
-      Format format =
-          track
-              .format
-              .buildUpon()
-              .setHasPrerollSamples(hasPrerollSamples || track.format.hasPrerollSamples)
-              .setHasReliablePresentationTimestamps(hasReliablePresentationTimestamps)
-              .build();
+    // hasReliablePresentationTimestamps was already applied to track's format at the top of this
+    // method; only hasPrerollSamples (which isn't known until now) remains to apply here.
+    if (hasPrerollSamples) {
+      Format format = track.format.buildUpon().setHasPrerollSamples(true).build();
       track = track.copyWithFormat(format);
     }
     return new TrackSampleTable(

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/BoxParser.java
@@ -961,8 +961,21 @@ public final class BoxParser {
     }
     long editedDurationUs =
         Util.scaleLargeTimestamp(pts, C.MICROS_PER_SECOND, track.movieTimescale);
-    if (hasPrerollSamples) {
-      Format format = track.format.buildUpon().setHasPrerollSamples(true).build();
+    // A video track with no ctts box has no real per-sample composition-time information: every
+    // sample's timestamp is just its decode time. For content with B-frame reordering that's a
+    // silently-wrong presentation timestamp, not merely a missing optimization (see
+    // https://github.com/androidx/media/issues/3347) — flag it so renderers don't treat these
+    // timestamps as ground truth for lateness-based decisions.
+    boolean hasReliablePresentationTimestamps =
+        !(track.type == C.TRACK_TYPE_VIDEO && ctts == null);
+    if (hasPrerollSamples || !hasReliablePresentationTimestamps) {
+      Format format =
+          track
+              .format
+              .buildUpon()
+              .setHasPrerollSamples(hasPrerollSamples || track.format.hasPrerollSamples)
+              .setHasReliablePresentationTimestamps(hasReliablePresentationTimestamps)
+              .build();
       track = track.copyWithFormat(format);
     }
     return new TrackSampleTable(


### PR DESCRIPTION
Fixes #3347

## Problem

On Google TV Streamer 4K (MediaTek MT8696, `c2.mtk.hevc.decoder`),
decoding specific HEVC Main10 content causes the codec to return
output buffers with non-monotonic `presentationTimeUs`, while the
order in which those buffers are released remains correct — confirmed
by comparing each buffer's release-order rank against its
timestamp-sorted rank: the two never diverge by more than a few
positions, and the timestamp values themselves are individually
correct for the frame they belong to.

Reproduced independently of ExoPlayer, using a minimal test harness
built directly on `AMediaCodec`/`AMediaExtractor` (no ExoPlayer, no
Java `MediaCodec`) against the same file: identical non-monotonic
timestamp pattern. This confirms the defect is in the decoder/HAL
output, not in ExoPlayer's handling of it.

`MediaCodecRenderer` processes output buffers in raw release order
but uses the codec-reported `presentationTimeUs` directly for the
render/drop decision in `MediaCodecVideoRenderer`. When a buffer's
timestamp is behind the previous one, it's treated as arriving too
late and dropped. Measured on affected content: ~30% of decoded video
frames dropped, sustained throughout playback, reproduced in the
Media3 demo app as well as Plex, Jellyfin, and other ExoPlayer-based
players on the same device/file.

## Fix

Re-derive each output buffer's `presentationTimeUs` from its release
order and the stream's known frame duration (from `Format.frameRate`),
instead of trusting the codec-reported value. Buffer release order is
left untouched — buffers are not held or reordered.

## Testing

Verified on the affected device (Google TV Streamer 4K) against three
files that reliably reproduce the issue on unpatched `main`,
including a 90-second real-world clip: dropped-frame count goes from
~30% to 0, and the fix was visually confirmed on-device — direct
observation of smooth playback, not just log metrics. HOWEVER, with this approach, video and audio lose sync.

An earlier approach that buffered and released output buffers in
sorted-timestamp order was also tried and rejected: it also eliminated
logged drops, but produced visible playback artifacts on-device. That
result is why this PR does not reorder buffers.
