### PR TITLE
Preserve HDR bitmap in image playback/export pipeline

### DIFF
--- a/libraries/effect/src/androidTest/java/androidx/media3/effect/BitmapToHardwareBufferProcessorTest.java
+++ b/libraries/effect/src/androidTest/java/androidx/media3/effect/BitmapToHardwareBufferProcessorTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.junit.After;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,10 +59,11 @@ import org.junit.runner.RunWith;
 @SdkSuppress(minSdkVersion = 26)
 public final class BitmapToHardwareBufferProcessorTest {
 
-  // TODO: b/475511702 - Update with HDR bitmap formats once supported.
   private enum BitmapType {
     HARDWARE,
     ARGB_8888,
+    RGBA_1010102,
+    RGBA_F16,
   }
 
   private static final float MAX_AVG_PIXEL_DIFFERENCE = 1.0f;
@@ -104,6 +106,8 @@ public final class BitmapToHardwareBufferProcessorTest {
   @Test
   public void process_validBitmap_copiesPixelsCorrectly(@TestParameter BitmapType bitmapType)
       throws Exception {
+    checkBitmapTypeSupported(bitmapType);
+
     Bitmap inputBitmap = readBitmap(bitmapType);
     // The pixel comparison can only run on ARGB_8888 bitmaps, if the input is HARDWARE, copy it to
     // a ARGB_8888 for the assertion.
@@ -183,6 +187,8 @@ public final class BitmapToHardwareBufferProcessorTest {
   @Test
   public void process_repeatedBitmap_reusesSameBuffer(@TestParameter BitmapType bitmapType)
       throws IOException {
+    checkBitmapTypeSupported(bitmapType);
+
     Bitmap inputBitmap = readBitmap(bitmapType);
     HardwareBufferFrame inputFrame1 = createBitmapFrame(inputBitmap);
     HardwareBufferFrame inputFrame2 = createBitmapFrame(inputBitmap);
@@ -200,6 +206,8 @@ public final class BitmapToHardwareBufferProcessorTest {
   @Test
   public void process_repeatedBitmapAfterRelease_reusesSameBuffer(
       @TestParameter BitmapType bitmapType) throws IOException {
+    checkBitmapTypeSupported(bitmapType);
+
     Bitmap inputBitmap = readBitmap(bitmapType);
     HardwareBufferFrame inputFrame1 = createBitmapFrame(inputBitmap);
     HardwareBufferFrame inputFrame2 = createBitmapFrame(inputBitmap);
@@ -218,6 +226,8 @@ public final class BitmapToHardwareBufferProcessorTest {
   public void process_differentBitmap_createsNewBufferAndRemovesReferenceToOldBuffer(
       @TestParameter BitmapType bitmapType)
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    checkBitmapTypeSupported(bitmapType);
+
     Bitmap bitmap1 = readBitmap(bitmapType);
     Bitmap bitmap2 = readBitmap(bitmapType);
 
@@ -278,6 +288,8 @@ public final class BitmapToHardwareBufferProcessorTest {
   @Test
   public void releaseOutputFrame_sharedBuffer_doesNotCloseSharedBuffer(
       @TestParameter BitmapType bitmapType) throws Exception {
+    checkBitmapTypeSupported(bitmapType);
+
     Bitmap inputBitmap = readBitmap(bitmapType);
     HardwareBufferFrame inputFrame1 = createBitmapFrame(inputBitmap);
     HardwareBufferFrame inputFrame2 = createBitmapFrame(inputBitmap);
@@ -387,8 +399,27 @@ public final class BitmapToHardwareBufferProcessorTest {
       case HARDWARE:
         return BitmapPixelTestUtil.readBitmap(INPUT_PATH)
             .copy(Config.HARDWARE, /* isMutable= */ false);
+      case RGBA_1010102:
+        if (Build.VERSION.SDK_INT >= 33) {
+          return BitmapPixelTestUtil.readBitmap(INPUT_PATH)
+              .copy(Config.RGBA_1010102, /* isMutable= */ false);
+        }
+        return BitmapPixelTestUtil.readBitmap(INPUT_PATH);
+      case RGBA_F16:
+        if (Build.VERSION.SDK_INT >= 33) {
+          return BitmapPixelTestUtil.readBitmap(INPUT_PATH)
+              .copy(Config.RGBA_F16, /* isMutable= */ false);
+        }
+        return BitmapPixelTestUtil.readBitmap(INPUT_PATH);
     }
     throw new IllegalArgumentException();
+  }
+
+  private static void checkBitmapTypeSupported(BitmapType bitmapType) {
+    if ((bitmapType == BitmapType.RGBA_1010102 || bitmapType == BitmapType.RGBA_F16)
+        && Build.VERSION.SDK_INT < 33) {
+      throw new AssumptionViolatedException("HDR bitmap formats require API level 33+");
+    }
   }
 
   private static HardwareBufferFrame createBitmapFrame(Bitmap bitmap) {

--- a/libraries/effect/src/main/java/androidx/media3/effect/BitmapToHardwareBufferProcessor.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/BitmapToHardwareBufferProcessor.java
@@ -123,7 +123,19 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
             } else {
               // Input is not HARDWARE and API >= 31: We can create a HARDWARE Bitmap copy
               // and get its HardwareBuffer.
-              buffer = nextBitmap.copy(Config.HARDWARE, /* isMutable= */ false).getHardwareBuffer();
+              Bitmap hwCopy = nextBitmap.copy(Config.HARDWARE, /* isMutable= */ false);
+              if (hwCopy != null) {
+                buffer = hwCopy.getHardwareBuffer();
+                // Discard the buffer if the HARDWARE copy silently downgraded an HDR
+                // bitmap's bit depth. The CPU-copy fallback preserves the source pixel
+                // format.
+                if (buffer != null
+                    && buffer.getFormat()
+                        != getHardwareBufferPixelFormat(nextBitmap.getConfig())) {
+                  buffer.close();
+                  buffer = null;
+                }
+              }
             }
           }
           // Fallback to the native helper when the HardwareBuffer retrieved from the Bitmap was
@@ -200,14 +212,14 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
   }
 
   /**
-   * Copies a {@link Bitmap.Config#ARGB_8888}, {@link Bitmap.Config#RGBA_F16} or {@link
-   * Bitmap.Config#RGBA_1010102} {@link Bitmap} to a {@link HardwareBuffer} using JNI.
+   * Copies a software {@link Bitmap} to a {@link HardwareBuffer} using JNI. The pixel format of the
+   * created buffer is derived from the source {@link Bitmap.Config} via {@link
+   * #getHardwareBufferPixelFormat} so that the source bit depth is preserved.
    *
    * <p>The created buffer will have {@linkplain HardwareBuffer#USAGE_GPU_SAMPLED_IMAGE GPU read},
    * {@linkplain HardwareBuffer#USAGE_GPU_COLOR_OUTPUT GPU write}, {@linkplain
    * HardwareBuffer#USAGE_CPU_READ_OFTEN CPU read} and {@linkplain
-   * HardwareBuffer#USAGE_CPU_WRITE_OFTEN CPU write} usage flags set, and pixelFormat of {@link
-   * HardwareBuffer#RGBA_8888}.
+   * HardwareBuffer#USAGE_CPU_WRITE_OFTEN CPU write} usage flags set.
    */
   private static HardwareBuffer copyCpuBitmapToHardwareBuffer(
       Bitmap bitmap, HardwareBufferJniWrapper hardwareBufferJniWrapper) {
@@ -215,7 +227,7 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
         HardwareBuffer.create(
             bitmap.getWidth(),
             bitmap.getHeight(),
-            /* pixelFormat= */ HardwareBuffer.RGBA_8888,
+            getHardwareBufferPixelFormat(bitmap.getConfig()),
             /* layers= */ 1,
             /* usageFlags= */ HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE
                 | HardwareBuffer.USAGE_GPU_COLOR_OUTPUT
@@ -224,6 +236,21 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
 
     checkState(hardwareBufferJniWrapper.nativeCopyBitmapToHardwareBuffer(bitmap, buffer));
     return buffer;
+  }
+
+  /**
+   * Returns the {@link HardwareBuffer} pixel format that matches the source bit depth of the given
+   * {@link Bitmap.Config}. Falls back to {@link HardwareBuffer#RGBA_8888} for configs whose bit
+   * depth is 8 bpc or unknown.
+   */
+  private static int getHardwareBufferPixelFormat(@Nullable Config config) {
+    if (SDK_INT >= 33 && config == Config.RGBA_1010102) {
+      return HardwareBuffer.RGBA_1010102;
+    }
+    if (config == Config.RGBA_F16) {
+      return HardwareBuffer.RGBA_FP16;
+    }
+    return HardwareBuffer.RGBA_8888;
   }
 
   private void releaseBuffer(HardwareBuffer buffer, @Nullable SyncFenceWrapper releaseFence) {

--- a/libraries/effect/src/main/java/androidx/media3/effect/BitmapToHardwareBufferProcessor.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/BitmapToHardwareBufferProcessor.java
@@ -130,8 +130,7 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
                 // bitmap's bit depth. The CPU-copy fallback preserves the source pixel
                 // format.
                 if (buffer != null
-                    && buffer.getFormat()
-                        != getHardwareBufferPixelFormat(nextBitmap.getConfig())) {
+                    && buffer.getFormat() != getHardwareBufferPixelFormat(nextBitmap.getConfig())) {
                   buffer.close();
                   buffer = null;
                 }

--- a/libraries/effect/src/main/java/androidx/media3/effect/BitmapToHardwareBufferProcessor.java
+++ b/libraries/effect/src/main/java/androidx/media3/effect/BitmapToHardwareBufferProcessor.java
@@ -116,26 +116,9 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
       if (currentFrame == null) {
         HardwareBuffer buffer = null;
         try {
-          if (SDK_INT >= 31) {
-            if (nextBitmap.getConfig() == Config.HARDWARE) {
-              // Input is HARDWARE and API >= 31: Direct access to HardwareBuffer is possible.
-              buffer = nextBitmap.getHardwareBuffer();
-            } else {
-              // Input is not HARDWARE and API >= 31: We can create a HARDWARE Bitmap copy
-              // and get its HardwareBuffer.
-              Bitmap hwCopy = nextBitmap.copy(Config.HARDWARE, /* isMutable= */ false);
-              if (hwCopy != null) {
-                buffer = hwCopy.getHardwareBuffer();
-                // Discard the buffer if the HARDWARE copy silently downgraded an HDR
-                // bitmap's bit depth. The CPU-copy fallback preserves the source pixel
-                // format.
-                if (buffer != null
-                    && buffer.getFormat() != getHardwareBufferPixelFormat(nextBitmap.getConfig())) {
-                  buffer.close();
-                  buffer = null;
-                }
-              }
-            }
+          if (SDK_INT >= 31 && nextBitmap.getConfig() == Config.HARDWARE) {
+            // Input is HARDWARE and API >= 31: Direct access to HardwareBuffer is possible.
+            buffer = nextBitmap.getHardwareBuffer();
           }
           // Fallback to the native helper when the HardwareBuffer retrieved from the Bitmap was
           // null, or SDK_INT < 31.
@@ -146,6 +129,7 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
               // and then copy that to a new HardwareBuffer via JNI.
               Bitmap softwareBitmap = nextBitmap.copy(Config.ARGB_8888, /* isMutable= */ false);
               buffer = copyCpuBitmapToHardwareBuffer(softwareBitmap, hardwareBufferJniWrapper);
+              softwareBitmap.recycle();
             } else {
               // Input is not HARDWARE: Copy the software Bitmap to a new HardwareBuffer via JNI.
               buffer = copyCpuBitmapToHardwareBuffer(nextBitmap, hardwareBufferJniWrapper);
@@ -239,15 +223,18 @@ public class BitmapToHardwareBufferProcessor implements HardwareBufferFrameProce
 
   /**
    * Returns the {@link HardwareBuffer} pixel format that matches the source bit depth of the given
-   * {@link Bitmap.Config}. Falls back to {@link HardwareBuffer#RGBA_8888} for configs whose bit
-   * depth is 8 bpc or unknown.
+   * {@link Bitmap.Config} on API 33+. Falls back to {@link HardwareBuffer#RGBA_8888} for configs
+   * whose bit depth is 8 bpc or unknown, or on API levels below 33.
    */
+  // TODO: b/545085046 - Investigate supporting RGBA_FP16 on API 30-32.
   private static int getHardwareBufferPixelFormat(@Nullable Config config) {
-    if (SDK_INT >= 33 && config == Config.RGBA_1010102) {
-      return HardwareBuffer.RGBA_1010102;
-    }
-    if (config == Config.RGBA_F16) {
-      return HardwareBuffer.RGBA_FP16;
+    if (SDK_INT >= 33) {
+      if (config == Config.RGBA_1010102) {
+        return HardwareBuffer.RGBA_1010102;
+      }
+      if (config == Config.RGBA_F16) {
+        return HardwareBuffer.RGBA_FP16;
+      }
     }
     return HardwareBuffer.RGBA_8888;
   }

--- a/libraries/effect_ndk/src/androidTest/java/androidx/media3/effect/ndk/HardwareBufferJniTest.java
+++ b/libraries/effect_ndk/src/androidTest/java/androidx/media3/effect/ndk/HardwareBufferJniTest.java
@@ -70,7 +70,7 @@ public final class HardwareBufferJniTest {
 
   @Test
   @SdkSuppress(minSdkVersion = 33)
-  public void nativeCopyBitmapToHardwareBuffer_hdr_matchesInputBitmap() throws Exception {
+  public void nativeCopyBitmapToHardwareBuffer_rgba1010102_matchesInputBitmap() throws Exception {
     Bitmap inputBitmap =
         BitmapPixelTestUtil.readBitmap(FILE_PATH)
             .copy(Bitmap.Config.RGBA_1010102, /* isMutable= */ false);
@@ -89,6 +89,35 @@ public final class HardwareBufferJniTest {
           Bitmap.wrapHardwareBuffer(hardwareBuffer, ColorSpace.get(ColorSpace.Named.SRGB));
       assertThat(hardwareBitmap).isNotNull();
       Bitmap outputBitmap = hardwareBitmap.copy(Bitmap.Config.RGBA_1010102, /* isMutable= */ false);
+      assertThat(
+              getBitmapAveragePixelAbsoluteDifferenceArgb8888(
+                  inputBitmap, outputBitmap, testName.getMethodName()))
+          .isEqualTo(0);
+    }
+  }
+
+  // TODO: b/545085046 - Investigate supporting RGBA_FP16 on API 30-32.
+  @Test
+  @SdkSuppress(minSdkVersion = 33)
+  public void nativeCopyBitmapToHardwareBuffer_f16_matchesInputBitmap() throws Exception {
+    Bitmap inputBitmap =
+        BitmapPixelTestUtil.readBitmap(FILE_PATH)
+            .copy(Bitmap.Config.RGBA_F16, /* isMutable= */ false);
+    try (HardwareBuffer hardwareBuffer =
+        HardwareBuffer.create(
+            inputBitmap.getWidth(),
+            inputBitmap.getHeight(),
+            HardwareBuffer.RGBA_FP16,
+            /* layers= */ 1,
+            HardwareBuffer.USAGE_CPU_WRITE_OFTEN | HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE)) {
+      assertThat(
+              HardwareBufferJni.INSTANCE.nativeCopyBitmapToHardwareBuffer(
+                  inputBitmap, hardwareBuffer))
+          .isTrue();
+      Bitmap hardwareBitmap =
+          Bitmap.wrapHardwareBuffer(hardwareBuffer, ColorSpace.get(ColorSpace.Named.SRGB));
+      assertThat(hardwareBitmap).isNotNull();
+      Bitmap outputBitmap = hardwareBitmap.copy(Bitmap.Config.RGBA_F16, /* isMutable= */ false);
       assertThat(
               getBitmapAveragePixelAbsoluteDifferenceArgb8888(
                   inputBitmap, outputBitmap, testName.getMethodName()))
@@ -189,7 +218,7 @@ public final class HardwareBufferJniTest {
 
   @Test
   @SdkSuppress(maxSdkVersion = 32)
-  public void nativeCopyHardwareBufferToHardwareBuffer_hdrBelowApi33_returnsTrue()
+  public void nativeCopyHardwareBufferToHardwareBuffer_rgba1010102BelowApi33_returnsTrue()
       throws Exception {
     // The methods to access the HDR bitmap do not exist below API 33, so just assert copying the
     // buffer formats succeeds.
@@ -218,7 +247,8 @@ public final class HardwareBufferJniTest {
 
   @Test
   @SdkSuppress(minSdkVersion = 33)
-  public void nativeCopyHardwareBufferToHardwareBuffer_hdr_matchesInputBuffer() throws Exception {
+  public void nativeCopyHardwareBufferToHardwareBuffer_rgba1010102_matchesInputBuffer()
+      throws Exception {
     Bitmap inputBitmap =
         BitmapPixelTestUtil.readBitmap(FILE_PATH)
             .copy(Bitmap.Config.RGBA_1010102, /* isMutable= */ false);
@@ -249,6 +279,43 @@ public final class HardwareBufferJniTest {
           Bitmap.wrapHardwareBuffer(dstHb, ColorSpace.get(ColorSpace.Named.SRGB));
       assertThat(hardwareBitmap).isNotNull();
       Bitmap outputBitmap = hardwareBitmap.copy(Bitmap.Config.RGBA_1010102, /* isMutable= */ false);
+      assertThat(
+              getBitmapAveragePixelAbsoluteDifferenceArgb8888(
+                  inputBitmap, outputBitmap, testName.getMethodName()))
+          .isEqualTo(0);
+    }
+  }
+
+  // TODO: b/545085046 - Investigate supporting RGBA_FP16 on API 30-32.
+  @Test
+  @SdkSuppress(minSdkVersion = 33)
+  public void nativeCopyHardwareBufferToHardwareBuffer_f16_matchesInputBuffer() throws Exception {
+    Bitmap inputBitmap =
+        BitmapPixelTestUtil.readBitmap(FILE_PATH)
+            .copy(Bitmap.Config.RGBA_F16, /* isMutable= */ false);
+    try (HardwareBuffer srcHb =
+            HardwareBuffer.create(
+                inputBitmap.getWidth(),
+                inputBitmap.getHeight(),
+                HardwareBuffer.RGBA_FP16,
+                /* layers= */ 1,
+                HardwareBuffer.USAGE_CPU_WRITE_OFTEN | HardwareBuffer.USAGE_CPU_READ_OFTEN);
+        HardwareBuffer dstHb =
+            HardwareBuffer.create(
+                inputBitmap.getWidth(),
+                inputBitmap.getHeight(),
+                HardwareBuffer.RGBA_FP16,
+                /* layers= */ 1,
+                HardwareBuffer.USAGE_CPU_WRITE_OFTEN | HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE)) {
+      assertThat(HardwareBufferJni.INSTANCE.nativeCopyBitmapToHardwareBuffer(inputBitmap, srcHb))
+          .isTrue();
+      assertThat(HardwareBufferJni.INSTANCE.nativeCopyHardwareBufferToHardwareBuffer(srcHb, dstHb))
+          .isTrue();
+
+      Bitmap hardwareBitmap =
+          Bitmap.wrapHardwareBuffer(dstHb, ColorSpace.get(ColorSpace.Named.SRGB));
+      assertThat(hardwareBitmap).isNotNull();
+      Bitmap outputBitmap = hardwareBitmap.copy(Bitmap.Config.RGBA_F16, /* isMutable= */ false);
       assertThat(
               getBitmapAveragePixelAbsoluteDifferenceArgb8888(
                   inputBitmap, outputBitmap, testName.getMethodName()))

--- a/libraries/effect_ndk/src/main/jni/hardware_buffer_jni.cc
+++ b/libraries/effect_ndk/src/main/jni/hardware_buffer_jni.cc
@@ -156,10 +156,10 @@ jboolean nativeCopyBitmapToHardwareBuffer(JNIEnv* env, jobject /* this */,
   }
 
   if (bitmapInfo.format != ANDROID_BITMAP_FORMAT_RGBA_8888 &&
-      bitmapInfo.format != ANDROID_BITMAP_FORMAT_RGBA_1010102) {
+      bitmapInfo.format != ANDROID_BITMAP_FORMAT_RGBA_1010102 &&
+      bitmapInfo.format != ANDROID_BITMAP_FORMAT_RGBA_F16) {
     LOGE(
-        "Unsupported bitmap format: %d. Only RGBA_8888 and RGBA_1010102 are "
-        "supported.",
+        "Unsupported bitmap format: %d. Only RGBA_8888, RGBA_1010102, and RGBA_F16 are supported.",
         bitmapInfo.format);
     return JNI_FALSE;
   }
@@ -171,10 +171,18 @@ jboolean nativeCopyBitmapToHardwareBuffer(JNIEnv* env, jobject /* this */,
     return JNI_FALSE;
   }
 
-  uint32_t expectedHbFormat =
-      (bitmapInfo.format == ANDROID_BITMAP_FORMAT_RGBA_1010102)
-          ? AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM
-          : AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+  uint32_t expectedHbFormat;
+  int bpp;
+  if (bitmapInfo.format == ANDROID_BITMAP_FORMAT_RGBA_1010102) {
+    expectedHbFormat = AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM;
+    bpp = 4;
+  } else if (bitmapInfo.format == ANDROID_BITMAP_FORMAT_RGBA_F16) {
+    expectedHbFormat = AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT;
+    bpp = 8;
+  } else {
+    expectedHbFormat = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+    bpp = 4;
+  }
 
   if (hbDesc.format != expectedHbFormat) {
     LOGE(
@@ -203,8 +211,6 @@ jboolean nativeCopyBitmapToHardwareBuffer(JNIEnv* env, jobject /* this */,
     uint8_t* src = static_cast<uint8_t*>(bitmapPixels);
     uint8_t* dst = static_cast<uint8_t*>(hbPixels);
 
-    // Both RGBA_8888 and RGBA_1010102 formats are 32-bit (4 bytes per pixel).
-    const int bpp = 4;
     const size_t rowSize = bitmapInfo.width * bpp;
 
     for (uint32_t y = 0; y < bitmapInfo.height; ++y) {
@@ -268,10 +274,12 @@ jboolean nativeCopyHardwareBufferToHardwareBuffer(JNIEnv* env,
   if (srcDesc.format == AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM ||
       srcDesc.format == AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM) {
     bpp = 4;
+  } else if (srcDesc.format == AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT) {
+    bpp = 8;
   } else {
     LOGE(
-        "Unsupported hardware buffer format: %u. Only RGBA_8888 and "
-        "RGBA_1010102 are supported.",
+        "Unsupported hardware buffer format: %u. Only RGBA_8888, "
+        "RGBA_1010102, and RGBA_FP16 are supported.",
         srcDesc.format);
     return JNI_FALSE;
   }

--- a/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerFrameProcessorTest.java
+++ b/libraries/transformer/src/androidTest/java/androidx/media3/transformer/TransformerFrameProcessorTest.java
@@ -16,18 +16,26 @@
  */
 package androidx.media3.transformer;
 
+import static android.graphics.Bitmap.Config.RGBA_1010102;
+import static androidx.media3.common.C.MICROS_PER_SECOND;
 import static androidx.media3.test.utils.AssetInfo.MP4_SIMPLE_ASSET;
+import static androidx.media3.test.utils.AssetInfo.PNG_ASSET;
 import static androidx.media3.test.utils.FormatSupportAssumptions.assumeFormatsSupported;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.hardware.HardwareBuffer;
+import android.net.Uri;
 import androidx.annotation.RequiresApi;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.VideoCompositorSettings;
+import androidx.media3.common.util.BitmapLoader;
+import androidx.media3.common.video.AsyncFrame;
 import androidx.media3.common.video.Frame;
 import androidx.media3.common.video.FrameProcessor;
+import androidx.media3.common.video.HardwareBufferFrame;
 import androidx.media3.effect.AlphaScale;
 import androidx.media3.effect.DefaultGlFrameProcessor;
 import androidx.media3.effect.HardwareBufferJniWrapper;
@@ -38,6 +46,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SdkSuppress;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -114,6 +125,79 @@ public class TransformerFrameProcessorTest {
         .isEqualTo(composition.videoCompositorSettings);
     assertThat(metadata.get(DefaultGlFrameProcessor.KEY_COMPOSITION_EFFECTS))
         .isEqualTo(composition.effects.videoEffects);
+  }
+
+  @Test
+  @SdkSuppress(minSdkVersion = 34)
+  public void export_withProgrammaticHdrImage_queuesHardwareBufferWithCorrectFormat()
+      throws Exception {
+    AtomicInteger receivedFormat = new AtomicInteger();
+    // Create a fake BitmapLoader that strictly outputs a true 10-bit SDR/HDR bitmap.
+    BitmapLoader fakeBitmapLoader =
+        new BitmapLoader() {
+          @Override
+          public boolean supportsMimeType(String mimeType) {
+            return true;
+          }
+
+          @Override
+          public ListenableFuture<Bitmap> decodeBitmap(byte[] data) {
+            return immediateFuture(Bitmap.createBitmap(1, 1, RGBA_1010102));
+          }
+
+          @Override
+          public ListenableFuture<Bitmap> loadBitmap(Uri uri) {
+            return immediateFuture(Bitmap.createBitmap(1, 1, RGBA_1010102));
+          }
+        };
+    FakeFrameProcessor.Factory fakeFrameProcessorFactory =
+        new FakeFrameProcessor.Factory(/* shouldCompleteIncomingFrames= */ true);
+    FrameProcessor.Factory interceptingFactory =
+        (output, listenerExecutor, listener) -> {
+          FrameProcessor realProcessor =
+              fakeFrameProcessorFactory.create(output, listenerExecutor, listener);
+
+          return new FrameProcessor() {
+            @Override
+            public boolean queue(List<AsyncFrame> frames) {
+              for (AsyncFrame asyncFrame : frames) {
+                if (asyncFrame.frame instanceof HardwareBufferFrame) {
+                  HardwareBufferFrame hardwareBufferFrame = (HardwareBufferFrame) asyncFrame.frame;
+                  // Safely capture the format synchronously before the buffer is closed later
+                  receivedFormat.set(hardwareBufferFrame.getHardwareBuffer().getFormat());
+                }
+              }
+              return realProcessor.queue(frames);
+            }
+
+            @Override
+            public void signalEndOfStream() {
+              realProcessor.signalEndOfStream();
+            }
+
+            @Override
+            public void close() {
+              realProcessor.close();
+            }
+          };
+        };
+    Transformer transformer =
+        new Transformer.Builder(context)
+            .setAssetLoaderFactory(new ImageAssetLoader.Factory(context, fakeBitmapLoader))
+            .setFrameProcessorFactory(interceptingFactory)
+            .setNativeHardwareBufferHelpers(new FakeHardwareBufferJniWrapper())
+            .build();
+    EditedMediaItem editedMediaItem =
+        new EditedMediaItem.Builder(MediaItem.fromUri(PNG_ASSET.uri))
+            .setDurationUs(MICROS_PER_SECOND / 2)
+            .setFrameRate(30)
+            .build();
+
+    new TransformerAndroidTestRunner.Builder(context, transformer)
+        .build()
+        .run(testId, editedMediaItem);
+
+    assertThat(receivedFormat.get()).isEqualTo(HardwareBuffer.RGBA_1010102);
   }
 
   /** A no-op {@link HardwareBufferJniWrapper} that always succeeds. */

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/HardwareBufferFrameReader.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/HardwareBufferFrameReader.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import android.graphics.Bitmap;
+import android.graphics.ColorSpace;
 import android.hardware.HardwareBuffer;
 import android.os.Handler;
 import android.os.Looper;
@@ -228,7 +229,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
             .setSampleMimeType(MimeTypes.IMAGE_RAW)
             .setWidth(bitmap.getWidth())
             .setHeight(bitmap.getHeight())
-            .setColorInfo(ColorInfo.SRGB_BT709_FULL)
+            .setColorInfo(resolveColorInfoFromBitmap(bitmap))
             .setFrameRate(/* frameRate= */ DEFAULT_FRAME_RATE)
             .build();
     synchronized (this) {
@@ -504,6 +505,29 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     for (int i = 0; i < rendererWakeupListenerList.size(); i++) {
       rendererWakeupListenerList.get(i).onWakeup();
     }
+  }
+
+  private static ColorInfo resolveColorInfoFromBitmap(Bitmap bitmap) {
+    if (SDK_INT >= 34) {
+      ColorSpace colorSpace = bitmap.getColorSpace();
+      if (colorSpace != null) {
+        int id = colorSpace.getId();
+        if (id == ColorSpace.get(ColorSpace.Named.BT2020_HLG).getId()) {
+          return new ColorInfo.Builder()
+              .setColorSpace(C.COLOR_SPACE_BT2020)
+              .setColorRange(C.COLOR_RANGE_FULL)
+              .setColorTransfer(C.COLOR_TRANSFER_HLG)
+              .build();
+        } else if (id == ColorSpace.get(ColorSpace.Named.BT2020_PQ).getId()) {
+          return new ColorInfo.Builder()
+              .setColorSpace(C.COLOR_SPACE_BT2020)
+              .setColorRange(C.COLOR_RANGE_FULL)
+              .setColorTransfer(C.COLOR_TRANSFER_ST2084)
+              .build();
+        }
+      }
+    }
+    return ColorInfo.SRGB_BT709_FULL;
   }
 
   /**

--- a/libraries/transformer/src/main/java/androidx/media3/transformer/HardwareBufferFrameReader.java
+++ b/libraries/transformer/src/main/java/androidx/media3/transformer/HardwareBufferFrameReader.java
@@ -21,12 +21,14 @@ import static com.google.common.base.Preconditions.checkState;
 
 import android.graphics.Bitmap;
 import android.graphics.ColorSpace;
+import android.hardware.DataSpace;
 import android.hardware.HardwareBuffer;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.Surface;
 import androidx.annotation.GuardedBy;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.media3.common.C;
 import androidx.media3.common.ColorInfo;
 import androidx.media3.common.Format;
@@ -508,24 +510,8 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
   }
 
   private static ColorInfo resolveColorInfoFromBitmap(Bitmap bitmap) {
-    if (SDK_INT >= 34) {
-      ColorSpace colorSpace = bitmap.getColorSpace();
-      if (colorSpace != null) {
-        int id = colorSpace.getId();
-        if (id == ColorSpace.get(ColorSpace.Named.BT2020_HLG).getId()) {
-          return new ColorInfo.Builder()
-              .setColorSpace(C.COLOR_SPACE_BT2020)
-              .setColorRange(C.COLOR_RANGE_FULL)
-              .setColorTransfer(C.COLOR_TRANSFER_HLG)
-              .build();
-        } else if (id == ColorSpace.get(ColorSpace.Named.BT2020_PQ).getId()) {
-          return new ColorInfo.Builder()
-              .setColorSpace(C.COLOR_SPACE_BT2020)
-              .setColorRange(C.COLOR_RANGE_FULL)
-              .setColorTransfer(C.COLOR_TRANSFER_ST2084)
-              .build();
-        }
-      }
+    if (SDK_INT >= 33) {
+      return Api33.resolveColorInfoFromBitmap(bitmap);
     }
     return ColorInfo.SRGB_BT709_FULL;
   }
@@ -621,6 +607,42 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
       this.sequenceOffsetUs = sequenceOffsetUs;
       this.itemIndex = itemIndex;
       this.format = format;
+    }
+  }
+
+  @RequiresApi(33)
+  private static final class Api33 {
+    private static final ColorInfo BT2020_HLG_FULL =
+        new ColorInfo.Builder()
+            .setColorSpace(C.COLOR_SPACE_BT2020)
+            .setColorRange(C.COLOR_RANGE_FULL)
+            .setColorTransfer(C.COLOR_TRANSFER_HLG)
+            .build();
+
+    private static final ColorInfo BT2020_PQ_FULL =
+        new ColorInfo.Builder()
+            .setColorSpace(C.COLOR_SPACE_BT2020)
+            .setColorRange(C.COLOR_RANGE_FULL)
+            .setColorTransfer(C.COLOR_TRANSFER_ST2084)
+            .build();
+
+    private static ColorInfo resolveColorInfoFromBitmap(Bitmap bitmap) {
+      ColorSpace colorSpace = bitmap.getColorSpace();
+      if (colorSpace != null) {
+        return dataSpaceToColorInfo(colorSpace.getDataSpace());
+      }
+      return ColorInfo.SRGB_BT709_FULL;
+    }
+
+    private static ColorInfo dataSpaceToColorInfo(int dataSpace) {
+      switch (dataSpace) {
+        case DataSpace.STANDARD_BT2020 | DataSpace.TRANSFER_HLG | DataSpace.RANGE_FULL:
+          return BT2020_HLG_FULL;
+        case DataSpace.STANDARD_BT2020 | DataSpace.TRANSFER_ST2084 | DataSpace.RANGE_FULL:
+          return BT2020_PQ_FULL;
+        default:
+          return ColorInfo.SRGB_BT709_FULL;
+      }
     }
   }
 }


### PR DESCRIPTION
Bug is https://partnerissuetracker.corp.google.com/issues/531143289

HardwareBufferFrameReader derives ColorInfo from the bitmap's ColorSpace (BT2020 HLG/PQ) instead of always emitting SRGB_BT709_FULL.
BitmapToHardwareBufferProcessor derives the HardwareBuffer pixel format from Bitmap.Config (RGBA_1010102 → RGBA_1010102, RGBA_F16 → RGBA_FP16, else RGBA_8888) so bit depth is preserved independently of
color space.
Prefers the Bitmap.copy(Config.HARDWARE) fast path for all configs. Falls back to CPU/JNI copy only when the HARDWARE path is unavailable or silently downgrades an HDR bitmap's bit depth.