### PR TITLE
Serialize audio capability callbacks on receiver handler

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilitiesReceiver.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilitiesReceiver.java
@@ -267,15 +267,18 @@ public final class AudioCapabilitiesReceiver {
   private final class AudioDeviceCallback extends android.media.AudioDeviceCallback {
     @Override
     public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
-      updateCurrentAudioCapabilities();
+      handler.post(AudioCapabilitiesReceiver.this::updateCurrentAudioCapabilities);
     }
 
     @Override
     public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
-      if (Util.contains(removedDevices, routedDevice)) {
-        routedDevice = null;
-      }
-      updateCurrentAudioCapabilities();
+      handler.post(
+          () -> {
+            if (Util.contains(removedDevices, routedDevice)) {
+              routedDevice = null;
+            }
+            updateCurrentAudioCapabilities();
+          });
     }
   }
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilitiesReceiver.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/AudioCapabilitiesReceiver.java
@@ -27,9 +27,11 @@ import android.database.ContentObserver;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Handler;
 import androidx.annotation.Nullable;
 import androidx.media3.common.AudioAttributes;
+import androidx.media3.common.MediaLibraryInfo;
 import androidx.media3.common.audio.AudioManagerCompat;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.util.Util;
@@ -225,6 +227,14 @@ public final class AudioCapabilitiesReceiver {
             context, audioAttributes, routedDevice, spatializerChannelMasks));
   }
 
