### PR TITLE
fix: be less strict about range request responses

### DIFF
--- a/libraries/datasource/src/main/java/androidx/media3/datasource/DefaultHttpDataSource.java
+++ b/libraries/datasource/src/main/java/androidx/media3/datasource/DefaultHttpDataSource.java
@@ -411,10 +411,10 @@ public class DefaultHttpDataSource extends BaseDataSource implements HttpDataSou
       throw new InvalidContentTypeException(contentType, dataSpec);
     }
 
-    // If we requested a range starting from a non-zero position and received a 200 rather than a
-    // 206, then the server does not support partial requests. We'll need to manually skip to the
-    // requested position.
-    long bytesToSkip = responseCode == 200 && dataSpec.position != 0 ? dataSpec.position : 0;
+    // If we requested a range starting from a non-zero position and did not receive a 206, then
+    // the server does not support partial requests. We'll need to manually skip to the requested
+    // position.
+    long bytesToSkip = responseCode != 206 && dataSpec.position != 0 ? dataSpec.position : 0;
 
     // Determine the length of the data to be read, after skipping.
     boolean isCompressed = isCompressed(connection);

--- a/libraries/datasource/src/main/java/androidx/media3/datasource/HttpEngineDataSource.java
+++ b/libraries/datasource/src/main/java/androidx/media3/datasource/HttpEngineDataSource.java
@@ -540,10 +540,10 @@ public final class HttpEngineDataSource extends BaseDataSource implements HttpDa
       }
     }
 
-    // If we requested a range starting from a non-zero position and received a 200 rather than a
-    // 206, then the server does not support partial requests. We'll need to manually skip to the
-    // requested position.
-    long bytesToSkip = responseCode == 200 && dataSpec.position != 0 ? dataSpec.position : 0;
+    // If we requested a range starting from a non-zero position and did not receive a 206, then
+    // the server does not support partial requests. We'll need to manually skip to the requested
+    // position.
+    long bytesToSkip = responseCode != 206 && dataSpec.position != 0 ? dataSpec.position : 0;
 
     // Calculate the content length.
     if (!isCompressed(responseInfo)) {

--- a/libraries/datasource_cronet/src/main/java/androidx/media3/datasource/cronet/CronetDataSource.java
+++ b/libraries/datasource_cronet/src/main/java/androidx/media3/datasource/cronet/CronetDataSource.java
@@ -670,10 +670,10 @@ public class CronetDataSource extends BaseDataSource implements HttpDataSource {
       }
     }
 
