### PR TITLE
Support injectable charset detection for standalone SubRip subtitles

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -57,6 +57,10 @@
     *   Fix reporting of late video frames with identical release timestamps so
         that they are reported as dropped instead of skipped.
 *   Text:
+    *   SubRip: Add support for injecting a `CharsetDetector` into
+        `DefaultSubtitleParserFactory` to detect the character encoding of
+        standalone SubRip subtitles without a byte order mark
+        ([#2247](https://github.com/androidx/media/issues/2247)).
 *   Metadata:
 *   Image:
 *   DataSource:

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/CharsetDetector.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/CharsetDetector.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.extractor.text;
+
+import androidx.annotation.Nullable;
+import androidx.media3.common.util.UnstableApi;
+import java.nio.charset.Charset;
+
+/** Detects the character encoding of subtitle byte data. */
+@UnstableApi
+public interface CharsetDetector {
+
+  /**
+   * Detects the character encoding of the requested range of {@code data}.
+   *
+   * <p>The requested range is not guaranteed to contain a complete subtitle file.
+   *
+   * @param data The subtitle byte data.
+   * @param offset The start offset in {@code data}.
+   * @param length The number of bytes to inspect.
+   * @return The detected character encoding, or {@code null} if it could not be determined.
+   */
+  @Nullable
+  Charset detect(byte[] data, int offset, int length);
+}

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/DefaultSubtitleParserFactory.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/DefaultSubtitleParserFactory.java
@@ -46,9 +46,32 @@ import java.util.Objects;
  *   <li>DVB ({@link DvbParser})
  *   <li>TTML ({@link TtmlParser})
  * </ul>
+ *
+ * <p>A {@link CharsetDetector} can be provided to detect the character encoding of standalone
+ * SubRip subtitles without a byte order mark.
  */
 @UnstableApi
 public final class DefaultSubtitleParserFactory implements SubtitleParser.Factory {
+
+  @Nullable private final CharsetDetector charsetDetector;
+
+  /** Creates an instance that defaults to UTF-8 for SubRip subtitles without a byte order mark. */
+  public DefaultSubtitleParserFactory() {
+    this(/* charsetDetector= */ null);
+  }
+
+  /**
+   * Creates an instance that uses {@code charsetDetector} for standalone SubRip subtitles without a
+   * byte order mark.
+   *
+   * <p>The detector is not used for SubRip subtitles embedded in a media container because these
+   * samples may contain only a small part of the subtitle file.
+   *
+   * @param charsetDetector The detector to use, or {@code null} to default to UTF-8.
+   */
+  public DefaultSubtitleParserFactory(@Nullable CharsetDetector charsetDetector) {
+    this.charsetDetector = charsetDetector;
+  }
 
   @Override
   public boolean supportsFormat(Format format) {
@@ -106,7 +129,7 @@ public final class DefaultSubtitleParserFactory implements SubtitleParser.Factor
         case MimeTypes.APPLICATION_MP4VTT:
           return new Mp4WebvttParser();
         case MimeTypes.APPLICATION_SUBRIP:
-          return new SubripParser();
+          return new SubripParser(isStandaloneSubrip(format) ? charsetDetector : null);
         case MimeTypes.APPLICATION_TX3G:
           return new Tx3gParser(format.initializationData);
         case MimeTypes.APPLICATION_PGS:
@@ -122,5 +145,9 @@ public final class DefaultSubtitleParserFactory implements SubtitleParser.Factor
       }
     }
     throw new IllegalArgumentException("Unsupported MIME type: " + mimeType);
+  }
+
+  private static boolean isStandaloneSubrip(Format format) {
+    return format.containerMimeType == null || MimeTypes.isText(format.containerMimeType);
   }
 }

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/subrip/SubripParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/subrip/SubripParser.java
@@ -31,6 +31,7 @@ import androidx.media3.common.util.Consumer;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.ParsableByteArray;
 import androidx.media3.common.util.UnstableApi;
+import androidx.media3.extractor.text.CharsetDetector;
 import androidx.media3.extractor.text.CuesWithTiming;
 import androidx.media3.extractor.text.SubtitleParser;
 import com.google.common.collect.ImmutableList;