+  private static boolean deviceNeedsAudioDeviceCallbackThreadingWorkaround() {
+    return MediaLibraryInfo.enableWorkarounds()
+        && SDK_INT < 38
+        && (("Jio".equals(Build.MANUFACTURER) && "JHSA400".equals(Build.MODEL))
+            || ("SkyworthDigital".equals(Build.MANUFACTURER)
+                && "XStream-Smart-Box-002".equals(Build.MODEL)));
+  }
+
   private final class HdmiAudioPlugBroadcastReceiver extends BroadcastReceiver {
 
     @Override
@@ -267,18 +277,27 @@ public final class AudioCapabilitiesReceiver {
   private final class AudioDeviceCallback extends android.media.AudioDeviceCallback {
     @Override
     public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
-      handler.post(AudioCapabilitiesReceiver.this::updateCurrentAudioCapabilities);
+      if (deviceNeedsAudioDeviceCallbackThreadingWorkaround()) {
+        handler.post(AudioCapabilitiesReceiver.this::updateCurrentAudioCapabilities);
+      } else {
+        updateCurrentAudioCapabilities();
+      }
     }
 
     @Override
     public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
-      handler.post(
+      Runnable updateAudioCapabilities =
           () -> {
             if (Util.contains(removedDevices, routedDevice)) {
               routedDevice = null;
             }
             updateCurrentAudioCapabilities();
-          });
+          };
+      if (deviceNeedsAudioDeviceCallbackThreadingWorkaround()) {
+        handler.post(updateAudioCapabilities);
+      } else {
+        updateAudioCapabilities.run();
+      }
     }
   }
 }

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/AudioCapabilitiesReceiverWrongThreadTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/AudioCapabilitiesReceiverWrongThreadTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.media3.exoplayer.audio;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.truth.Truth.assertThat;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.media.AudioDeviceCallback;
+import android.media.AudioDeviceInfo;
+import android.media.AudioManager;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.Looper;
+import androidx.annotation.Nullable;
+import androidx.media3.common.C;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+/** Tests that raw OEM audio-device callbacks are serialized on the receiver handler. */
+@RunWith(AndroidJUnit4.class)
+@Config(sdk = 23)
+public class AudioCapabilitiesReceiverWrongThreadTest {
+
+  private static final String PLAYBACK_THREAD_NAME = "ExoPlayer:Playback";
+  private static final String OEM_THREAD_NAME = "AudioMonitorHdmiThread";
+  private static final long TEST_TIMEOUT_SECONDS = 5;
+
+  private HandlerThread playbackThread;
+  private Handler playbackHandler;
+
+  @Before
+  public void setUp() {
+    playbackThread = new HandlerThread(PLAYBACK_THREAD_NAME);
+    playbackThread.start();
+    playbackHandler = new Handler(playbackThread.getLooper());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    playbackThread.quitSafely();
+    playbackThread.join(TimeUnit.SECONDS.toMillis(TEST_TIMEOUT_SECONDS));
+  }
+
+  @Test
+  public void rawThreadDeviceAddition_notifiesListenerOnReceiverHandler() throws Exception {
+    assertRawThreadCallbackIsDeliveredOnReceiverHandler(/* added= */ true);
+  }
+
+  @Test
+  public void rawThreadDeviceRemoval_notifiesListenerOnReceiverHandler() throws Exception {
+    assertRawThreadCallbackIsDeliveredOnReceiverHandler(/* added= */ false);
+  }
+
+  private void assertRawThreadCallbackIsDeliveredOnReceiverHandler(boolean added)
+      throws Exception {
+    CapabilityContext context =
+        new CapabilityContext(ApplicationProvider.getApplicationContext());
+    TrackingListener listener = new TrackingListener();
+    AtomicReference<AudioDeviceCallback> callbackReference = new AtomicReference<>();
+    AtomicReference<AudioCapabilitiesReceiver> receiverReference = new AtomicReference<>();
+
+    runOnPlayback(
+        () -> {
+          AudioCapabilitiesReceiver receiver =
+              new AudioCapabilitiesReceiver(context, listener);
+          listener.receiver = receiver;
+          receiver.register();
+          receiverReference.set(receiver);
+          callbackReference.set(getPrivateField(receiver, "audioDeviceCallback"));
+        });
+
+    AtomicReference<Throwable> callbackFailure =
+        invokeFromRawOemThread(checkNotNull(callbackReference.get()), added);
+    runOnPlayback(() -> {});
+
+    assertThat(callbackFailure.get()).isNull();
+    assertThat(listener.threadName).isEqualTo(PLAYBACK_THREAD_NAME);
+    assertThat(listener.looperName).isEqualTo(PLAYBACK_THREAD_NAME);
+    assertThat(listener.stateAtListener)
+        .isEqualTo(getPrivateField(receiverReference.get(), "audioCapabilities"));
+  }
+
+  private AtomicReference<Throwable> invokeFromRawOemThread(
+      AudioDeviceCallback callback, boolean added) throws Exception {
+    AtomicReference<Throwable> callbackFailure = new AtomicReference<>();
+    Thread oemThread =
+        new Thread(
+            () -> {
+              try {
+                assertThat(Looper.myLooper()).isNull();
+                if (added) {
+                  callback.onAudioDevicesAdded(new AudioDeviceInfo[0]);
+                } else {
+                  callback.onAudioDevicesRemoved(new AudioDeviceInfo[0]);
+                }
+              } catch (Throwable throwable) {
+                callbackFailure.set(throwable);
+              }
+            },
+            OEM_THREAD_NAME);
+    oemThread.start();
+    oemThread.join(TimeUnit.SECONDS.toMillis(TEST_TIMEOUT_SECONDS));
+    assertThat(oemThread.isAlive()).isFalse();
+    return callbackFailure;
+  }
+
+  private void runOnPlayback(Runnable action) throws Exception {
+    CountDownLatch complete = new CountDownLatch(1);
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    playbackHandler.post(
+        () -> {
+          try {
+            action.run();
+          } catch (Throwable throwable) {
+            failure.set(throwable);
+          } finally {
+            complete.countDown();
+          }
+        });
+    assertThat(complete.await(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+    if (failure.get() != null) {
+      throw new AssertionError("Playback-thread action failed", failure.get());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T getPrivateField(Object target, String fieldName) {
+    try {
+      Field field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (T) field.get(target);
+    } catch (ReflectiveOperationException exception) {
+      throw new AssertionError("Could not read private field " + fieldName, exception);
+    }
+  }
+
+  private static final class TrackingListener implements AudioCapabilitiesReceiver.Listener {
+    @Nullable AudioCapabilitiesReceiver receiver;
+    String threadName;
+    String looperName;
+    AudioCapabilities stateAtListener;
+
+    @Override
+    public void onAudioCapabilitiesChanged(AudioCapabilities audioCapabilities) {
+      threadName = Thread.currentThread().getName();
+      Looper looper = Looper.myLooper();
+      looperName = looper == null ? "null" : looper.getThread().getName();
+      stateAtListener = getPrivateField(checkNotNull(receiver), "audioCapabilities");
+    }
+  }
+
+  private static final class CapabilityContext extends ContextWrapper {
+    private int nextEncoding = C.ENCODING_AC3;
+
+    CapabilityContext(Context base) {
+      super(base);
+    }
+
+    @Override
+    public Context getApplicationContext() {
+      return this;
+    }
+
+    @Override
+    public Intent registerReceiver(BroadcastReceiver receiver, IntentFilter filter) {
+      if (receiver != null) {
+        return super.registerReceiver(receiver, filter);
+      }
+      int encoding = nextEncoding;
+      nextEncoding = nextEncoding == C.ENCODING_AC3 ? C.ENCODING_DTS : C.ENCODING_AC3;
+      return new Intent(AudioManager.ACTION_HDMI_AUDIO_PLUG)
+          .putExtra(AudioManager.EXTRA_AUDIO_PLUG_STATE, 1)
+          .putExtra(AudioManager.EXTRA_ENCODINGS, new int[] {encoding})
+          .putExtra(AudioManager.EXTRA_MAX_CHANNEL_COUNT, 6);
+    }
+  }
+}

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/AudioCapabilitiesReceiverWrongThreadTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/AudioCapabilitiesReceiverWrongThreadTest.java
@@ -26,11 +26,13 @@ import android.content.IntentFilter;
 import android.media.AudioDeviceCallback;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
+import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
 import androidx.annotation.Nullable;
 import androidx.media3.common.C;
+import androidx.media3.common.MediaLibraryInfo;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import java.lang.reflect.Field;
@@ -42,10 +44,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
+import org.robolectric.util.ReflectionHelpers;
 
 /** Tests that raw OEM audio-device callbacks are serialized on the receiver handler. */
 @RunWith(AndroidJUnit4.class)
-@Config(sdk = 23)
+@Config(sdk = 29)
 public class AudioCapabilitiesReceiverWrongThreadTest {
 
   private static final String PLAYBACK_THREAD_NAME = "ExoPlayer:Playback";
@@ -54,9 +57,18 @@ public class AudioCapabilitiesReceiverWrongThreadTest {
 
   private HandlerThread playbackThread;
   private Handler playbackHandler;
+  private String originalManufacturer;
+  private String originalModel;
+  private boolean originalEnableWorkarounds;
 
   @Before
   public void setUp() {
+    originalManufacturer = Build.MANUFACTURER;
+    originalModel = Build.MODEL;
+    originalEnableWorkarounds = MediaLibraryInfo.enableWorkarounds();
+    ReflectionHelpers.setStaticField(Build.class, "MANUFACTURER", "SkyworthDigital");
+    ReflectionHelpers.setStaticField(Build.class, "MODEL", "XStream-Smart-Box-002");
+    MediaLibraryInfo.setEnableWorkarounds(true);
     playbackThread = new HandlerThread(PLAYBACK_THREAD_NAME);
     playbackThread.start();
     playbackHandler = new Handler(playbackThread.getLooper());
@@ -64,6 +76,9 @@ public class AudioCapabilitiesReceiverWrongThreadTest {
 
   @After
   public void tearDown() throws Exception {
+    ReflectionHelpers.setStaticField(Build.class, "MANUFACTURER", originalManufacturer);
+    ReflectionHelpers.setStaticField(Build.class, "MODEL", originalModel);
+    MediaLibraryInfo.setEnableWorkarounds(originalEnableWorkarounds);
     playbackThread.quitSafely();
     playbackThread.join(TimeUnit.SECONDS.toMillis(TEST_TIMEOUT_SECONDS));
   }
@@ -76,6 +91,35 @@ public class AudioCapabilitiesReceiverWrongThreadTest {
   @Test
   public void rawThreadDeviceRemoval_notifiesListenerOnReceiverHandler() throws Exception {
     assertRawThreadCallbackIsDeliveredOnReceiverHandler(/* added= */ false);
+  }
+
+  @Test
+  public void disabledWorkarounds_rawThreadDeviceAddition_notifiesListenerOnOemThread()
+      throws Exception {
+    MediaLibraryInfo.setEnableWorkarounds(false);
+
+    CapabilityContext context =
+        new CapabilityContext(ApplicationProvider.getApplicationContext());
+    TrackingListener listener = new TrackingListener();
+    AtomicReference<AudioDeviceCallback> callbackReference = new AtomicReference<>();
+    AtomicReference<AudioCapabilitiesReceiver> receiverReference = new AtomicReference<>();
+
+    runOnPlayback(
+        () -> {
+          AudioCapabilitiesReceiver receiver = new AudioCapabilitiesReceiver(context, listener);
+          listener.receiver = receiver;
+          receiver.register();
+          receiverReference.set(receiver);
+          callbackReference.set(getPrivateField(receiver, "audioDeviceCallback"));
+        });
+
+    AtomicReference<Throwable> callbackFailure =
+        invokeFromRawOemThread(checkNotNull(callbackReference.get()), /* added= */ true);
+
+    assertThat(callbackFailure.get()).isNull();
+    assertThat(listener.threadName).isEqualTo(OEM_THREAD_NAME);
+    assertThat(listener.looperName).isEqualTo("null");
+    runOnPlayback(() -> checkNotNull(receiverReference.get()).unregister());
   }
 
   private void assertRawThreadCallbackIsDeliveredOnReceiverHandler(boolean added)


### PR DESCRIPTION
Fixes #3386.

## Context

Some Android devices invoke `AudioDeviceCallback` from an OEM thread instead of the `Handler` supplied during registration. This violates the `AudioManager` callback contract and can notify `DefaultAudioSink` off its playback looper.

The resulting crash is:

```
IllegalStateException: Current looper (null) is not the playback looper
```

## Change

This change reposts audio-device capability updates to the `AudioCapabilitiesReceiver` handler only for the confirmed affected device cohort.

The workaround is enabled only when all of the following are true:

- `MediaLibraryInfo.enableWorkarounds()` is enabled.
- `SDK_INT < 38`.
- The device matches the narrow static manufacturer/model list.

All other devices retain the existing direct callback path. The API 38 gate allows this workaround to retire where CTS verifies that `AudioManager` invokes callbacks on the supplied handler thread.

For removed devices, routed-device invalidation and capability recalculation run in the same handler task, preserving receiver state ordering.

## Testing

- Added and removed callbacks are invoked from a looper-less thread.
- Listener delivery is verified on the receiver handler for an affected device.
- The workaround is verified disabled when `MediaLibraryInfo.enableWorkarounds()` is false.
- `./gradlew :lib-exoplayer:testDebugUnitTest --tests androidx.media3.exoplayer.audio.AudioCapabilitiesReceiverWrongThreadTest --no-daemon` passes.