### PR TITLE
Fix crash when the live default position moves past a playing SSAI ad

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -32,6 +32,9 @@
     *   Fix an issue where Player.getCurrentPosition() could return stale values
         (updating only a few times per second) when dynamic scheduling is
         enabled ([#3286](https://github.com/androidx/media/issues/3286)).
+    *   Fix `ArrayIndexOutOfBoundsException` when a live timeline refresh moves
+        the default position past a server-side inserted ad that is currently
+        being played ([#3348](https://github.com/androidx/media/issues/3348)).
 *   CompositionPlayer:
     *   Support configuring the frame rate of video frame aggregation via
         `Composition.Builder.setVideoFrameAggregationParameters` for playback

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImplInternal.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImplInternal.java
@@ -4096,14 +4096,16 @@ import java.util.Objects;
             && isOldAdGroupWithinNewPeriod
             && earliestAdGroupIsUnchangedOrLater;
     // Drop update if the change is from/to server-side inserted ads at the same content position to
-    // avoid any unintentional renderer reset.
+    // avoid any unintentional renderer reset. Note that the resolved period may be a period
+    // preceding newPeriodUid, because resolveMediaPeriodIdForAdsAfterPeriodPositionChange rolls
+    // back to unplayed ad periods, so the period has to be looked up by the resolved period uid.
     boolean isInStreamAdChange =
         isIgnorableServerSideAdInsertionPeriodChange(
             isUsingPlaceholderPeriod,
             oldPeriodId,
             oldContentPositionUs,
             periodIdWithAds,
-            timeline.getPeriodByUid(newPeriodUid, period),
+            timeline.getPeriodByUid(periodIdWithAds.periodUid, period),
             newContentPositionUs);
     MediaPeriodId newPeriodId =
         onlyNextAdGroupIndexIncreased || isInStreamAdChange ? oldPeriodId : periodIdWithAds;

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImplInternal.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/ExoPlayerImplInternal.java
@@ -4096,17 +4096,16 @@ import java.util.Objects;
             && isOldAdGroupWithinNewPeriod
             && earliestAdGroupIsUnchangedOrLater;
     // Drop update if the change is from/to server-side inserted ads at the same content position to
-    // avoid any unintentional renderer reset. Note that the resolved period may be a period
-    // preceding newPeriodUid, because resolveMediaPeriodIdForAdsAfterPeriodPositionChange rolls
-    // back to unplayed ad periods, so the period has to be looked up by the resolved period uid.
+    // avoid any unintentional renderer reset.
     boolean isInStreamAdChange =
         isIgnorableServerSideAdInsertionPeriodChange(
+            timeline,
             isUsingPlaceholderPeriod,
             oldPeriodId,
             oldContentPositionUs,
             periodIdWithAds,
-            timeline.getPeriodByUid(periodIdWithAds.periodUid, period),
-            newContentPositionUs);
+            newContentPositionUs,
+            period);
     MediaPeriodId newPeriodId =
         onlyNextAdGroupIndexIncreased || isInStreamAdChange ? oldPeriodId : periodIdWithAds;
 
@@ -4180,27 +4179,29 @@ import java.util.Objects;
   }
 
   private static boolean isIgnorableServerSideAdInsertionPeriodChange(
+      Timeline timeline,
       boolean isUsingPlaceholderPeriod,
       MediaPeriodId oldPeriodId,
       long oldContentPositionUs,
       MediaPeriodId newPeriodId,
-      Timeline.Period newPeriod,
-      long newContentPositionUs) {
+      long newContentPositionUs,
+      Timeline.Period period) {
     if (isUsingPlaceholderPeriod
         || oldContentPositionUs != newContentPositionUs
         || !oldPeriodId.periodUid.equals(newPeriodId.periodUid)) {
       // The period position changed.
       return false;
     }
-    if (oldPeriodId.isAd() && newPeriod.isServerSideInsertedAdGroup(oldPeriodId.adGroupIndex)) {
+    timeline.getPeriodByUid(newPeriodId.periodUid, period);
+    if (oldPeriodId.isAd() && period.isServerSideInsertedAdGroup(oldPeriodId.adGroupIndex)) {
       // Whether the old period was a server side ad that doesn't need skipping to the content.
-      return newPeriod.getAdState(oldPeriodId.adGroupIndex, oldPeriodId.adIndexInAdGroup)
+      return period.getAdState(oldPeriodId.adGroupIndex, oldPeriodId.adIndexInAdGroup)
               != AdPlaybackState.AD_STATE_ERROR
-          && newPeriod.getAdState(oldPeriodId.adGroupIndex, oldPeriodId.adIndexInAdGroup)
+          && period.getAdState(oldPeriodId.adGroupIndex, oldPeriodId.adIndexInAdGroup)
               != AdPlaybackState.AD_STATE_SKIPPED;
     }
     // If the new period is a server side inserted ad, we can just continue playing.
-    return newPeriodId.isAd() && newPeriod.isServerSideInsertedAdGroup(newPeriodId.adGroupIndex);
+    return newPeriodId.isAd() && period.isServerSideInsertedAdGroup(newPeriodId.adGroupIndex);
   }
 
   private static boolean isUsingPlaceholderPeriod(

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/ExoPlayerAdTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/ExoPlayerAdTest.java
@@ -1059,6 +1059,66 @@ public class ExoPlayerAdTest {
   }
 
   @Test
+  public void timelineRefresh_movingLiveDefaultPositionPastPlayingSsaiAd_keepsPlayingAd()
+      throws Exception {
+    // Live window with three 20s periods: |- p0 content -|- p1 ad -|- p2 content -|.
+    Object adsId = new Object();
+    TimelineWindowDefinition liveWindowDefinition =
+        new TimelineWindowDefinition.Builder()
+            .setDynamic(true)
+            .setLive(true)
+            .setSeekable(true)
+            .setPeriodCount(3)
+            .setDurationUs(60_000_000)
+            .setWindowStartTimeUs(1_720_000_000_000_000L)
+            .setWindowPositionInFirstPeriodUs(0)
+            .setDefaultPositionUs(30_000_000)
+            .build();
+    Timeline initialContentTimeline = new FakeTimeline(liveWindowDefinition);
+    // p1 is entirely covered by a server-side inserted ad.
+    AdPlaybackState contentOnlyAdPlaybackState = new AdPlaybackState(adsId);
+    AdPlaybackState adPeriodAdPlaybackState =
+        addAdGroupToAdPlaybackState(
+            contentOnlyAdPlaybackState,
+            /* fromPositionUs= */ 0,
+            /* contentResumeOffsetUs= */ 20_000_000,
+            /* adDurationsUs...= */ 20_000_000);
+    // ServerSideAdInsertionMediaSource requires an AdPlaybackState for every period.
+    ImmutableMap<Object, AdPlaybackState> adPlaybackStates =
+        ImmutableMap.of(
+            initialContentTimeline.getUidOfPeriod(/* periodIndex= */ 0),
+            contentOnlyAdPlaybackState,
+            initialContentTimeline.getUidOfPeriod(/* periodIndex= */ 1),
+            adPeriodAdPlaybackState,
+            initialContentTimeline.getUidOfPeriod(/* periodIndex= */ 2),
+            contentOnlyAdPlaybackState);
+    FakeMediaSource contentMediaSource = new FakeMediaSource(initialContentTimeline);
+    ServerSideAdInsertionMediaSource mediaSource =
+        new ServerSideAdInsertionMediaSource(
+            contentMediaSource, /* adPlaybackStateUpdater= */ contentTimeline -> false);
+    mediaSource.setAdPlaybackStates(adPlaybackStates, initialContentTimeline);
+    ExoPlayer player = parameterizeTestExoPlayerBuilder(new TestExoPlayerBuilder(context)).build();
+
+    // Join the live stream while the ad in p1 is on air.
+    player.setMediaSource(mediaSource);
+    player.prepare();
+    advance(player).untilState(Player.STATE_READY);
+    boolean isPlayingAdAfterJoining = player.isPlayingAd();
+    // Refresh the live timeline with a default position that moved past the ad, into p2.
+    contentMediaSource.setNewSourceInfo(
+        new FakeTimeline(
+            liveWindowDefinition.buildUpon().setDefaultPositionUs(45_000_000).build()));
+    advance(player).untilPendingCommandsAreFullyHandled();
+    boolean isPlayingAdAfterRefresh = player.isPlayingAd();
+    @Nullable PlaybackException error = player.getPlayerError();
+    player.release();
+
+    assertThat(isPlayingAdAfterJoining).isTrue();
+    assertThat(error).isNull();
+    assertThat(isPlayingAdAfterRefresh).isTrue();
+  }
+
+  @Test
   public void addMediaSource_whilePlayingAd_correctMasking() throws Exception {
     long contentDurationMs = 10_000;
     long adDurationMs = 5_000;


### PR DESCRIPTION
Fixes #3348.

### Problem

Joining a live SSAI stream (e.g. AWS MediaTailor) while an ad break is on air, and
then receiving a manifest refresh that moves the window default position past that
ad, crashes the playback thread:

```
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
  at androidx.media3.common.AdPlaybackState.getAdGroup
  at androidx.media3.common.Timeline$Period.isServerSideInsertedAdGroup
  at androidx.media3.exoplayer.ExoPlayerImplInternal.isIgnorableServerSideAdInsertionPeriodChange
  at androidx.media3.exoplayer.ExoPlayerImplInternal.resolvePositionForPlaylistChange
  at androidx.media3.exoplayer.ExoPlayerImplInternal.handleMediaSourceListInfoRefreshed
```

### Root cause

`resolvePositionForPlaylistChange` passes the period looked up by `newPeriodUid` to
`isIgnorableServerSideAdInsertionPeriodChange`, assuming it is the period that
`periodIdWithAds` refers to. That assumption doesn't hold:
`MediaPeriodQueue.resolveMediaPeriodIdForAdsAfterPeriodPositionChange` rolls back to a
preceding unplayed server-side inserted ad period, so the returned `MediaPeriodId` can
belong to a different period than `newPeriodUid`.

For a live window `|- p0 content -|- p1 ad -|- p2 content -|` where playback joined
inside the ad in p1 and the refreshed default position lands in p2:

* `newPeriodUid` → **p2**, which has an empty `AdPlaybackState`
* `periodIdWithAds` → **p1**, `adGroupIndex = 0`

The uid equality guard inside `isIgnorableServerSideAdInsertionPeriodChange` compares
`oldPeriodId.periodUid` with `newPeriodId.periodUid` — both p1, so it passes — and the
following line then indexes p2's empty `AdPlaybackState` with p1's ad group index,
throwing `ArrayIndexOutOfBoundsException`.

This only reproduces when the refreshed default position lands in a period *after* the
ad. If it lands before the ad (p0), the uid guard returns early and the faulty line is
never reached, which is why the crash looks position-dependent.

### Fix

Look the period up by the resolved period uid (`periodIdWithAds.periodUid`) instead of
`newPeriodUid`. Past the uid guard, `oldPeriodId` and `newPeriodId` share a period uid
by construction, so the resolved uid is the only correct one to use here.

With the fix, the change is correctly detected as an in-stream ad change, the update is
dropped and the ad keeps playing across the refresh — no renderer reset.

### Testing

Added `ExoPlayerAdTest.timelineRefresh_movingLiveDefaultPositionPastPlayingSsaiAd_keepsPlayingAd`,
which fails with the `ArrayIndexOutOfBoundsException` above without the fix and passes
with it.

Ran on `:lib-exoplayer`: `ExoPlayerAdTest` (64), `ExoPlayerTest` (2180),
`MediaPeriodQueueTest` (58), `AdsMediaSourceTest` (27),
`ServerSideAdInsertionMediaSourceTest` (32), `ServerSideAdInsertionUtilTest` (8) —
2369 tests, 0 failures.