@@ -82,11 +83,24 @@ public final class SubripParser implements SubtitleParser {
   private final StringBuilder textBuilder;
   private final ArrayList<String> tags;
   private final ParsableByteArray parsableByteArray;
+  @Nullable private final CharsetDetector charsetDetector;
 
   public SubripParser() {
+    this(/* charsetDetector= */ null);
+  }
+
+  /**
+   * Creates an instance that uses {@code charsetDetector} when the input doesn't contain a byte
+   * order mark.
+   *
+   * @param charsetDetector The detector to use, or {@code null} to default to UTF-8 when the input
+   *     doesn't contain a byte order mark.
+   */
+  public SubripParser(@Nullable CharsetDetector charsetDetector) {
     textBuilder = new StringBuilder();
     tags = new ArrayList<>();
     parsableByteArray = new ParsableByteArray();
+    this.charsetDetector = charsetDetector;
   }
 
   @Override
@@ -103,7 +117,7 @@ public final class SubripParser implements SubtitleParser {
       Consumer<CuesWithTiming> output) {
     parsableByteArray.reset(data, /* limit= */ offset + length);
     parsableByteArray.setPosition(offset);
-    Charset charset = detectUtfCharset(parsableByteArray);
+    Charset charset = detectCharset(data, offset, length);
 
     @Nullable
     List<CuesWithTiming> cuesWithTimingBeforeRequestedStartTimeUs =
@@ -188,12 +202,27 @@ public final class SubripParser implements SubtitleParser {
   }
 
   /**
-   * Determine UTF encoding of the byte array from a byte order mark (BOM), defaulting to UTF-8 if
-   * no BOM is found.
+   * Returns the charset to use for line parsing.
+   *
+   * <p>A byte order mark takes precedence. Otherwise, input detected as anything other than UTF-8
+   * or US-ASCII is transcoded to UTF-8 in {@link #parsableByteArray} first.
    */
-  private Charset detectUtfCharset(ParsableByteArray data) {
-    @Nullable Charset charset = data.readUtfCharsetFromBom();
-    return charset != null ? charset : StandardCharsets.UTF_8;
+  private Charset detectCharset(byte[] data, int offset, int length) {
+    @Nullable Charset utfCharset = parsableByteArray.readUtfCharsetFromBom();
+    if (utfCharset != null) {
+      return utfCharset;
+    }
+    @Nullable
+    Charset detectedCharset =
+        charsetDetector != null ? charsetDetector.detect(data, offset, length) : null;
+    Charset charset = detectedCharset != null ? detectedCharset : StandardCharsets.UTF_8;
+    if (charset.equals(StandardCharsets.UTF_8) || charset.equals(StandardCharsets.US_ASCII)) {
+      return charset;
+    }
+    // Normalize detected input to UTF-8 so line parsing uses a single code path.
+    parsableByteArray.reset(
+        new String(data, offset, length, charset).getBytes(StandardCharsets.UTF_8));
+    return StandardCharsets.UTF_8;
   }
 
   /**

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/text/DefaultSubtitleParserFactoryTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/text/DefaultSubtitleParserFactoryTest.java
@@ -20,17 +20,80 @@ import static org.junit.Assert.assertThrows;
 
 import androidx.media3.common.Format;
 import androidx.media3.common.MimeTypes;
+import androidx.media3.extractor.text.SubtitleParser.OutputOptions;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableList;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /** Tests for {@link DefaultSubtitleParserFactory}. */
 @RunWith(AndroidJUnit4.class)
 public class DefaultSubtitleParserFactoryTest {
+
+  @Test
+  public void createStandaloneSubripParser_usesCharsetDetector() {
+    Charset charset = Charset.forName("GB18030");
+    DefaultSubtitleParserFactory factory =
+        new DefaultSubtitleParserFactory((data, offset, length) -> charset);
+    Format format = new Format.Builder().setSampleMimeType(MimeTypes.APPLICATION_SUBRIP).build();
+    String expectedText = "起来 快起来";
+    byte[] bytes = createSubripBytes(expectedText, charset);
+
+    List<CuesWithTiming> cues = new ArrayList<>();
+    factory.create(format).parse(bytes, OutputOptions.allCues(), cues::add);
+
+    assertThat(cues).hasSize(1);
+    assertThat(cues.get(0).cues.get(0).text.toString()).isEqualTo(expectedText);
+  }
+
+  @Test
+  public void createStandaloneSubripParserWithTextContainerMimeType_usesCharsetDetector() {
+    Charset charset = Charset.forName("GB18030");
+    DefaultSubtitleParserFactory factory =
+        new DefaultSubtitleParserFactory((data, offset, length) -> charset);
+    Format format =
+        new Format.Builder()
+            .setSampleMimeType(MimeTypes.APPLICATION_SUBRIP)
+            .setContainerMimeType(MimeTypes.APPLICATION_SUBRIP)
+            .build();
+    String expectedText = "起来 快起来";
+    byte[] bytes = createSubripBytes(expectedText, charset);
+
+    List<CuesWithTiming> cues = new ArrayList<>();
+    factory.create(format).parse(bytes, OutputOptions.allCues(), cues::add);
+
+    assertThat(cues).hasSize(1);
+    assertThat(cues.get(0).cues.get(0).text.toString()).isEqualTo(expectedText);
+  }
+
+  @Test
+  public void createEmbeddedSubripParser_doesNotUseCharsetDetector() {
+    DefaultSubtitleParserFactory factory =
+        new DefaultSubtitleParserFactory(
+            (data, offset, length) -> {
+              throw new AssertionError("Charset detector should not be called");
+            });
+    Format format =
+        new Format.Builder()
+            .setSampleMimeType(MimeTypes.APPLICATION_SUBRIP)
+            .setContainerMimeType(MimeTypes.VIDEO_MATROSKA)
+            .build();
+    String expectedText = "This is an embedded subtitle.";
+    byte[] bytes = createSubripBytes(expectedText, StandardCharsets.UTF_8);
+
+    List<CuesWithTiming> cues = new ArrayList<>();
+    factory.create(format).parse(bytes, OutputOptions.allCues(), cues::add);
+
+    assertThat(cues).hasSize(1);
+    assertThat(cues.get(0).cues.get(0).text.toString()).isEqualTo(expectedText);
+  }
 
   /**
    * This test loops through all the public fields of {@link MimeTypes} and assumes all the static,
@@ -73,5 +136,9 @@ public class DefaultSubtitleParserFactoryTest {
         }
       }
     }
+  }
+
+  private static byte[] createSubripBytes(String text, Charset charset) {
+    return ("1\r\n" + "00:00:00,000 --> 00:00:05,000\r\n" + text + "\r\n").getBytes(charset);
   }
 }

--- a/libraries/extractor/src/test/java/androidx/media3/extractor/text/subrip/SubripParserTest.java
+++ b/libraries/extractor/src/test/java/androidx/media3/extractor/text/subrip/SubripParserTest.java
@@ -28,6 +28,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
@@ -81,6 +83,89 @@ public final class SubripParserTest {
     assertTypicalCue1(allCues.get(0));
     assertTypicalCue2(allCues.get(1));
     assertTypicalCue3(allCues.get(2));
+  }
+
+  @Test
+  public void parseGb18030WithCharsetDetector_outputsDecodedText() {
+    assertTextParsedWithCharsetDetector("起来 快起来", Charset.forName("GB18030"));
+  }
+
+  @Test
+  public void parseEucKrWithCharsetDetector_outputsDecodedText() {
+    assertTextParsedWithCharsetDetector("이것은 한국어 자막 테스트입니다.", Charset.forName("EUC-KR"));
+  }
+
+  @Test
+  public void parseShiftJisWithCharsetDetector_outputsDecodedText() {
+    assertTextParsedWithCharsetDetector("これは日本語の字幕テストです。", Charset.forName("Shift_JIS"));
+  }
+
+  @Test
+  public void parseUtf8WithCharsetDetector_outputsDecodedText() {
+    assertTextParsedWithCharsetDetector("This is a UTF-8 subtitle.", StandardCharsets.UTF_8);
+  }
+
+  @Test
+  public void parseUsAsciiWithCharsetDetector_outputsDecodedText() {
+    assertTextParsedWithCharsetDetector("This is an ASCII subtitle.", StandardCharsets.US_ASCII);
+  }
+
+  @Test
+  public void parseWithByteOrderMark_doesNotCallCharsetDetector() throws IOException {
+    SubripParser parser =
+        new SubripParser(
+            (data, offset, length) -> {
+              throw new AssertionError("Charset detector should not be called");
+            });
+    byte[] bytes =
+        TestUtil.getByteArray(
+            ApplicationProvider.getApplicationContext(), TYPICAL_WITH_BYTE_ORDER_MARK);
+
+    ImmutableList<CuesWithTiming> allCues = parseAllCues(parser, bytes);
+
+    assertThat(allCues).hasSize(3);
+    assertTypicalCue1(allCues.get(0));
+    assertTypicalCue2(allCues.get(1));
+    assertTypicalCue3(allCues.get(2));
+  }
+
+  @Test
+  public void parseWithCharsetDetectorReturningNull_defaultsToUtf8() throws IOException {
+    SubripParser parser = new SubripParser((data, offset, length) -> null);
+    byte[] bytes = TestUtil.getByteArray(ApplicationProvider.getApplicationContext(), TYPICAL_FILE);
+
+    ImmutableList<CuesWithTiming> allCues = parseAllCues(parser, bytes);
+
+    assertThat(allCues).hasSize(3);
+    assertTypicalCue1(allCues.get(0));
+    assertTypicalCue2(allCues.get(1));
+    assertTypicalCue3(allCues.get(2));
+  }
+
+  @Test
+  public void parseAtOffsetWithCharsetDetector_passesRequestedRangeToDetector() {
+    Charset charset = Charset.forName("GB18030");
+    String expectedText = "这是一个字幕测试。";
+    byte[] subtitleBytes =
+        ("1\r\n" + "00:00:00,000 --> 00:00:05,000\r\n" + expectedText + "\r\n").getBytes(charset);
+    int offset = 5;
+    byte[] bytes = new byte[offset + subtitleBytes.length + 7];
+    System.arraycopy(subtitleBytes, 0, bytes, offset, subtitleBytes.length);
+    SubripParser parser =
+        new SubripParser(
+            (data, detectorOffset, detectorLength) -> {
+              assertThat(data).isSameInstanceAs(bytes);
+              assertThat(detectorOffset).isEqualTo(offset);
+              assertThat(detectorLength).isEqualTo(subtitleBytes.length);
+              return charset;
+            });
+    ImmutableList.Builder<CuesWithTiming> cues = ImmutableList.builder();
+
+    parser.parse(bytes, offset, subtitleBytes.length, OutputOptions.allCues(), cues::add);
+
+    ImmutableList<CuesWithTiming> allCues = cues.build();
+    assertThat(allCues).hasSize(1);
+    assertThat(allCues.get(0).cues.get(0).text.toString()).isEqualTo(expectedText);
   }
 
   @Test
@@ -307,6 +392,17 @@ public final class SubripParserTest {
     ImmutableList.Builder<CuesWithTiming> cues = ImmutableList.builder();
     parser.parse(data, OutputOptions.allCues(), cues::add);
     return cues.build();
+  }
+
+  private static void assertTextParsedWithCharsetDetector(String expectedText, Charset charset) {
+    byte[] bytes =
+        ("1\r\n" + "00:00:00,000 --> 00:00:05,000\r\n" + expectedText + "\r\n").getBytes(charset);
+    SubripParser parser = new SubripParser((data, offset, length) -> charset);
+
+    ImmutableList<CuesWithTiming> allCues = parseAllCues(parser, bytes);
+
+    assertThat(allCues).hasSize(1);
+    assertThat(allCues.get(0).cues.get(0).text.toString()).isEqualTo(expectedText);
   }
 
   private static void assertTypicalCue1(CuesWithTiming cuesWithTiming) {


### PR DESCRIPTION
## Summary

External standalone and raw-text SubRip inputs without a supported UTF byte order mark currently fall back to UTF-8. As a result, subtitles encoded with legacy character encodings such as GB18030, EUC-KR, or Shift_JIS may be decoded incorrectly.

This change introduces an injectable `CharsetDetector` contract in the extractor text package and passes it through `DefaultSubtitleParserFactory` to applicable `SubripParser` instances. Applications can provide their own charset detection implementation without requiring Media3 to depend on a specific detection library.

This follows the extension-point approach proposed in [google/ExoPlayer#3644](https://github.com/google/ExoPlayer/issues/3644#issuecomment-565503504).

## Behavior
- Existing behavior is unchanged when no detector is configured or when the detector returns `null`: a UTF-8 or UTF-16 byte order mark still wins, and everything else falls back to UTF-8.
- A byte order mark takes precedence over the detector, which is not called at all in that case.
- The detector is only used for SubRip `Format`s whose `containerMimeType` is null or a text MIME type, i.e. standalone `.srt` input. 
  - SubRip muxed into a container (Matroska/WebM) keeps the current UTF-8 behavior, because a single sample may hold only a small part of the subtitle stream.
- `CharsetDetector.detect()` receives exactly the `offset` and `length` passed to `SubtitleParser.parse()`. 
  - That range is not guaranteed to be a complete file, so implementations have to tolerate partial input.
- Scoping is done by `DefaultSubtitleParserFactory`. `SubripParser` itself always uses whatever detector it is constructed with.

This PR intentionally does not provide a charset detection implementation. Applications remain responsible for choosing and configuring one.

### Example - injecting a detector for an external SRT

The following example assumes that `appCharsetDetector` wraps a detection library selected by the application.

```java
CharsetDetector charsetDetector =
    (data, offset, length) -> appCharsetDetector.detect(data, offset, length);

DefaultMediaSourceFactory mediaSourceFactory =
    new DefaultMediaSourceFactory(context)
        .setSubtitleParserFactory(new DefaultSubtitleParserFactory(charsetDetector));

ExoPlayer player =
    new ExoPlayer.Builder(context)
        .setMediaSourceFactory(mediaSourceFactory)
        .build();

MediaItem.SubtitleConfiguration subtitleConfiguration =
    new MediaItem.SubtitleConfiguration.Builder(subtitleUri)
        .setMimeType(MimeTypes.APPLICATION_SUBRIP)
        .setLanguage("ko")
        .build();

MediaItem mediaItem =
    new MediaItem.Builder()
        .setUri(videoUri)
        .setSubtitleConfigurations(Collections.singletonList(subtitleConfiguration))
        .build();

player.setMediaItem(mediaItem);
player.prepare();
player.play();
```

When the external SRT is opened, `DefaultMediaSourceFactory` creates a standalone subtitle `Format`. `DefaultSubtitleParserFactory` then creates a `SubripParser` with the configured detector. If the input has no supported UTF BOM, the parser asks the detector to inspect the exact requested byte range and decodes that range using the returned charset.

The same detector is also used for raw-text SubRip inputs. It is not passed to SubRip samples embedded in Matroska or WebM containers.

## Before / After

The same BOM-free subtitle files were played on the same physical device. Without a detector, the existing UTF-8 fallback produces replacement characters. Injecting a detector that returns the matching charset restores the original Korean, Chinese, and Japanese text.

| Language and encoding | Before : no detector | After : matching detector |
| --- | --- | --- |
| Korean (`EUC-KR`) | <img width="1080" height="2640" alt="02-euc-kr-without-detector" src="https://github.com/user-attachments/assets/d5fac3f3-3777-403a-b044-b5ce296debff" /> | <img width="1080" height="2640" alt="03-euc-kr-with-detector" src="https://github.com/user-attachments/assets/db73b25b-9aa7-4a57-91a8-ff3d188d9366" /> |
| Chinese (`GB18030`) | <img width="1080" height="2640" alt="05-zh-gb18030-before" src="https://github.com/user-attachments/assets/92765703-5b9e-486a-afb3-09adf1fac499" /> | <img width="1080" height="2640" alt="06-zh-gb18030-after" src="https://github.com/user-attachments/assets/0fab6525-1ec8-44c8-bd54-d79067b82c2a" /> |
| Japanese (`Shift_JIS`) | <img width="1080" height="2640" alt="07-ja-shiftjis-before" src="https://github.com/user-attachments/assets/26448f3b-3b9f-4f43-abc8-e81a6b2b57f0" /> | <img width="1080" height="2640" alt="08-ja-shiftjis-after" src="https://github.com/user-attachments/assets/77eb8be4-9d5f-49d7-83cc-6307850395bf" />  |








Fixes #2247