### PR TITLE
fix: be less strict about range request responses

### DIFF
--- a/libraries/datasource/src/main/java/androidx/media3/datasource/DefaultHttpDataSource.java
+++ b/libraries/datasource/src/main/java/androidx/media3/datasource/DefaultHttpDataSource.java
@@ -411,10 +411,10 @@ public class DefaultHttpDataSource extends BaseDataSource implements HttpDataSou
       throw new InvalidContentTypeException(contentType, dataSpec);
     }
 
-    // If we requested a range starting from a non-zero position and received a 200 rather than a
-    // 206, then the server does not support partial requests. We'll need to manually skip to the
-    // requested position.
-    long bytesToSkip = responseCode == 200 && dataSpec.position != 0 ? dataSpec.position : 0;
+    // If we requested a range starting from a non-zero position and did not receive a 206, then
+    // the server does not support partial requests. We'll need to manually skip to the requested
+    // position.
+    long bytesToSkip = responseCode != 206 && dataSpec.position != 0 ? dataSpec.position : 0;
 
     // Determine the length of the data to be read, after skipping.
     boolean isCompressed = isCompressed(connection);

--- a/libraries/datasource/src/main/java/androidx/media3/datasource/HttpEngineDataSource.java
+++ b/libraries/datasource/src/main/java/androidx/media3/datasource/HttpEngineDataSource.java
@@ -540,10 +540,10 @@ public final class HttpEngineDataSource extends BaseDataSource implements HttpDa
       }
     }
 
-    // If we requested a range starting from a non-zero position and received a 200 rather than a
-    // 206, then the server does not support partial requests. We'll need to manually skip to the
-    // requested position.
-    long bytesToSkip = responseCode == 200 && dataSpec.position != 0 ? dataSpec.position : 0;
+    // If we requested a range starting from a non-zero position and did not receive a 206, then
+    // the server does not support partial requests. We'll need to manually skip to the requested
+    // position.
+    long bytesToSkip = responseCode != 206 && dataSpec.position != 0 ? dataSpec.position : 0;
 
     // Calculate the content length.
     if (!isCompressed(responseInfo)) {

--- a/libraries/datasource_cronet/src/main/java/androidx/media3/datasource/cronet/CronetDataSource.java
+++ b/libraries/datasource_cronet/src/main/java/androidx/media3/datasource/cronet/CronetDataSource.java
@@ -670,10 +670,10 @@ public class CronetDataSource extends BaseDataSource implements HttpDataSource {
       }
     }
 
-    // If we requested a range starting from a non-zero position and received a 200 rather than a
-    // 206, then the server does not support partial requests. We'll need to manually skip to the
-    // requested position.
-    long bytesToSkip = responseCode == 200 && dataSpec.position != 0 ? dataSpec.position : 0;
+    // If we requested a range starting from a non-zero position and did not receive a 206, then
+    // the server does not support partial requests. We'll need to manually skip to the requested
+    // position.
+    long bytesToSkip = responseCode != 206 && dataSpec.position != 0 ? dataSpec.position : 0;
 
     // Calculate the content length.
     if (!isCompressed(responseInfo)) {

--- a/libraries/datasource_ktor/src/main/java/androidx/media3/datasource/ktor/KtorDataSource.kt
+++ b/libraries/datasource_ktor/src/main/java/androidx/media3/datasource/ktor/KtorDataSource.kt
@@ -227,7 +227,7 @@ private constructor(
       throw HttpDataSource.InvalidContentTypeException(contentType, dataSpec)
     }
 
-    val bytesToSkip = if (responseCode == 200 && dataSpec.position != 0L) dataSpec.position else 0L
+    val bytesToSkip = if (responseCode != 206 && dataSpec.position != 0L) dataSpec.position else 0L
 
     if (dataSpec.length != C.LENGTH_UNSET.toLong()) {
       bytesToRead = dataSpec.length

--- a/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
+++ b/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
@@ -317,10 +317,10 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
       throw new InvalidContentTypeException(contentType, dataSpec);
     }
 
-    // If we requested a range starting from a non-zero position and received a 200 rather than a
-    // 206, then the server does not support partial requests. We'll need to manually skip to the
-    // requested position.
-    long bytesToSkip = responseCode == 200 && dataSpec.position != 0 ? dataSpec.position : 0;
+    // If we requested a range starting from a non-zero position and did not receive a 206, then
+    // the server does not support partial requests. We'll need to manually skip to the requested
+    // position.
+    long bytesToSkip = responseCode != 206 && dataSpec.position != 0 ? dataSpec.position : 0;
 
     // Determine the length of the data to be read, after skipping.
     if (dataSpec.length != C.LENGTH_UNSET) {


### PR DESCRIPTION
The code currently only does manual byte skipping for HTTP responses with a 200 status. There are other valid status codes that may be returned for a non-range response (e.g. 203), so we should be less strict about it.