-    // If we requested a range starting from a non-zero position and received a 200 rather than a
-    // 206, then the server does not support partial requests. We'll need to manually skip to the
-    // requested position.
-    long bytesToSkip = responseCode == 200 && dataSpec.position != 0 ? dataSpec.position : 0;
+    // If we requested a range starting from a non-zero position and did not receive a 206, then
+    // the server does not support partial requests. We'll need to manually skip to the requested
+    // position.
+    long bytesToSkip = responseCode != 206 && dataSpec.position != 0 ? dataSpec.position : 0;
 
     // Calculate the content length.
     if (!isCompressed(responseInfo)) {

--- a/libraries/datasource_ktor/src/main/java/androidx/media3/datasource/ktor/KtorDataSource.kt
+++ b/libraries/datasource_ktor/src/main/java/androidx/media3/datasource/ktor/KtorDataSource.kt
@@ -227,7 +227,7 @@ private constructor(
       throw HttpDataSource.InvalidContentTypeException(contentType, dataSpec)
     }
 
-    val bytesToSkip = if (responseCode == 200 && dataSpec.position != 0L) dataSpec.position else 0L
+    val bytesToSkip = if (responseCode != 206 && dataSpec.position != 0L) dataSpec.position else 0L
 
     if (dataSpec.length != C.LENGTH_UNSET.toLong()) {
       bytesToRead = dataSpec.length

--- a/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
+++ b/libraries/datasource_okhttp/src/main/java/androidx/media3/datasource/okhttp/OkHttpDataSource.java
@@ -317,10 +317,10 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
       throw new InvalidContentTypeException(contentType, dataSpec);
     }
 
-    // If we requested a range starting from a non-zero position and received a 200 rather than a
-    // 206, then the server does not support partial requests. We'll need to manually skip to the
-    // requested position.
-    long bytesToSkip = responseCode == 200 && dataSpec.position != 0 ? dataSpec.position : 0;
+    // If we requested a range starting from a non-zero position and did not receive a 206, then
+    // the server does not support partial requests. We'll need to manually skip to the requested
+    // position.
+    long bytesToSkip = responseCode != 206 && dataSpec.position != 0 ? dataSpec.position : 0;
 
     // Determine the length of the data to be read, after skipping.
     if (dataSpec.length != C.LENGTH_UNSET) {

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/HttpDataSourceTestEnv.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/HttpDataSourceTestEnv.java
@@ -91,6 +91,15 @@ public class HttpDataSourceTestEnv extends ExternalResource {
           .setExtraResponseHeaders(EXTRA_HEADERS)
           .build();
 
+  public static final WebServerDispatcher.Resource RANGE_NOT_SUPPORTED_NON_AUTHORITATIVE =
+      new WebServerDispatcher.Resource.Builder()
+          .setPath("/doesnt/support/range-requests-non-authoritative")
+          .setData(TestUtil.buildTestData(/* length= */ 20, seed++))
+          .supportsRangeRequests(false)
+          .setNonRangeResponseCode(203)
+          .setExtraResponseHeaders(EXTRA_HEADERS)
+          .build();
+
   public static final WebServerDispatcher.Resource GZIP_ENABLED =
       new WebServerDispatcher.Resource.Builder()
           .setPath("/gzip/enabled")
@@ -139,6 +148,7 @@ public class HttpDataSourceTestEnv extends ExternalResource {
         createTestResource("range not supported", RANGE_NOT_SUPPORTED),
         createTestResource(
             "range not supported, length unknown", RANGE_NOT_SUPPORTED_LENGTH_UNKNOWN),
+        createTestResource("range not supported (203)", RANGE_NOT_SUPPORTED_NON_AUTHORITATIVE),
         // TODO: crbug.com/41313195 - Set these back to false when CronetDataSource and
         //  HttpEngineDataSource are able to set Accept-Encoding: identity.
         createTestResource("gzip enabled", GZIP_ENABLED, /* mayResolveToUnknownLength= */ true),
@@ -196,6 +206,7 @@ public class HttpDataSourceTestEnv extends ExternalResource {
                 RANGE_SUPPORTED_LENGTH_UNKNOWN,
                 RANGE_NOT_SUPPORTED,
                 RANGE_NOT_SUPPORTED_LENGTH_UNKNOWN,
+                RANGE_NOT_SUPPORTED_NON_AUTHORITATIVE,
                 GZIP_ENABLED,
                 GZIP_FORCED,
                 POST_EMPTY_REQUEST_BODY,

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/WebServerDispatcher.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/WebServerDispatcher.java
@@ -121,6 +121,7 @@ public final class WebServerDispatcher extends Dispatcher {
       private byte[] requestBody;
       private byte @MonotonicNonNull [] data;
       private boolean supportsRangeRequests;
+      private int nonRangeResponseCode;
       private boolean includesContentLengthInRangeResponses;
       private boolean resolvesToUnknownLength;
       private @GzipSupport int gzipSupport;
@@ -131,6 +132,7 @@ public final class WebServerDispatcher extends Dispatcher {
         this.httpMethod = HTTP_METHOD_GET;
         this.requestHeaders = ImmutableListMultimap.of();
         this.requestBody = EMPTY_BYTE_ARRAY;
+        this.nonRangeResponseCode = 200;
         this.includesContentLengthInRangeResponses = true;
         this.gzipSupport = GZIP_SUPPORT_DISABLED;
         this.extraResponseHeaders = ImmutableListMultimap.of();
@@ -143,6 +145,7 @@ public final class WebServerDispatcher extends Dispatcher {
         this.requestBody = resource.getRequestBody();
         this.data = resource.getData();
         this.supportsRangeRequests = resource.supportsRangeRequests();
+        this.nonRangeResponseCode = resource.getNonRangeResponseCode();
         this.includesContentLengthInRangeResponses =
             resource.includesContentLengthInRangeResponses();
         this.resolvesToUnknownLength = resource.resolvesToUnknownLength();
@@ -230,6 +233,19 @@ public final class WebServerDispatcher extends Dispatcher {
       }
 
       /**
+       * Sets the HTTP response code to use when a range is not supported or not requested.
+       *
+       * <p>Defaults to 200.
+       *
+       * @return this builder, for convenience.
+       */
+      @CanIgnoreReturnValue
+      public Builder setNonRangeResponseCode(int nonRangeResponseCode) {
+        this.nonRangeResponseCode = nonRangeResponseCode;
+        return this;
+      }
+
+      /**
        * Sets if RFC 7233 HTTP 206 range responses should include a {@code Content-Length} header.
        *
        * <p>Setting this to false allows simulating servers or proxies that only include the {@code
@@ -304,6 +320,7 @@ public final class WebServerDispatcher extends Dispatcher {
             requestBody,
             checkNotNull(data),
             supportsRangeRequests,
+            nonRangeResponseCode,
             includesContentLengthInRangeResponses,
             resolvesToUnknownLength,
             gzipSupport,
@@ -317,6 +334,7 @@ public final class WebServerDispatcher extends Dispatcher {
     private final byte[] requestBody;
     private final byte[] data;
     private final boolean supportsRangeRequests;
+    private final int nonRangeResponseCode;
     private final boolean includesContentLengthInRangeResponses;
     private final boolean resolvesToUnknownLength;
     private final @GzipSupport int gzipSupport;
@@ -329,6 +347,7 @@ public final class WebServerDispatcher extends Dispatcher {
         byte[] requestBody,
         byte[] data,
         boolean supportsRangeRequests,
+        int nonRangeResponseCode,
         boolean includesContentLengthInRangeResponses,
         boolean resolvesToUnknownLength,
         @GzipSupport int gzipSupport,
@@ -339,10 +358,16 @@ public final class WebServerDispatcher extends Dispatcher {
       this.requestBody = requestBody;
       this.data = data;
       this.supportsRangeRequests = supportsRangeRequests;
+      this.nonRangeResponseCode = nonRangeResponseCode;
       this.includesContentLengthInRangeResponses = includesContentLengthInRangeResponses;
       this.resolvesToUnknownLength = resolvesToUnknownLength;
       this.gzipSupport = gzipSupport;
       this.extraResponseHeaders = extraResponseHeaders;
+    }
+
+    /** The HTTP response code when a range is not supported or not requested. */
+    public int getNonRangeResponseCode() {
+      return nonRangeResponseCode;
     }
 
     /** Returns the path this resource is available at. */
@@ -497,6 +522,7 @@ public final class WebServerDispatcher extends Dispatcher {
 
     @Nullable String rangeHeader = request.getHeader(HttpHeaders.RANGE);
     if (!resource.supportsRangeRequests() || rangeHeader == null) {
+      response.setResponseCode(resource.getNonRangeResponseCode());
       setResponseBody(
           response,
           preferredContentCoding,


### PR DESCRIPTION
The code currently only does manual byte skipping for HTTP responses with a 200 status. There are other valid status codes that may be returned for a non-range response (e.g. 203), so we should be less strict about it.

This PR is a re-creation of #3404 to ease merging.