### PR TITLE
Fix stale decryptOnlyCodecFormat used for non-DRM periods

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/audio/MediaCodecAudioRenderer.java
@@ -817,6 +817,12 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
   }
 
   @Override
+  protected void resetCodecStateForRelease() {
+    super.resetCodecStateForRelease();
+    decryptOnlyCodecFormat = null;
+  }
+
+  @Override
   protected void onRelease() {
     audioSink.release();
     if (SDK_INT >= 35 && loudnessCodecController != null) {

--- a/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/MediaCodecAudioRendererTest.java
+++ b/libraries/exoplayer/src/test/java/androidx/media3/exoplayer/audio/MediaCodecAudioRendererTest.java
@@ -283,6 +283,80 @@ public class MediaCodecAudioRendererTest {
   }
 
   @Test
+  public void
+      onOutputFormatChanged_afterDecryptOnlyCodecReleased_usesBypassFormatNotDecryptOnlyFormat()
+          throws Exception {
+    // Regression test for a DRM -> non-DRM period transition. A DRM protected period that is played
+    // back directly (passthrough) uses a codec only for decryption, which sets the renderer's
+    // decryptOnlyCodecFormat. When the codec is released while transitioning to a following non-DRM
+    // period that uses codec bypass, decryptOnlyCodecFormat must be cleared, otherwise the stale
+    // (multichannel) DRM format would be wrongly used to configure the AudioSink for the non-DRM
+    // (stereo) period.
+    Format drmPassthroughFormat =
+        new Format.Builder()
+            .setSampleMimeType(MimeTypes.AUDIO_AC4)
+            .setChannelCount(6)
+            .setSampleRate(48000)
+            .build();
+    Format bypassFormat =
+        new Format.Builder()
+            .setSampleMimeType(MimeTypes.AUDIO_AC4)
+            .setChannelCount(2)
+            .setSampleRate(48000)
+            .build();
+    FakeSampleStream fakeSampleStream =
+        new FakeSampleStream(
+            new DefaultAllocator(/* trimOnReset= */ true, /* individualAllocationSize= */ 1024),
+            /* mediaSourceEventDispatcher= */ null,
+            DrmSessionManager.DRM_UNSUPPORTED,
+            new DrmSessionEventListener.EventDispatcher(),
+            /* initialFormat= */ bypassFormat,
+            ImmutableList.of(
+                oneByteSample(/* timeUs= */ 0, C.BUFFER_FLAG_KEY_FRAME), END_OF_STREAM_ITEM));
+    fakeSampleStream.writeData(/* startPositionUs= */ 0);
+    mediaCodecAudioRenderer.enable(
+        RendererConfiguration.DEFAULT,
+        new Format[] {bypassFormat},
+        fakeSampleStream,
+        /* positionUs= */ 0,
+        /* joining= */ false,
+        /* mayRenderStartOfStream= */ false,
+        /* startPositionUs= */ 0,
+        /* offsetUs= */ 0,
+        new MediaSource.MediaPeriodId(new Object()));
+    // Configure a decrypt-only (raw) codec for the DRM period, which sets decryptOnlyCodecFormat.
+    MediaCodecInfo decryptOnlyCodecInfo =
+        MediaCodecInfo.newInstance(
+            /* name= */ "raw-decoder",
+            /* mimeType= */ MimeTypes.AUDIO_RAW,
+            /* codecMimeType= */ MimeTypes.AUDIO_RAW,
+            /* capabilities= */ null,
+            /* hardwareAccelerated= */ false,
+            /* softwareOnly= */ true,
+            /* vendor= */ false,
+            /* forceDisableAdaptive= */ false,
+            /* forceSecure= */ false);
+    mediaCodecAudioRenderer.getMediaCodecConfiguration(
+        decryptOnlyCodecInfo,
+        drmPassthroughFormat,
+        /* crypto= */ null,
+        /* codecOperatingRate= */ 0);
+    // Release the decrypt-only codec, as happens when transitioning to the following non-DRM period.
+    mediaCodecAudioRenderer.resetCodecStateForRelease();
+    MediaFormat mediaFormat = new MediaFormat();
+    mediaFormat.setInteger(MediaFormat.KEY_CHANNEL_COUNT, 2);
+    mediaFormat.setInteger(MediaFormat.KEY_SAMPLE_RATE, 48000);
+
+    // Direct playback with codec bypass for the non-DRM period (getCodec() == null).
+    mediaCodecAudioRenderer.onOutputFormatChanged(bypassFormat, mediaFormat);
+
+    ArgumentCaptor<AudioSink.AudioSinkConfig> configCaptor =
+        ArgumentCaptor.forClass(AudioSink.AudioSinkConfig.class);
+    verify(audioSink, atLeastOnce()).configure(configCaptor.capture());
+    assertThat(configCaptor.getValue().format).isEqualTo(bypassFormat);
+  }
+
+  @Test
   public void render_configuresAudioSink_afterFormatChange() throws Exception {
     Format changedFormat = AUDIO_AAC.buildUpon().setSampleRate(48_000).setEncoderDelay(400).build();
     FakeSampleStream fakeSampleStream =


### PR DESCRIPTION
When an audio stream is played back directly (passthrough or offload) but is DRM protected, MediaCodecAudioRenderer still instantiates a MediaCodec that is used only to decrypt the samples. In that case getMediaCodecConfiguration() stores the input format in decryptOnlyCodecFormat, and onOutputFormatChanged() uses it to configure the AudioSink with the original (encoded) format instead of the codec's raw output.

decryptOnlyCodecFormat is only ever assigned in
getMediaCodecConfiguration(), which runs from initCodec() and is therefore only reached for periods that actually create a codec. It was never cleared when the codec was released, so it lived for as long as the renderer did.

As a result, for a DRM, non-DRM, DRM period sequence the non-DRM period is played through codec bypass and does not initialize a codec, so getMediaCodecConfiguration() is not called. onOutputFormatChanged() then still sees the decryptOnlyCodecFormat left over from the previous DRM period and configures the AudioSink with that stale format instead of the current one. Because the two formats can differ (for example in channel count), the sink is configured with the wrong input format.

Fix this by clearing decryptOnlyCodecFormat when the codec is released, by overriding resetCodecStateForRelease() in MediaCodecAudioRenderer.